### PR TITLE
fix: make examples validate against the schema and require jwk key material

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# TRACE v0.1 example Trust Records
+
+Each file is a canonical TRACE v0.1 Trust Record that validates as-is against
+`schema/trace-claim.json` (no preprocessing, no comment stripping).
+
+- `intel-tdx.json`: Intel TDX example.
+- `amd-sev-snp.json`: AMD SEV-SNP example.
+- `nvidia-h100.json`: NVIDIA H100 Confidential Computing example.
+
+The schema sets `additionalProperties: false`, so examples must not carry
+non-schema keys such as `_comment`. Keep descriptive notes in this file.

--- a/examples/amd-sev-snp.json
+++ b/examples/amd-sev-snp.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — AMD SEV-SNP example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676142,
   "subject": "spiffe://trust.example.org/agent/payments-processor/prod",

--- a/examples/intel-tdx.json
+++ b/examples/intel-tdx.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — Intel TDX example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676200,
   "subject": "spiffe://trust.example.org/agent/document-processor/staging",

--- a/examples/nvidia-h100.json
+++ b/examples/nvidia-h100.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "TRACE v0.1 Trust Record — NVIDIA H100 Confidential Computing example.",
   "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
   "iat": 1750676300,
   "subject": "spiffe://trust.example.org/agent/image-analysis/prod",

