### PR TITLE
fix(models): enforce exact hex length and reject uppercase in DigestStr

### DIFF
--- a/examples/amd-sev-snp.json
+++ b/examples/amd-sev-snp.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — AMD SEV-SNP example. Truncated digests shown with '...' suffix.",
+  "_comment": "TRACE v0.1 Trust Record — AMD SEV-SNP example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676142,
   "subject": "spiffe://trust.example.org/agent/payments-processor/prod",
@@ -11,28 +11,28 @@
   },
   "runtime": {
     "platform": "amd-sev-snp",
-    "measurement": "sha384:c9e4b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4...",
+    "measurement": "sha384:c9e4b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
     "rim_uri": "https://kdsintf.amd.com/vcek/v1/Milan/cert_chain",
     "firmware_version": "1.53.0",
     "nonce": "ZRVkXG1wbVJhY2tSZWNvcmQ"
   },
   "policy": {
-    "bundle_hash": "sha256:b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2...",
+    "bundle_hash": "sha256:b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
     "enforcement_mode": "enforce",
     "version": "1.2.0",
     "policy_uri": "https://registry.agentrust.io/policy/payments-v1.2.0"
   },
   "data_class": "confidential",
   "tool_transcript": {
-    "hash": "sha256:d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4...",
+    "hash": "sha256:d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
     "call_count": 3,
     "transcript_uri": "https://registry.agentrust.io/transcript/amd-2026-06-23T09:15:42Z"
   },
   "build_provenance": {
     "slsa_level": 2,
     "builder": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml",
-    "digest": "sha256:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5...",
-    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/..."
+    "digest": "sha256:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
+    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/def456"
   },
   "appraisal": {
     "status": "affirming",
@@ -45,8 +45,8 @@
     "jwk": {
       "kty": "EC",
       "crv": "P-256",
-      "x": "MEkwEwYHKoZIzj0CAQY...",
-      "y": "GHkVPyQs9bXm2A...",
+      "x": "MEkwEwYHKoZIzj0CAQY",
+      "y": "GHkVPyQs9bXm2A",
       "kid": "sev-snp-workload-key-2026-06-23"
     }
   }

--- a/examples/intel-tdx.json
+++ b/examples/intel-tdx.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — Intel TDX example. Truncated digests shown with '...' suffix.",
+  "_comment": "TRACE v0.1 Trust Record — Intel TDX example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676200,
   "subject": "spiffe://trust.example.org/agent/document-processor/staging",
@@ -7,33 +7,33 @@
     "provider": "meta",
     "model_id": "llama-3.3-70b-instruct",
     "version": "3.3",
-    "weights_digest": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2...",
+    "weights_digest": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
     "aibom_uri": "https://registry.agentrust.io/aibom/llama-3.3-70b-20260101"
   },
   "runtime": {
     "platform": "intel-tdx",
-    "measurement": "sha384:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5...",
+    "measurement": "sha384:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8",
     "rim_uri": "https://api.trustedservices.intel.com/sgx/certification/v4/rootcacrl",
     "firmware_version": "2.0.3",
     "nonce": "dGRYLXdvcmtsb2FkLW5vbmNl"
   },
   "policy": {
-    "bundle_hash": "sha256:c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3...",
+    "bundle_hash": "sha256:c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
     "enforcement_mode": "enforce",
     "version": "2.0.1",
     "policy_uri": "https://registry.agentrust.io/policy/document-v2.0.1"
   },
   "data_class": "internal",
   "tool_transcript": {
-    "hash": "sha256:f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6...",
+    "hash": "sha256:f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7",
     "call_count": 7,
     "transcript_uri": "https://registry.agentrust.io/transcript/tdx-2026-06-23T09:16:40Z"
   },
   "build_provenance": {
     "slsa_level": 3,
     "builder": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml",
-    "digest": "sha256:b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8...",
-    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/..."
+    "digest": "sha256:b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9",
+    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/abc123"
   },
   "appraisal": {
     "status": "affirming",
@@ -46,8 +46,8 @@
     "jwk": {
       "kty": "EC",
       "crv": "P-384",
-      "x": "TDXd2VyaWZpY2F0aW9uS2V5...",
-      "y": "UmVmZXJlbmNlTWVhc3VyZW1l...",
+      "x": "TDXd2VyaWZpY2F0aW9uS2V5",
+      "y": "UmVmZXJlbmNlTWVhc3VyZW1l",
       "kid": "tdx-workload-key-2026-06-23"
     }
   }

