### PR TITLE
fix: contents: read permission in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
 
 permissions:
+  contents: read
   id-token: write  # OIDC trusted publishing — no stored API token needed
 
 jobs:


### PR DESCRIPTION
Explicit permissions blocks set all unspecified permissions to none. Adding only id-token: write caused actions/checkout to fail with 'repository not found' because it lost contents: read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)