--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -225,7 +225,7 @@
       "properties": {
         "jwk": {
           "type": "object",
-          "description": "JWK (RFC 7517) representing the TEE-sealed public key.",
+          "description": "JWK (RFC 7517) representing the TEE-sealed public key. Keys must carry actual key material: OKP keys require crv and x; EC keys require crv, x, and y.",
           "required": ["kty"],
           "properties": {
             "kty": {"type": "string"},
@@ -233,7 +233,23 @@
             "x":   {"type": "string"},
             "y":   {"type": "string"},
             "kid": {"type": "string"}
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": ["kty"],
+                "properties": {"kty": {"const": "OKP"}}
+              },
+              "then": {"required": ["crv", "x"]}
+            },
+            {
+              "if": {
+                "required": ["kty"],
+                "properties": {"kty": {"const": "EC"}}
+              },
+              "then": {"required": ["crv", "x", "y"]}
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _DIGEST_RE = r"^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
 
@@ -82,6 +82,18 @@ class JWK(BaseModel):
     x: str | None = None
     y: str | None = None
     kid: str | None = None
+
+    @model_validator(mode="after")
+    def _require_key_material(self) -> JWK:
+        """A confirmation key without key material binds nothing (RFC 7518 §6)."""
+        required_by_kty = {"OKP": ("crv", "x"), "EC": ("crv", "x", "y")}
+        required = required_by_kty.get(self.kty, ())
+        missing = [name for name in required if getattr(self, name) is None]
+        if missing:
+            raise ValueError(
+                f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
+            )
+        return self
 
 
 class ConfirmationKey(BaseModel):

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -225,7 +225,7 @@
       "properties": {
         "jwk": {
           "type": "object",
-          "description": "JWK (RFC 7517) representing the TEE-sealed public key.",
+          "description": "JWK (RFC 7517) representing the TEE-sealed public key. Keys must carry actual key material: OKP keys require crv and x; EC keys require crv, x, and y.",
           "required": ["kty"],
           "properties": {
             "kty": {"type": "string"},
@@ -233,7 +233,23 @@
             "x":   {"type": "string"},
             "y":   {"type": "string"},
             "kid": {"type": "string"}
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": ["kty"],
+                "properties": {"kty": {"const": "OKP"}}
+              },
+              "then": {"required": ["crv", "x"]}
+            },
+            {
+              "if": {
+                "required": ["kty"],
+                "properties": {"kty": {"const": "EC"}}
+              },
+              "then": {"required": ["crv", "x", "y"]}
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,9 +12,8 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 
 
 def _load(name: str) -> dict:
-    data = json.loads((EXAMPLES_DIR / name).read_text())
-    data.pop("_comment", None)  # examples carry a human note; not part of the schema
-    return data
+    # Examples must validate exactly as published: no preprocessing.
+    return json.loads((EXAMPLES_DIR / name).read_text())
 
 
 @pytest.mark.parametrize("filename", ["intel-tdx.json", "amd-sev-snp.json", "nvidia-h100.json"])
@@ -101,3 +100,32 @@ def test_digest_sha512_rejected() -> None:
     data["runtime"]["measurement"] = "sha512:" + "a" * 128
     with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
+
+
+# cnf.jwk key material enforcement
+
+
+def test_okp_jwk_without_key_material_rejected() -> None:
+    """An OKP confirmation key with no crv/x carries no key material and binds nothing."""
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {"kty": "OKP"}
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)
+
+
+def test_ec_jwk_without_y_rejected() -> None:
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {"kty": "EC", "crv": "P-256", "x": "dGVzdA"}
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)
+
+
+def test_okp_jwk_with_key_material_accepted() -> None:
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+    }
+    record = TrustRecord.model_validate(data)
+    assert record.cnf.jwk.x is not None

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -11,9 +11,8 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 
 
 def _load(name: str) -> dict:
-    data = json.loads((EXAMPLES_DIR / name).read_text())
-    data.pop("_comment", None)
-    return data
+    # Examples must validate exactly as published: no preprocessing.
+    return json.loads((EXAMPLES_DIR / name).read_text())
 
 
 @pytest.mark.parametrize("filename", ["intel-tdx.json", "amd-sev-snp.json", "nvidia-h100.json"])
@@ -42,3 +41,37 @@ def test_missing_required_field_fails() -> None:
 def test_schema_is_dict() -> None:
     assert isinstance(SCHEMA, dict)
     assert SCHEMA.get("title") == "TRACE Trust Record"
+
+
+def test_comment_key_fails() -> None:
+    """additionalProperties is false: a _comment key must be rejected, including in examples."""
+    data = _load("intel-tdx.json")
+    data["_comment"] = "human note"
+    errors = iter_errors(data)
+    assert errors
+
+
+def test_okp_jwk_without_key_material_fails() -> None:
+    """cnf.jwk must carry key material: OKP requires crv and x."""
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {"kty": "OKP"}
+    errors = iter_errors(data)
+    assert errors
+
+
+def test_ec_jwk_without_y_fails() -> None:
+    """cnf.jwk must carry key material: EC requires crv, x, and y."""
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {"kty": "EC", "crv": "P-256", "x": "dGVzdA"}
+    errors = iter_errors(data)
+    assert errors
+
+
+def test_okp_jwk_with_key_material_passes() -> None:
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"] = {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+    }
+    assert iter_errors(data) == []


### PR DESCRIPTION
## Summary

1. **Examples failed the repo's own schema:** `examples/amd-sev-snp.json`, `examples/intel-tdx.json`, and `examples/nvidia-h100.json` carried a top-level `_comment` key while `schema/trace-claim.json` sets `additionalProperties: false`. The Python tests masked this by popping `_comment` before validating. The `_comment` keys are removed (notes moved to `examples/README.md`) and the `.pop("_comment")` preprocessing is removed from both test files, so the examples are now validated exactly as published. A regression test asserts that a `_comment` key is rejected.
2. **cnf.jwk accepted keys with no key material:** the schema required only `kty`, so `{"kty": "OKP"}` passed as a confirmation key that binds nothing. The schema (both the canonical copy and the packaged `src/agentrust_trace/schema/trace-v0.1.json`) now uses JSON Schema if/then to require `crv` + `x` for OKP keys and `crv` + `x` + `y` for EC keys. The pydantic `JWK` model enforces the same rule. All three examples already carry full EC key material and pass unchanged; the trace-tests vectors were checked and all valid vectors already carry key material.

## Tests

27 passed (positive and negative coverage for both fixes), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)