### PR TITLE
feat: add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,11 @@
+# ADOPTERS
+
+Organizations using or evaluating the TRACE specification.
+
+To add your organization, open a pull request editing this file.
+
+---
+
+| Organization | Usage |
+|---|---|
+| Opaque Systems | Founding contributor — developed the initial specification, reference implementation, and TRACE registry infrastructure |


### PR DESCRIPTION
cmcp and agent-manifest both have ADOPTERS.md; trace-spec is missing one despite being the most mature spec. Adds the file with Opaque Systems as founding contributor.