### PR TITLE
feat: add contributor reputation check and maintainer gate workflows

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -1,0 +1,42 @@
+name: Contributor reputation check
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      username:
+        description: GitHub username to check
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'copilot-swe-agent[bot]' &&
+      github.actor != 'claude-code[bot]' &&
+      github.actor != 'imran-siddique'
+    steps:
+      - name: Checkout org action
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: agentrust-io/.github
+          ref: main
+          persist-credentials: false
+          sparse-checkout: |
+            scripts
+            .github/actions/contributor-check
+
+      - name: Run contributor check
+        uses: ./.github/actions/contributor-check
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -1,0 +1,39 @@
+name: Require maintainer approval
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for maintainer approval
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const MAINTAINERS = ['imran-siddique'];
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const association = context.payload.pull_request.author_association;
+            if (association === 'MEMBER' || association === 'OWNER') {
+              core.info(`Author is ${association} — skipping gate`);
+              return;
+            }
+            const approved = reviews.some(
+              r => r.state === 'APPROVED' &&
+                   r.user.type === 'User' &&
+                   MAINTAINERS.includes(r.user.login)
+            );
+            if (!approved) {
+              core.setFailed('Waiting for maintainer approval before merging.');
+            }


### PR DESCRIPTION
## Summary

- Adds \`contributor-check.yml\`: calls the composite action in \`agentrust-io/.github\` to screen incoming contributors for coordinated inauthentic behavior
- Adds \`require-maintainer-approval.yml\`: blocking gate that fails the merge check until a named maintainer approves

Scripts live in the org \`.github\` repo; updates to detection logic deploy to all repos at once.

Borrowed from AGT under MIT License (copyright Microsoft Corporation).

## Test plan

- [ ] CI passes
- [ ] Open a test PR from an external account to confirm \`contributor-check\` fires
- [ ] Confirm \`require-maintainer-approval\` blocks merge until imran-siddique approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)