### PR TITLE
fix: opt into node.js 24 across all workflows before june 16 deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "feat/**", "fix/**"]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   id-token: write  # OIDC trusted publishing — no stored API token needed
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Opts into Node.js 24 via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 at workflow level before the June 16 forced cutover. After June 16, GitHub forces Node.js 24 anyway — this makes it explicit now so any incompatibilities surface on our timeline.