### PR TITLE
feat: add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,30 @@
+name: SBOM
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sbom.yml` — generates an SPDX-JSON SBOM on push to main and on release publish. Same pattern as agent-manifest.

## Test plan
- [ ] CI passes
- [ ] SBOM artifact appears in run

🤖 Generated with [Claude Code](https://claude.com/claude-code)