### PR TITLE
docs: fix spec version table, roadmap description, and AGT star count

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ Announced at Confidential Computing Summit, San Francisco, June 23 2026.
 - Wire formats: EAT/JWT and CBOR-COSE
 - Hardware roots: NVIDIA H100/Blackwell, Intel TDX, AMD SEV-SNP, Azure MAA, GCP Confidential Space, AWS Nitro
 - JSON Schema and three hardware examples
-- Reference implementation: cMCP Phase 1 (runtime trust, no policy enforcement)
+- Reference implementation: cMCP Phase 1 (Cedar policy enforcement, TRACE Level 2 emission)
 
 **Not in v0.1:** MCP profile (normative), A2A profile, vendor platform annexes, OWASP/ATLAS cross-walks, encrypted claims envelope.
 

--- a/docs/integration/agt.md
+++ b/docs/integration/agt.md
@@ -1,6 +1,6 @@
 # Integration: AGT
 
-[AGT (Agent Governance Toolkit)](https://github.com/microsoft/agent-governance-toolkit) is the most widely adopted agent governance framework (4,200+ stars, 100+ contributors). It provides Cedar policy enforcement, SPIFFE/SVID identity, and Merkle-chained audit logs for any agent framework.
+[AGT (Agent Governance Toolkit)](https://github.com/microsoft/agent-governance-toolkit) is the most widely adopted agent governance framework (4,100+ stars, 100+ contributors). It provides Cedar policy enforcement, SPIFFE/SVID identity, and Merkle-chained audit logs for any agent framework.
 
 AGT emits TRACE v0.1 Trust Records via `TRACEAuditSink` — see [ADR 0032](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/adr/0032-agt-emits-trace-v01-trust-records.md) for the full design.
 

--- a/spec/trace-v0.1.md
+++ b/spec/trace-v0.1.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Version | 0.2 — Draft |
+| Version | 0.1 — Draft |
 | Status | RFC — Request for Comments |
 | Authors | Rishabh Poddar, Aaron Fulkerson (OPAQUE Systems) |
 | Target announcement | Confidential Computing Summit, San Francisco — 23 June 2026 |


### PR DESCRIPTION
## Summary

Three factual errors found during docs audit:

- `spec/trace-v0.1.md`: version table listed `0.2 — Draft` but the file is `trace-v0.1.md`. Fix to `0.1 — Draft`.
- `ROADMAP.md`: described the cMCP Phase 1 reference implementation as "no policy enforcement" — cMCP enforces Cedar policy, that's a core feature. Fix to accurate description.
- `docs/integration/agt.md`: listed "4,200+ stars" for AGT; actual count is 4,103. Fix to "4,100+".

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)