### PR TITLE
spec: make signature and freshness binding mandatory for Trust Records

### DIFF
--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -253,6 +253,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "signature": {
+      "type": "string",
+      "description": "OPTIONAL embedded signature: base64url (no padding) signature by the cnf key over the canonical JSON form of the record with this field absent. Every Trust Record MUST be signature-bound per spec section 3.2.2, but enveloped profiles (e.g. JWS, cMCP RuntimeClaim) carry the signature outside the record, so this field is not required by the schema.",
+      "pattern": "^[A-Za-z0-9_-]+$"
     }
   },
   "additionalProperties": false

--- a/spec/trace-v0.1.md
+++ b/spec/trace-v0.1.md
@@ -115,6 +115,7 @@ The Trust Record is the unit of evidence. All fields are required unless marked 
 | `cnf` | Confirmation key — binds record to TEE-held signing key | EAT `cnf` claim (RFC 8747) |
 | `eat_profile` | Profile URI identifying this as a TRACE v0.1 record | EAT profile claim |
 | `iat` | Issued-at timestamp (Unix epoch) | EAT standard claim |
+| `signature` | OPTIONAL as a record field: embedded signature by the `cnf` key over the canonical record (section 3.2.2). Profiles using an enveloping signature (JWS, COSE, cMCP RuntimeClaim) omit this field and carry the signature in the envelope. The signature binding itself is mandatory either way. | JWS / COSE signature over canonical JSON |
 
 Each field is independently verifiable. Sub-records (e.g., per-tool-call transcripts) compose under one root envelope.
 
