### PR TITLE
fix: resolve ruff lint failures

### DIFF
--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -11,7 +11,7 @@ from agentrust_trace.models import (
     ToolTranscript,
     TrustRecord,
 )
-from agentrust_trace.validate import SCHEMA, iter_errors, validate_json
+from agentrust_trace.validate import iter_errors, SCHEMA, validate_json
 
 __version__ = "0.1.0"
 

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -14,9 +14,9 @@ class ModelInfo(BaseModel):
 
     provider: str
     model_id: str
-    version: Optional[str] = None
-    weights_digest: Optional[DigestStr] = None
-    aibom_uri: Optional[str] = None
+    version: str | None = None
+    weights_digest: DigestStr | None = None
+    aibom_uri: str | None = None
 
 
 class RuntimeInfo(BaseModel):
@@ -33,9 +33,9 @@ class RuntimeInfo(BaseModel):
         "tpm2",
     ]
     measurement: DigestStr
-    rim_uri: Optional[str] = None
-    nonce: Optional[str] = None
-    firmware_version: Optional[str] = None
+    rim_uri: str | None = None
+    nonce: str | None = None
+    firmware_version: str | None = None
 
 
 class PolicyInfo(BaseModel):
@@ -43,25 +43,25 @@ class PolicyInfo(BaseModel):
 
     bundle_hash: DigestStr
     enforcement_mode: Literal["enforce", "advisory", "silent"]
-    version: Optional[str] = None
-    policy_uri: Optional[str] = None
+    version: str | None = None
+    policy_uri: str | None = None
 
 
 class ToolTranscript(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     hash: DigestStr
-    call_count: Optional[Annotated[int, Field(ge=0)]] = None
-    transcript_uri: Optional[str] = None
+    call_count: Annotated[int, Field(ge=0)] | None = None
+    transcript_uri: str | None = None
 
 
 class BuildProvenance(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     slsa_level: Annotated[int, Field(ge=1, le=3)]
-    builder: Optional[str] = None
+    builder: str | None = None
     digest: DigestStr
-    provenance_uri: Optional[str] = None
+    provenance_uri: str | None = None
 
 
 class Appraisal(BaseModel):
@@ -69,8 +69,8 @@ class Appraisal(BaseModel):
 
     status: Literal["affirming", "warning", "contraindicated", "none"]
     verifier: str
-    policy_ref: Optional[str] = None
-    timestamp: Optional[int] = None
+    policy_ref: str | None = None
+    timestamp: int | None = None
 
 
 class JWK(BaseModel):
@@ -78,10 +78,10 @@ class JWK(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     kty: str
-    crv: Optional[str] = None
-    x: Optional[str] = None
-    y: Optional[str] = None
-    kid: Optional[str] = None
+    crv: str | None = None
+    x: str | None = None
+    y: str | None = None
+    kid: str | None = None
 
 
 class ConfirmationKey(BaseModel):
@@ -102,7 +102,7 @@ class TrustRecord(BaseModel):
     runtime: RuntimeInfo
     policy: PolicyInfo
     data_class: str
-    tool_transcript: Optional[ToolTranscript] = None
+    tool_transcript: ToolTranscript | None = None
     build_provenance: BuildProvenance
     appraisal: Appraisal
     transparency: str

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from agentrust_trace import TrustRecord
 
@@ -35,26 +36,26 @@ def test_intel_tdx_fields() -> None:
 def test_extra_fields_rejected() -> None:
     data = _load("intel-tdx.json")
     data["unknown_field"] = "should fail"
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
 
 
 def test_missing_required_field_rejected() -> None:
     data = _load("intel-tdx.json")
     del data["cnf"]
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
 
 
 def test_bad_digest_rejected() -> None:
     data = _load("intel-tdx.json")
     data["runtime"]["measurement"] = "not-a-digest"
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
 
 
 def test_bad_platform_rejected() -> None:
     data = _load("intel-tdx.json")
     data["runtime"]["platform"] = "unknown-cloud"
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)


### PR DESCRIPTION
## Summary

- `models.py`: `Optional[X]` → `X | None` throughout (UP045)
- `__init__.py`: sort names within validate import to satisfy isort (I001)
- `test_models.py`: `pytest.raises(ValidationError)` instead of bare `Exception` (B017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)