### PR TITLE
feat(schema): add software-only platform value for non-attested dev records

### DIFF
--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -78,9 +78,10 @@
             "aws-nitro",
             "arm-cca",
             "google-confidential-space",
-            "tpm2"
+            "tpm2",
+            "software-only"
           ],
-          "description": "Hardware platform providing the root of trust."
+          "description": "Hardware platform providing the root of trust. software-only marks development-mode records with no hardware backing; they must never be treated as attested evidence."
         },
         "measurement": {
           "type": "string",

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -31,6 +31,10 @@ class RuntimeInfo(BaseModel):
         "arm-cca",
         "google-confidential-space",
         "tpm2",
+        # Development / non-attested mode. Distinct from tpm2 so a dev-mode
+        # record can never be mistaken for hardware-backed evidence by a
+        # consumer that only inspects runtime.platform.
+        "software-only",
     ]
     measurement: DigestStr
     rim_uri: str | None = None

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -78,9 +78,10 @@
             "aws-nitro",
             "arm-cca",
             "google-confidential-space",
-            "tpm2"
+            "tpm2",
+            "software-only"
           ],
-          "description": "Hardware platform providing the root of trust."
+          "description": "Hardware platform providing the root of trust. software-only marks development-mode records with no hardware backing; they must never be treated as attested evidence."
         },
         "measurement": {
           "type": "string",


### PR DESCRIPTION
Dev-mode records currently claim `platform: "tpm2"` with a `firmware_version: "software-only-dev-mode"` sentinel -- any consumer that keys trust decisions on `runtime.platform` alone treats non-attested evidence as TPM-backed. This adds `software-only` as a first-class platform value (model Literal + both schema copies), documented as never being attested evidence.

Paired with a cmcp change that emits the new value and updates the verifier. A release of agentrust-trace including this is needed before the cmcp side can merge.

Generated with [Claude Code](https://claude.ai/code)