@@ -183,15 +184,30 @@ Each field is independently verifiable. Sub-records (e.g., per-tool-call transcr
 - **Revocation:** silicon-root revocation is consumed from existing vendor channels. Workload-level keys SHOULD rotate at TEE-image boundaries. Verifiers MUST consult current revocation status at verification time.
 - **Hash agility:** SHA-256 minimum; SHA-384 required for FIPS-aligned profiles. Algorithm signaled in the EAT envelope per RFC 9711 §6.
 
+#### 3.2.2 Mandatory signature and freshness binding
+
+**Signature binding.** Every TRACE Trust Record MUST be cryptographically bound by a signature over its canonical JSON form, made by the key in `cnf`. Canonicalization is RFC 8785 (JCS) unless the profile declares a different canonicalization. The signature MAY be either:
+
+- **Embedded:** carried in the record's top-level `signature` field (base64url, no padding), computed over the canonical form of the record with the `signature` field absent; or
+- **Enveloping:** carried by a signed wrapper structure, e.g. a JWS (RFC 7515) whose payload is the record, a COSE_Sign1 envelope, or cMCP's RuntimeClaim (signature over the canonical record, key in `trace.cnf.jwk`).
+
+Each profile MUST declare which binding form it uses. A record with no verifiable signature binding is not a Trust Record: verifiers MUST reject it. Schema validity alone confers no trust.
+
+**Freshness.** Records MUST carry `iat`. Verifiers MUST enforce a maximum record age: a record whose `iat` is older than the maximum age MUST be rejected. The default maximum age is 24 hours; a deployment profile MAY specify a different value. Verifiers SHOULD additionally support challenge-nonce binding for online verification: the verifier supplies a nonce, the issuer echoes it in `runtime.nonce`, and the verifier checks the echo. When a challenge nonce was issued, a record that omits or mismatches it MUST be rejected.
+
+**Conformance alignment.** The TRACE conformance suite (trace-tests) already enforces both rules: records without a verifiable signature fail at conformance level 1 and above, and the default 24-hour max-age is enforced.
+
 ### 3.3 Verification
 
 Any party — browser, CLI, in-cluster verifier, third-party auditor — verifies:
 
-1. Signature chain resolves to a known silicon root (NVIDIA, Intel, AMD, or equivalent).
-2. Runtime measurements match published Reference Integrity Manifests (RIMs).
-3. Policy hash matches the policy bundle the verifier expects.
-4. SCITT receipt resolves on the named transparency log.
-5. SLSA provenance resolves to a trusted builder.
+1. The record's signature binding (section 3.2.2) verifies against the key in `cnf`, BEFORE any other field is trusted. A record with no verifiable binding MUST be rejected.
+2. The record is fresh: `iat` is within the maximum age (default 24 hours unless the deployment profile specifies otherwise). If the verifier issued a challenge nonce, `runtime.nonce` echoes it.
+3. Signature chain resolves to a known silicon root (NVIDIA, Intel, AMD, or equivalent).
+4. Runtime measurements match published Reference Integrity Manifests (RIMs).
+5. Policy hash matches the policy bundle the verifier expects.
+6. SCITT receipt resolves on the named transparency log.
+7. SLSA provenance resolves to a trusted builder.
 
 No callback to the issuer. No vendor in the trust path beyond silicon root and transparency log operators.
 

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -119,3 +119,8 @@ class TrustRecord(BaseModel):
     appraisal: Appraisal
     transparency: str
     cnf: ConfirmationKey
+    signature: Annotated[str, Field(pattern=r"^[A-Za-z0-9_-]+$")] | None = None
+    """Optional embedded signature (base64url, no padding) by the cnf key over the
+    canonical JSON form of the record with this field absent. Every Trust Record must
+    be signature-bound per spec section 3.2.2; enveloped profiles carry the signature
+    outside the record instead of in this field."""

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -253,6 +253,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "signature": {
+      "type": "string",
+      "description": "OPTIONAL embedded signature: base64url (no padding) signature by the cnf key over the canonical JSON form of the record with this field absent. Every Trust Record MUST be signature-bound per spec section 3.2.2, but enveloped profiles (e.g. JWS, cMCP RuntimeClaim) carry the signature outside the record, so this field is not required by the schema.",
+      "pattern": "^[A-Za-z0-9_-]+$"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Decision

Issue #18 identified that a TRACE v0.1 Trust Record is replayable as an unsigned blob: nothing in the schema or verification steps requires a signature binding the `cnf` key to the record, and `iat` has only a lower bound, so any historical record validates forever. This PR makes signature binding a MUST.

### Normative additions (new section 3.2.2)

1. **Signature binding.** Every Trust Record MUST be cryptographically bound by a signature over its canonical JSON form (RFC 8785, or the profile's declared canonicalization), made by the key in `cnf`. The signature MAY be embedded (top-level `signature` field, computed over the record with that field absent) or enveloping (JWS, COSE_Sign1, or cMCP's RuntimeClaim). The profile MUST declare which form it uses. Verifiers MUST reject records with no verifiable binding; schema validity alone confers no trust.
2. **Freshness.** Records MUST carry `iat`; verifiers MUST enforce a maximum age (default 24 hours unless the deployment profile specifies otherwise) and SHOULD support challenge-nonce binding via `runtime.nonce` for online verification. A record that omits or mismatches an issued challenge nonce MUST be rejected.

### Verification steps (section 3.3)

The numbered steps now verify the signature binding against `cnf` BEFORE trusting any other field, then enforce max-age and nonce echo, then proceed to the existing silicon-root, RIM, policy, SCITT, and SLSA checks.

### Schema and model

Both schema copies (`schema/trace-claim.json` and the packaged `src/agentrust_trace/schema/trace-v0.1.json`) gain an OPTIONAL top-level `signature` property (string, base64url pattern) so an embedded signature no longer violates `additionalProperties: false`. It is deliberately NOT in the schema's `required` set: enveloped profiles carry the signature outside the record, and the MUST lives in spec prose. The pydantic `TrustRecord` model gains the matching optional field (it has `extra="forbid"`, so the schema and model must stay in lockstep).

### Conformance alignment

The conformance suite (trace-tests) already fails records without verifiable signatures at level >= 1 and enforces a 24h default max-age; this PR brings the spec in line with it.

## Testing

- `pytest`: 27 passed (existing vectors and examples unaffected)
- Sanity check: examples validate with an embedded base64url `signature` added (schema and pydantic model); non-base64url values are rejected

Closes #18

Generated with [Claude Code](https://claude.ai/code)