--- a/examples/nvidia-h100.json
+++ b/examples/nvidia-h100.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — NVIDIA H100 Confidential Computing example. Truncated digests shown with '...' suffix.",
+  "_comment": "TRACE v0.1 Trust Record — NVIDIA H100 Confidential Computing example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676300,
   "subject": "spiffe://trust.example.org/agent/image-analysis/prod",
@@ -7,33 +7,33 @@
     "provider": "anthropic",
     "model_id": "claude-opus-4-8",
     "version": "20260601",
-    "weights_digest": "sha256:d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4...",
+    "weights_digest": "sha256:d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
     "aibom_uri": "https://registry.agentrust.io/aibom/claude-opus-4-8-20260601"
   },
   "runtime": {
     "platform": "nvidia-h100",
-    "measurement": "sha384:b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6...",
-    "rim_uri": "https://nras.nvidia.com/v1/attestation/rim/...",
+    "measurement": "sha384:b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9",
+    "rim_uri": "https://nras.nvidia.com/v1/attestation/rim/h100",
     "firmware_version": "535.183.06",
     "nonce": "bnZpZGlhLWgxMDAtbm9uY2U"
   },
   "policy": {
-    "bundle_hash": "sha256:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5...",
+    "bundle_hash": "sha256:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
     "enforcement_mode": "enforce",
     "version": "1.0.0",
     "policy_uri": "https://registry.agentrust.io/policy/image-analysis-v1.0.0"
   },
   "data_class": "restricted",
   "tool_transcript": {
-    "hash": "sha256:a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7...",
+    "hash": "sha256:a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8",
     "call_count": 1,
     "transcript_uri": "https://registry.agentrust.io/transcript/h100-2026-06-23T09:18:20Z"
   },
   "build_provenance": {
     "slsa_level": 2,
     "builder": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml",
-    "digest": "sha256:c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9...",
-    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/..."
+    "digest": "sha256:c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0",
+    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/ghi789"
   },
   "appraisal": {
     "status": "affirming",
@@ -46,8 +46,8 @@
     "jwk": {
       "kty": "EC",
       "crv": "P-256",
-      "x": "SDEwMENvbmZpZGVudGlhbA...",
-      "y": "Q29tcHV0aW5nS2V5Rm9yVA...",
+      "x": "SDEwMENvbmZpZGVudGlhbA",
+      "y": "Q29tcHV0aW5nS2V5Rm9yVA",
       "kid": "h100-cc-workload-key-2026-06-23"
     }
   }

