### PR TITLE
fix: security email, spec attribution, pin ci actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Vulnerabilities in the reference implementation (cMCP) should be reported at [ag
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Report vulnerabilities by email to: **security@opaque.co**
+Report vulnerabilities via [GitHub Security Advisories](https://github.com/agentrust-io/trace-spec/security/advisories/new). Do not use public issues.
 
 Include:
 - A description of the vulnerability and the affected spec section or schema path

--- a/spec/trace-v0.1.md
+++ b/spec/trace-v0.1.md
@@ -9,7 +9,7 @@
 | Reference implementation | [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) — Confidential MCP |
 | License | CC BY 4.0 |
 
-> **Note:** This is a pre-ratification draft. Fields, wire formats, and conformance requirements are subject to change before v1.0. Send feedback to: aaron@opaque.co or open an issue on this repository.
+> **Note:** This is a pre-ratification draft. Fields, wire formats, and conformance requirements are subject to change before v1.0. Send feedback to: open an issue on this repository.
 
 ---
 
@@ -270,7 +270,7 @@ TRACE will publish vendor-co-authored claim-mapping annexes — one per silicon-
 
 ## 5. Reference Implementation: Confidential MCP (cMCP)
 
-OPAQUE's reference build at the MCP tool-call boundary.
+the reference implementation at the MCP tool-call boundary.
 
 | Phase | What ships | TRACE fields | Timeline |
 |---|---|---|---|


### PR DESCRIPTION
## Summary
- `SECURITY.md`: replace `security@opaque.co` with GitHub Security Advisories link — public vulnerability disclosures should not route to a private company inbox
- `spec/trace-v0.1.md` line 12: remove `aaron@opaque.co` from the draft feedback note (just "open an issue" is sufficient)
- `spec/trace-v0.1.md` line 273: `OPAQUE's reference build` → `the reference implementation`
- CI: pin `actions/setup-python` from `@v5` to `@v4` in both `ci.yml` and `publish.yml`

## What was NOT changed
Spec header byline (`Rishabh Poddar, Aaron Fulkerson (OPAQUE Systems)`) — this is accurate authorship attribution, intentionally left intact.

## Test plan
- [ ] `grep "opaque.co" SECURITY.md` returns nothing
- [ ] CI passes on this PR with pinned actions