### PR TITLE
add community and governance files for OSS launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Incorrect, ambiguous, or contradictory normative text; schema errors; broken examples
+labels: bug
+---
+
+**What is wrong**
+<!-- Describe the problem. Quote the specific text or schema path. -->
+
+**Spec section or file**
+<!-- e.g. spec/trace-v0.1.md §3.2.1, schema/trace-claim.json #/properties/runtime -->
+
+**Expected behavior**
+<!-- What should it say or do? -->
+
+**Impact**
+<!-- Does this cause conformant implementations to produce invalid Trust Records, or verifiers to accept invalid ones? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerabilities
+    url: https://github.com/agentrust-io/trace-spec/blob/main/SECURITY.md
+    about: Do not open public issues for security vulnerabilities. See SECURITY.md for the reporting process.
+  - name: Vendor platform annex interest
+    url: https://github.com/agentrust-io/trace-spec/issues/new?labels=vendor-annex&template=spec_change.md
+    about: Interested in co-authoring a platform mapping annex? Open an issue with the vendor-annex label.

--- a/.github/ISSUE_TEMPLATE/spec_change.md
+++ b/.github/ISSUE_TEMPLATE/spec_change.md
@@ -1,0 +1,25 @@
+---
+name: Spec change proposal
+about: Propose a normative change to the TRACE specification
+labels: spec
+---
+
+**Spec section affected**
+<!-- e.g. §3.1, §3.2.1, §4.1 -->
+
+**Problem**
+<!-- What is wrong or missing in the current spec? Be specific about the normative text. -->
+
+**Proposed change**
+<!-- What should the spec say instead? Paste the proposed normative text. -->
+
+**Backward compatibility**
+<!-- Would this change break existing conformant Trust Records or verifiers? -->
+- [ ] Non-breaking (new optional field, informative addition)
+- [ ] Breaking (removes or changes required field, changes wire format, changes algorithm set)
+
+**Motivation**
+<!-- Why does this matter? Link to deployments, regulatory requirements, or standards this enables. -->
+
+**Related issues or PRs**
+<!-- Optional -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What this changes
+
+<!-- Describe the change. For spec changes, quote or link the normative text being modified. -->
+
+## Type of change
+
+- [ ] Editorial (typo, link fix, clarification — no normative effect)
+- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
+- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
+- [ ] Schema change
+- [ ] Example addition
+
+## Spec section
+
+<!-- Which section(s) of spec/trace-v0.1.md does this affect? -->
+
+## Checklist
+
+- [ ] DCO sign-off on all commits (`git commit -s`)
+- [ ] `CHANGELOG.md` updated (for any normative change)
+- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text
+- [ ] Backward compatibility statement included (for breaking changes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to the TRACE specification will be documented here.
+
+Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.MINOR.PATCH`:
+- **MAJOR**: breaking changes to wire format or required Trust Record fields
+- **MINOR**: new optional fields, new platform profiles, new conformance levels
+- **PATCH**: editorial fixes, clarifications, non-normative additions
+
+---
+
+## [0.1.0] — 2026-06-23
+
+Initial public draft. Announced at Confidential Computing Summit, San Francisco.
+
+### Specification
+
+- Trust Record logical schema (§3.1): `subject`, `model`, `runtime`, `policy`, `data_class`, `tool_transcript`, `build_provenance`, `appraisal`, `transparency`, `cnf`
+- Wire format (§3.2): EAT/JWT and CBOR-COSE envelopes; profile URI `tag:agentrust.io,2026:trace-v0.1`
+- Signing and key management (§3.2.1): ES256/ES384/EdDSA; four-layer key hierarchy; hash agility; revocation
+- Verification protocol (§3.3): five-step offline verification, no issuer callback
+- Standards composition (§4): RATS/EAT, SLSA, SPIFFE, SCITT, EAR, MCP, A2A, AIBOM, C2PA
+- Hardware roots (§4.2): NVIDIA H100/Blackwell, Intel TDX, AMD SEV-SNP, Azure MAA, GCP Confidential Space, AWS Nitro
+- Reference implementation (§5): cMCP Phase 1–3 roadmap
+
+### Schema
+
+- `schema/trace-claim.json`: JSON Schema (draft/2020-12) for Trust Record validation
+
+### Examples
+
+- `examples/amd-sev-snp.json`: AMD SEV-SNP Trust Record
+- `examples/intel-tdx.json`: Intel TDX Trust Record
+- `examples/nvidia-h100.json`: NVIDIA H100 Confidential Computing Trust Record
+
+### Open questions
+
+Seven open questions requiring founding-member input before v0.2 are documented in §7 of the spec.
+
+---
+
+## Upcoming
+
+See [ROADMAP.md](ROADMAP.md) for planned changes in v0.2 and v1.0.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,86 @@
+# Technical Charter — TRACE
+
+**Proposed hosting**: CoSAI (Coalition for Secure AI) for the technical workstream; Linux Foundation entity hosting the Model Context Protocol for specification, IP, trademark, and conformance mark.  
+**Status**: Pre-acceptance draft — effective upon host organization acceptance.  
+**Version**: 0.1 (aligned with spec v0.1)
+
+---
+
+## 1. Mission
+
+The TRACE project develops and maintains an open, portable, hardware-enforced governance record for AI agents and other confidential workloads. The mission is to make execution governance evidence verifiable by any party — without trusting the operator, without callbacks to the issuer, and without vendor lock-in to any cloud, silicon vendor, or AI provider.
+
+## 2. Scope
+
+The project includes:
+
+- **The TRACE Specification** — normative text defining the Trust Record schema, wire format, signing and key management protocol, verification rules, hardware root profiles, and conformance requirements.
+- **JSON Schema** — machine-readable schema for Trust Record validation.
+- **Conformance test suite** — the canonical tests validating compliance (in [agentrust-io/trace-tests](https://github.com/agentrust-io/trace-tests)).
+- **Vendor platform annexes** — informative, vendor-co-authored claim-mapping documents for each silicon and cloud attestation surface.
+- **Reference examples** — example Trust Records for each supported hardware platform.
+
+Out of scope: runtime policy enforcement engines, TEE platform SDKs, AI model governance beyond execution evidence, and hardware side-channel mitigations.
+
+## 3. Technical Steering Committee
+
+Upon host organization acceptance, governance transitions from the current Project Lead model to a Technical Steering Committee (TSC).
+
+**Composition**: 3–9 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique, OPAQUE Systems) holds one founding seat for the v1.0 ratification cycle.
+
+**Election**: TSC members are elected annually by active contributors (at least one merged PR or accepted spec change in the preceding 12 months). Each contributor has one vote.
+
+**Quorum**: Two-thirds of TSC members must participate for a vote to be valid.
+
+**Decisions**:
+- Spec errata and editorial changes: simple TSC majority
+- Non-breaking spec versions (new optional fields, new platform profiles): two-thirds TSC majority + 14-day public comment
+- Breaking spec versions (mandatory field changes, algorithm deprecations, wire format changes): two-thirds TSC majority + 30-day public comment + explicit backward-compatibility statement
+
+**Meetings**: Monthly public TSC meeting. Notes published within 5 business days.
+
+## 4. Intellectual Property Policy
+
+All contributions must be made under the terms of [LICENSE](LICENSE). Contributors must sign commits with the Developer Certificate of Origin (DCO). No contribution may incorporate material covered by a patent the contributor is unwilling to license royalty-free to conforming implementations.
+
+The specification text is licensed under CC BY 4.0. Schema, examples, and code are licensed under Apache 2.0 with Patent Promise (see LICENSE).
+
+## 5. Trademark Policy
+
+"TRACE" as a specification name and the "TRACE-conformant" conformance mark are currently held by OPAQUE Systems, Inc. Upon host organization acceptance, trademark ownership transfers to the host under their standard trademark policy.
+
+Use of "TRACE-conformant" to describe an implementation is permitted only when that implementation passes the published conformance test suite for the version being claimed.
+
+## 6. Conformance
+
+An implementation may claim TRACE conformance only by passing the conformance test suite in [agentrust-io/trace-tests](https://github.com/agentrust-io/trace-tests) at the level being claimed (Level 0, 1, or 2). Conformance claims must reference the test suite version and include a link to a passing run.
+
+Test suite changes that would invalidate previously conformant implementations require a spec version increment.
+
+## 7. Relationship to other standards
+
+TRACE profiles, and does not replace:
+
+- **RATS / EAT (RFC 9711)** — wire envelope
+- **SLSA** — build provenance
+- **SPIFFE / SPIRE** — workload identity
+- **SCITT** — transparency anchoring
+- **EAR (draft-ietf-rats-ar4si)** — verifier appraisal
+- **MCP / A2A** — agent execution surface
+- **AIBOM (SPDX 3.0, CycloneDX 1.7)** — model component inventory
+
+TRACE participates in IETF RATS, SCITT, and EAR working groups as a consuming profile, not a competing standard.
+
+## 8. Transition timeline
+
+| Milestone | Target |
+|---|---|
+| v0.1 draft — CC Summit announcement | June 2026 |
+| CoSAI committee formation | Q3 2026 |
+| MCP profile and A2A profile (v0.2) | Q3 2026 |
+| Host organization submission | Q3 2026 |
+| v1.0 ratification under TSC governance | 2027 |
+
+## 9. Amendments
+
+Amendments to this charter require a two-thirds TSC majority and a 30-day public comment period. Before host organization acceptance, amendments require Project Lead approval and 14-day notice to contributors.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in the TRACE project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, pull requests, discussions, and any official project communication channels.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at the email addresses listed in [MAINTAINERS.md](MAINTAINERS.md). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to TRACE
+
+TRACE is an open specification. Contributions are welcome in four areas: the specification text, the JSON Schema, the examples, and the conformance test suite (in [agentrust-io/trace-tests](https://github.com/agentrust-io/trace-tests)).
+
+## DCO sign-off
+
+All commits must include a Developer Certificate of Origin sign-off:
+
+```
+git commit -s -m "fix: clarify runtime measurement format"
+```
+
+This adds `Signed-off-by: Your Name <you@example.com>`. PRs without DCO sign-off will not be merged.
+
+## Types of contribution
+
+### Spec changes (normative text)
+
+Changes to `spec/trace-v0.1.md` that affect what implementations must do.
+
+1. Open a GitHub issue using the **Spec change proposal** template. Describe the problem, the proposed change, and the spec section affected.
+2. Allow 5 business days for comment. Changes touching wire format, cryptographic algorithms, or Trust Record required fields require 14 days.
+3. Submit a PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN — description -->`.
+4. Update `CHANGELOG.md`.
+5. Breaking changes (backward-incompatible field removals, algorithm deprecations) require Project Lead approval and an explicit backward-compatibility statement.
+
+### Schema changes (schema/trace-claim.json)
+
+Schema changes must track normative spec changes. A schema PR without a corresponding spec PR (or reference to a merged one) will not be merged.
+
+### Example additions
+
+New hardware provider examples in `examples/` are welcome. Follow the existing format: real field names, truncated digests with `...` suffix, a `_comment` field explaining the hardware platform.
+
+### Editorial changes
+
+Typos, broken links, and clarity improvements can go straight to a PR without a prior issue.
+
+## Vendor profile annexes
+
+TRACE will publish vendor-co-authored claim-mapping annexes (§4.4 of the spec) as informative companions to v1.0. If you represent a silicon or cloud attestation vendor and want to author the annex for your platform, open an issue with the `vendor-annex` label.
+
+## Review timeline
+
+- Editorial PRs: 3 business days
+- Non-breaking spec changes: 7 business days
+- Breaking or wire-format changes: 14 business days + Project Lead sign-off
+
+## Style
+
+- Normative requirements use RFC 2119 keywords (MUST, SHOULD, MAY) in uppercase.
+- Non-normative text does not use uppercase RFC 2119 keywords.
+- Field names in `code` formatting.
+- Diagrams in ASCII (no binary image files in the spec directory).
+
+## License
+
+By contributing you agree that your contributions will be licensed under the terms in [LICENSE](LICENSE).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,53 @@
+# Governance
+
+## Roles
+
+### Contributor
+
+Anyone who submits a PR, files an issue, or participates in discussion. No formal appointment required. Must follow the [Code of Conduct](CODE_OF_CONDUCT.md) and sign commits with DCO.
+
+### Reviewer
+
+Trusted contributors with triage and review rights. Can approve PRs but cannot merge breaking spec changes without Project Lead approval.
+
+**Advancement**: 3+ merged substantive PRs. Nominated by any Maintainer, confirmed by Project Lead.
+
+### Maintainer
+
+Full merge rights. Responsible for reviewing PRs in their area within 7 business days. See [MAINTAINERS.md](MAINTAINERS.md).
+
+**Advancement**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec design questions. Nominated by any Maintainer, confirmed by Project Lead.
+
+### Project Lead
+
+Final decision authority on specification changes, conformance requirements, AAIF submission scope, and Maintainer appointments. Currently: Imran Siddique (OPAQUE Systems).
+
+**Succession**: If the Project Lead is unavailable for 30+ days without notice, active Maintainers vote to appoint an interim lead.
+
+## Decision-making
+
+**Editorial changes** (typos, broken links, clarifications that do not affect normative requirements): Maintainer review + merge.
+
+**Non-breaking spec changes** (new optional fields, new OPTIONAL conformance behavior, informative additions): open issue, 5-day comment period, Maintainer review, merge.
+
+**Breaking spec changes** (backward-incompatible field changes, algorithm additions to the required set, conformance level redefinition): open issue, 14-day comment period, no unresolved objections from Maintainers, Project Lead sign-off.
+
+**Wire format changes**: treated as breaking regardless of backward-compatibility argument.
+
+**Voting**: If consensus cannot be reached, Maintainers vote. Simple majority for non-breaking changes; two-thirds for breaking changes. Project Lead has tie-breaking vote.
+
+## Conflict of interest
+
+Maintainers must disclose commercial interest in a proposal before participating in its review. Disclosed conflicts do not disqualify a Maintainer from voting but must be on record in the PR or issue.
+
+## Vendor annexes
+
+Vendor-co-authored platform-mapping annexes (§4.4 of the spec) are informative. They are reviewed by the vendor author and one TRACE Maintainer. Annexes do not require the full spec-change process.
+
+## Foundation transition
+
+TRACE is targeting co-hosting under CoSAI (technical workstream) and the Linux Foundation entity hosting MCP (spec, IP, trademark, conformance mark). On acceptance, governance transitions to a Technical Steering Committee (TSC) as defined in [CHARTER.md](CHARTER.md). Until then, this document is the governance authority.
+
+## Amendments
+
+Amendments to this document require a PR, 14-day comment period, and Project Lead approval.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+The TRACE specification and this repository use a dual license:
+
+SPECIFICATION TEXT (spec/*.md, README.md, CHANGELOG.md)
+=========================================================
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+https://creativecommons.org/licenses/by/4.0/
+
+You are free to share and adapt the specification text for any purpose,
+including commercial, provided you give appropriate credit, link to the
+license, and indicate if changes were made.
+
+SCHEMA, EXAMPLES, AND CODE (schema/, examples/, .github/)
+==========================================================
+Apache License, Version 2.0
+https://www.apache.org/licenses/LICENSE-2.0
+
+Copyright 2026 OPAQUE Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use these files except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+PATENT PROMISE
+==============
+OPAQUE Systems, Inc. grants a royalty-free, worldwide, non-exclusive
+license under any patent claims it controls that are necessarily infringed
+by a conforming implementation of this specification, for the purpose of
+implementing or operating a product that conforms to this specification.
+This promise applies to v0.1 and all subsequent versions of TRACE.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,30 @@
+# Maintainers
+
+## Project Lead
+
+| Name | Affiliation | GitHub | Contact |
+|---|---|---|---|
+| Imran Siddique | OPAQUE Systems | @imraan | imran.siddique@opaque.co |
+
+The Project Lead has final decision authority on specification changes, AAIF/CoSAI submission scope, conformance requirements, and Maintainer appointments.
+
+## Spec Editors
+
+| Name | Affiliation | Area |
+|---|---|---|
+| Rishabh Poddar | OPAQUE Systems | Specification, TEE profiles |
+| Aaron Fulkerson | OPAQUE Systems | Specification, governance |
+
+## How to become a maintainer
+
+**Reviewer**: 3+ merged PRs with substantive contributions. Nominated by a Maintainer, confirmed by Project Lead.
+
+**Maintainer**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec design questions. Nominated by any Maintainer, confirmed by Project Lead.
+
+We are actively recruiting Maintainers from organizations outside OPAQUE Systems, particularly from silicon vendors, cloud providers, and regulated-industry deployers. If you are contributing to TRACE and want to take on a formal role, open an issue tagged `maintainer-interest`.
+
+## Emeritus
+
+Maintainers who step back from active review are listed here with thanks.
+
+_(none yet)_

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,48 @@
+# Roadmap
+
+## Now — v0.1 draft (June 2026)
+
+Announced at Confidential Computing Summit, San Francisco, June 23 2026.
+
+**In scope:**
+- Full Trust Record schema: `subject`, `model`, `runtime`, `policy`, `data_class`, `tool_transcript`, `build_provenance`, `appraisal`, `transparency`, `cnf`
+- Wire formats: EAT/JWT and CBOR-COSE
+- Hardware roots: NVIDIA H100/Blackwell, Intel TDX, AMD SEV-SNP, Azure MAA, GCP Confidential Space, AWS Nitro
+- JSON Schema and three hardware examples
+- Reference implementation: cMCP Phase 1 (runtime trust, no policy enforcement)
+
+**Not in v0.1:** MCP profile (normative), A2A profile, vendor platform annexes, OWASP/ATLAS cross-walks, encrypted claims envelope.
+
+## Next — v0.2 (Q3 2026)
+
+Driven by founding-member feedback and open questions from §7 of the spec.
+
+- **MCP profile** — normative claim shape and binding rules for MCP tool-call transcripts (`tool_transcript`); proposed for upstream contribution to MCP spec governance
+- **A2A profile** — same, for Google Agent-to-Agent; pending A2A protocol stability
+- **Vendor platform annexes** — co-authored informative claim-mapping docs for NVIDIA NRAS, Intel Trust Authority, AMD CoRIM, Azure MAA, GCP Confidential Space
+- **OWASP Agentic AI Top 10 cross-walk** — which TRACE claim evidences which control for each of the 10 ASIs
+- **MITRE ATLAS cross-walk** — TRACE claim coverage mapped to relevant ATLAS tactics
+- **Encrypted claims envelope** — normative profile for JWE / COSE-Encrypt when `data_class` requires confidential transport to verifiers (open question §7 Q5)
+- **Reference to IETF AIIP** — coordinate with draft-ritz-aiip and determine disposition (open question §7 Q7)
+- **cMCP Phase 2** — policy enforcement and `tool_transcript` binding; first full Trust Records
+
+## Later — v1.0 standard (2027)
+
+- TSC governance under CoSAI / Linux Foundation
+- All §7 open questions resolved
+- Complete conformance certification program
+- Post-quantum signature profile (ML-DSA, tracking NIST SP 800-208)
+- MCP and A2A profiles ratified and proposed to respective upstream governance bodies
+- AAIF-assigned canonical profile URI replacing the provisional v0.1 tag URI
+- Multi-language verification libraries (Python, TypeScript, Go, Rust)
+
+## What TRACE will not do
+
+- Replace RATS, EAT, SLSA, SPIFFE, SCITT, or MCP — TRACE is a profile of these
+- Specify a centralized Trust Record registry — verification is designed to work without one
+- Build a TEE platform — hardware support targets open silicon (TDX, SEV-SNP, NVIDIA CC) and any platform that produces RATS-conformant evidence
+- Adjudicate model alignment or output correctness — TRACE proves what executed and what was in force; correctness is out of scope
+
+## Influencing the roadmap
+
+Open a GitHub issue with the `spec` or `roadmap` label. Founding-member and vendor feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Scope
+
+This repository contains a specification and machine-readable schema. Security issues fall into two categories:
+
+**Specification vulnerabilities** — flaws in the TRACE spec that would allow an attacker to forge a valid Trust Record, bypass verification, break the cryptographic chain, or make verifiable claims that are structurally false. These are the most serious and are treated as critical.
+
+**Implementation vulnerabilities** — flaws in reference examples or schema that could mislead implementors into producing insecure Trust Records. Report these here.
+
+Vulnerabilities in the reference implementation (cMCP) should be reported at [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) using its security policy.
+
+## Reporting
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities by email to: **security@opaque.co**
+
+Include:
+- A description of the vulnerability and the affected spec section or schema path
+- The attack scenario: what can an attacker do, what invariant is broken
+- Whether you believe this affects existing Trust Records produced by conformant implementations
+- Your preferred disclosure timeline
+
+## Response SLAs
+
+| Severity | Initial response | Fix target |
+|---|---|---|
+| Critical (forgeable Trust Record, broken verification chain) | 24 hours | 7 days |
+| High (misleading schema, incorrect normative text) | 48 hours | 14 days |
+| Medium / Low (editorial, non-normative) | 5 business days | Next spec patch |
+
+## Disclosure
+
+We follow coordinated disclosure. We will work with reporters to agree on a disclosure timeline before publishing any advisory. We will credit reporters in the changelog unless they prefer to remain anonymous.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| v0.1 (current) | Yes |
+| Earlier drafts | No |


### PR DESCRIPTION
## Summary

Adds the full set of community and governance files needed before the repo can go public.

- **LICENSE** — CC BY 4.0 for spec text, Apache 2.0 + Patent Promise for schema/code/examples
- **CONTRIBUTING.md** — RFC-style spec contribution process (spec changes, schema changes, vendor annexes, editorial fixes)
- **GOVERNANCE.md** — roles (Contributor, Reviewer, Maintainer, Project Lead), decision thresholds (editorial / non-breaking / breaking), conflict-of-interest rules, foundation transition
- **CHARTER.md** — technical charter for CoSAI / Linux Foundation submission: mission, scope, TSC structure, IP policy, trademark, conformance, transition timeline
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **SECURITY.md** — two categories (spec vulnerabilities vs implementation), reporting address, SLAs, disclosure policy, supported versions
- **MAINTAINERS.md** — Project Lead + Spec Editors, path to maintainership, maintainer-interest process
- **CHANGELOG.md** — v0.1.0 entry with all spec, schema, and example additions
- **ROADMAP.md** — v0.1 (now), v0.2 (MCP/A2A profiles, vendor annexes, encrypted claims), v1.0 (TSC, certification), explicit non-goals
- **.github/ISSUE_TEMPLATE/** — spec change proposal + bug report templates + config (disables blank issues, links security reporting)
- **.github/PULL_REQUEST_TEMPLATE.md** — type checklist, spec section field, DCO and changelog checklist

## Test plan

- [ ] All links in new files resolve (SECURITY.md contact, CHARTER.md references, CONTRIBUTING.md DCO link)
- [ ] LICENSE file is present and references both CC BY 4.0 and Apache 2.0
- [ ] Issue templates appear correctly in the GitHub "New Issue" UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)