--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -53,7 +53,7 @@
         "weights_digest": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the model weights. Required for local/confidential-inference deployments.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "aibom_uri": {
           "type": "string",
@@ -85,7 +85,7 @@
         "measurement": {
           "type": "string",
           "description": "Hardware measurement of the workload (e.g. TDX MRTD, SEV measurement, TPM PCR composite).",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "rim_uri": {
           "type": "string",
@@ -111,7 +111,7 @@
         "bundle_hash": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the policy bundle in force at execution time.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "enforcement_mode": {
           "type": "string",
@@ -143,7 +143,7 @@
         "hash": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the full tool-call transcript, bound into the EAT envelope.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "call_count": {
           "type": "integer",
@@ -176,7 +176,7 @@
         "digest": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the container image or workload binary.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "provenance_uri": {
           "type": "string",

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-_DIGEST_RE = r"^sha(256|384):[0-9a-f]+"
+_DIGEST_RE = r"^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
 
 DigestStr = Annotated[str, Field(pattern=_DIGEST_RE)]
 

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -53,7 +53,7 @@
         "weights_digest": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the model weights. Required for local/confidential-inference deployments.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "aibom_uri": {
           "type": "string",
@@ -85,7 +85,7 @@
         "measurement": {
           "type": "string",
           "description": "Hardware measurement of the workload (e.g. TDX MRTD, SEV measurement, TPM PCR composite).",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "rim_uri": {
           "type": "string",
@@ -111,7 +111,7 @@
         "bundle_hash": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the policy bundle in force at execution time.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "enforcement_mode": {
           "type": "string",
@@ -143,7 +143,7 @@
         "hash": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the full tool-call transcript, bound into the EAT envelope.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "call_count": {
           "type": "integer",
@@ -176,7 +176,7 @@
         "digest": {
           "type": "string",
           "description": "SHA-256 or SHA-384 digest of the container image or workload binary.",
-          "pattern": "^sha(256|384):[0-9a-f]+"
+          "pattern": "^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
         },
         "provenance_uri": {
           "type": "string",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,3 +59,45 @@ def test_bad_platform_rejected() -> None:
     data["runtime"]["platform"] = "unknown-cloud"
     with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
+
+
+# CRYPTO-008 / CRYPTO-009: DigestStr regex enforcement
+
+def test_digest_uppercase_rejected() -> None:
+    """CRYPTO-008: uppercase hex must be rejected (sha256: is lowercase-only)."""
+    data = _load("intel-tdx.json")
+    data["runtime"]["measurement"] = "sha256:" + "A" * 64
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)
+
+
+def test_digest_sha256_too_short_rejected() -> None:
+    """CRYPTO-008/009: sha256 digest shorter than 64 chars must be rejected."""
+    data = _load("intel-tdx.json")
+    data["runtime"]["measurement"] = "sha256:" + "a" * 63
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)
+
+
+def test_digest_sha256_exact_length_accepted() -> None:
+    """sha256 digest with exactly 64 lowercase hex chars must be accepted."""
+    data = _load("intel-tdx.json")
+    data["runtime"]["measurement"] = "sha256:" + "a" * 64
+    record = TrustRecord.model_validate(data)
+    assert record.runtime.measurement == "sha256:" + "a" * 64
+
+
+def test_digest_sha384_exact_length_accepted() -> None:
+    """sha384 digest with exactly 96 lowercase hex chars must be accepted."""
+    data = _load("intel-tdx.json")
+    data["runtime"]["measurement"] = "sha384:" + "b" * 96
+    record = TrustRecord.model_validate(data)
+    assert record.runtime.measurement == "sha384:" + "b" * 96
+
+
+def test_digest_sha512_rejected() -> None:
+    """CRYPTO-009: unsupported algorithm sha512 must be rejected."""
+    data = _load("intel-tdx.json")
+    data["runtime"]["measurement"] = "sha512:" + "a" * 128
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)


### PR DESCRIPTION
﻿## Summary

Fixes two regex defects in `DigestStr` validation (CRYPTO-008, CRYPTO-009).

**Problem 1 (CRYPTO-008, closes #6):** The old pattern `^sha(256|384):[0-9a-f]+` had no end anchor, so `sha256:abcXXX` matched the prefix `sha256:abc` and passed. Uppercase hex and arbitrary suffixes were silently accepted.

**Problem 2 (CRYPTO-009, closes #7):** The `+` quantifier accepted any non-zero hex length. `sha256:a` passed. SHA-256 must be exactly 64 hex chars; SHA-384 must be exactly 96.

**Fix:** New pattern `^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$` -- end-anchored, per-algorithm exact lengths, lowercase-only character class.

## Changes

- `src/agentrust_trace/models.py` -- updated `_DIGEST_RE`
- `src/agentrust_trace/schema/trace-v0.1.json` -- updated all 5 DigestStr pattern fields
- `schema/trace-claim.json` -- updated all 5 DigestStr pattern fields
- `examples/*.json` -- replaced truncated placeholder digests with full-length hex strings so examples remain valid under the new regex
- `tests/test_models.py` -- added 5 targeted regression tests

## Test plan

- [ ] `test_digest_uppercase_rejected` -- sha256 + A*64 raises ValidationError
- [ ] `test_digest_sha256_too_short_rejected` -- sha256 + a*63 raises ValidationError
- [ ] `test_digest_sha256_exact_length_accepted` -- sha256 + a*64 passes
- [ ] `test_digest_sha384_exact_length_accepted` -- sha384 + b*96 passes
- [ ] `test_digest_sha512_rejected` -- sha512 + a*128 raises ValidationError
- [ ] All 20 tests pass (pytest tests/ -v)

Generated with [Claude Code](https://claude.com/claude-code)