### PR TITLE
fix: make charter draft status prominent for external contributors

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,7 +1,9 @@
 # Technical Charter — TRACE
 
 **Proposed hosting**: CoSAI (Coalition for Secure AI) for the technical workstream; Linux Foundation entity hosting the Model Context Protocol for specification, IP, trademark, and conformance mark.  
-**Status**: Pre-acceptance draft — effective upon host organization acceptance.  
+**Status**: Pre-acceptance draft — effective upon host organization acceptance.
+
+> **Note for external contributors:** This charter is a working draft and has not yet been accepted by a host organization. Governance terms, IP policy, and conformance mark ownership described here are proposed, not final. Do not implement production systems based on governance commitments in this document until v1.0 ratification.  
 **Version**: 0.1 (aligned with spec v0.1)
 
 ---


### PR DESCRIPTION
`CHARTER.md` had a single inline `**Status**: Pre-acceptance draft` line that was easy to miss. Added a blockquote callout immediately after it explaining that governance terms are proposed, not final, and that production implementations should wait for v1.0 ratification. Prevents partners from treating draft governance commitments as binding.