### PR TITLE
fix(docs): remove nonexistent custom_dir from mkdocs theme config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,6 @@ theme:
   font: false
   logo: docs/assets/icon.svg
   favicon: docs/assets/icon.svg
-  custom_dir: docs/overrides
   palette:
     - scheme: slate
       primary: custom


### PR DESCRIPTION
## Summary

`docs/overrides` was referenced as `custom_dir` in the mkdocs theme config but the directory was never created. This caused every build to abort immediately:

```
ERROR - Config value 'theme': The path set in custom_dir ('docs/overrides') does not exist.
```

Removing the line unblocks the docs workflow. No functionality lost — we have no theme overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)