### PR TITLE
fix(dns): update custom domain to trace.agentrust-io.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-agentrust.io
+trace.agentrust-io.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: TRACE
 site_description: Trust Runtime Attestation and Compliance Evidence — open attestation standard for agentic AI governance
-site_url: https://agentrust.io/trace
+site_url: https://trace.agentrust-io.com
 repo_url: https://github.com/agentrust-io/trace-spec
 repo_name: agentrust-io/trace-spec
 edit_uri: edit/main/


### PR DESCRIPTION
## Summary

Updates the GitHub Pages custom domain from the placeholder `agentrust.io` to the confirmed live domain `trace.agentrust-io.com`.

- `CNAME`: `agentrust.io` → `trace.agentrust-io.com`
- `mkdocs.yml` `site_url`: `https://agentrust.io/trace` → `https://trace.agentrust-io.com`

DNS records for `agentrust-io.com` have been added in Cloudflare (`trace CNAME agentrust-io.github.io`). Once merged, GitHub Pages will activate the custom domain and `https://trace.agentrust-io.com` will go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)