### PR TITLE
chore: release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentrust-trace"
-version = "0.1.0"
+version = "0.1.1"
 description = "TRACE v0.1 — hardware-attested governance records for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Version bump for the 0.1.1 release: publishes the software-only platform value (#23), the optional embedded signature field + JWK key-material requirements (#17/#24) to PyPI. cmcp-runtime main needs this release -- its CI installs agentrust-trace from PyPI, and 0.1.0 rejects the software-only platform that the runtime now emits for dev-mode records.

Tag v0.1.1 after merge triggers the existing OIDC publish workflow.

Generated with [Claude Code](https://claude.ai/code)