### PR TITLE
docs: add Trust Levels, Glossary, Platforms index; fix quickstart

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,68 @@
+# Glossary
+
+Terms used in the TRACE specification and documentation.
+
+---
+
+**Appraisal**
+The process of evaluating a TEE evidence bundle against a reference integrity manifest (RIM) to produce an `appraisal.status` verdict. An `"affirming"` verdict means the measured environment matches the expected state. Defined in IETF RFC 9334 (RATS).
+
+---
+
+**cnf / JWK**
+The TRACE `cnf` field (from RFC 7800) carries a JSON Web Key (`jwk` sub-field) that contains the Ed25519 public key used to sign the record. It is included in the signed payload so the verifier does not need to retrieve the key out-of-band.
+
+---
+
+**Conformance**
+A trust record is conformant if it passes all test cases required at its declared trust level. Conformance is verified by the `trace-tests` test suite. Partial conformance (record passes some but not all required tests) is not valid.
+
+---
+
+**EAT — Entity Attestation Token**
+A JWT-based format for conveying evidence about a hardware or software entity. TRACE records use the EAT `eat_profile` claim to identify the specific TRACE profile version. Defined in IETF draft-ietf-rats-eat.
+
+---
+
+**GatewayClaim**
+A cMCP claim embedded in a TRACE trust record that binds the record to a specific cMCP session. Contains the session ID, gateway DID, and the Cedar policy bundle hash that governed the session.
+
+---
+
+**JCS — JSON Canonicalization Scheme**
+RFC 8785. A deterministic serialization of JSON objects: Unicode code-point-ordered keys, no whitespace, IEEE 754 double-precision number encoding. TRACE uses JCS to canonicalize the record before computing the Ed25519 signature.
+
+---
+
+**RIM — Reference Integrity Manifest**
+A signed document describing the expected firmware and software measurements for a TEE environment. During Level 1 appraisal, the verifier compares the TEE's runtime measurements against the RIM. The `runtime.rim_uri` field optionally points to a RIM.
+
+---
+
+**RATS — Remote Attestation Procedures**
+The IETF working group and architecture (RFC 9334) that defines the roles and flows for remote attestation: Attester (the hardware), Verifier (checks evidence against RIM), Relying Party (consumes the resulting attestation result). TRACE Level 1 and 2 follow the RATS architecture.
+
+---
+
+**SCITT — Supply Chain Integrity, Transparency, and Trust**
+An IETF draft standard for append-only transparency logs of software and attestation artifacts. TRACE Level 2 records include a SCITT receipt URI in the `transparency` field, anchoring the record to a public or shared log.
+
+---
+
+**SPIFFE / SPIRE**
+SPIFFE (Secure Production Identity Framework For Everyone) defines URI-based workload identities of the form `spiffe://<trust-domain>/<workload-path>`. TRACE requires the `subject` field to be a SPIFFE URI or a DID. SPIRE is the reference implementation.
+
+---
+
+**Trust Level**
+A numeric value (0, 1, or 2) that summarizes the strength of the guarantees carried by a trust record. See [Trust Levels](trust-levels.md) for the full definition of each level.
+
+---
+
+**Trust Record**
+A signed JSON document emitted by an AI agent at the end of a governed session. It asserts the agent's identity, model, policy, data class, tool invocations, and (at Level 1+) hardware attestation state. Defined in full in the [TRACE Specification](../spec/trace-v0.1.md).
+
+---
+
+**Transparency**
+In the TRACE context, transparency means that a trust record has been submitted to an append-only log (SCITT) and can be independently audited by any party with access to the log. The `transparency` field holds the receipt URI. Required at Level 2.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -1,0 +1,34 @@
+# Attestation Platforms
+
+TRACE Level 1 trust records require a TEE-backed signing key and a hardware measurement in the `runtime` field. The following platforms are supported.
+
+| Platform | `runtime.platform` value | Measurement source |
+|----------|-------------------------|-------------------|
+| AMD SEV-SNP | `sev-snp` | Launch measurement (128-bit digest extended to sha256) |
+| Intel TDX | `tdx` | MRTD + RTMRs combined measurement |
+| NVIDIA H100 | `opaque` | GPU attestation report RIM hash |
+| TPM2 | `tpm2` | PCR bank quote (sha256 bank, PCRs 0–7) |
+
+For `software-only` (Level 0) records, no TEE is required and the `runtime.platform` value must be exactly `"software-only"`.
+
+## How platform verification works
+
+At Level 1, the cMCP runtime:
+
+1. Requests a fresh quote from the TEE firmware at session start.
+2. Submits the quote to the TRACE verifier endpoint, which checks it against the relevant RIM.
+3. Embeds the verified measurement in `runtime.measurement` and sets `appraisal.status` to `"affirming"`.
+4. Signs the completed record with the TEE-bound key.
+
+The signing key is generated inside the TEE and never leaves the enclave boundary. The `cnf.jwk` in the record carries only the public half.
+
+## Platform guides
+
+- [AMD SEV-SNP](amd-sev-snp.md) — setup, measurement format, launch policy
+- [Intel TDX](intel-tdx.md) — MRTD/RTMR layout, on-premises and cloud deployment
+- [NVIDIA H100](nvidia-h100.md) — GPU attestation, RIM URI format
+
+## Related
+
+- [Trust Levels](../trust-levels.md) — what Level 1 guarantees and when to use it
+- [Hardware Attestation Platforms tutorial](../tutorials/hardware-attestation-platforms.md) — end-to-end walkthrough

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,58 @@ pip install agentrust-trace
 python -m agentrust_trace keygen --out trace-key.pem
 ```
 
+## Emit a Trust Record (standalone)
+
+Use `sign_record()` to produce a Level 0 record without AGT or any other framework:
+
+```python
+import time, json
+from agentrust_trace import generate_key, sign_record
+
+key = generate_key()
+
+record = {
+    "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+    "iat": int(time.time()),
+    "subject": "spiffe://trust.example.org/agent/my-agent",
+    "model": {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-6",
+        "version": "20251001",
+    },
+    "runtime": {
+        "platform": "software-only",
+        "measurement": "sha256:" + "0" * 64,
+    },
+    "policy": {
+        "bundle_hash": "sha256:b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7"
+                       "f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+        "enforcement_mode": "enforce",
+    },
+    "data_class": "internal",
+    "build_provenance": {
+        "slsa_level": 1,
+        "digest": "sha256:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+                  "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
+    },
+    "appraisal": {
+        "status": "none",
+        "verifier": "https://verifier.example.org",
+    },
+    "transparency": "https://registry.agentrust.io/claim/placeholder",
+}
+
+signed = sign_record(record, key)
+
+with open("session.trace.json", "w") as f:
+    json.dump(signed, f, indent=2)
+```
+
+This produces a valid Level 0 record. For hardware-attested (Level 1+) records, use cMCP as the runtime — it handles TEE key generation and measurement automatically.
+
 ## Emit a Trust Record from AGT
+
+For agent frameworks using AGT, the `govern()` decorator emits records automatically:
 
 ```python
 from agentmesh.governance import govern, GovernanceConfig

--- a/docs/trust-levels.md
+++ b/docs/trust-levels.md
@@ -1,0 +1,114 @@
+# Trust Levels
+
+TRACE defines three trust levels. Each level adds a stronger guarantee about the origin and integrity of the trust record. Higher levels require additional infrastructure but enable stronger relying-party policies.
+
+## Summary
+
+| Level | Name | Key guarantee | Typical use |
+|-------|------|--------------|-------------|
+| 0 | Software-only | Record is structurally valid and Ed25519-signed | Development, CI, unit testing |
+| 1 | TEE attestation | Record is signed by a key that was generated inside a verified TEE | Staging, regulated production |
+| 2 | Transparency anchoring | Level 1 plus SCITT transparency log entry | Multi-tenant, cross-org audit chains |
+
+## Level 0 — Software-only
+
+Level 0 records are signed with an Ed25519 key held by the agent process. There is no hardware attestation step. The `runtime.platform` field must be `software-only`.
+
+**What it proves:** The record has not been tampered with since the agent process signed it. The signing key is trust-on-first-use.
+
+**What it does not prove:** The key was generated in a trusted execution environment. An attacker with access to the signing key can forge records.
+
+**Minimum required fields:**
+
+```json
+{
+  "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+  "iat": 1750000000,
+  "subject": "spiffe://trust.example.org/agent/my-agent",
+  "model": { "provider": "anthropic", "model_id": "claude-sonnet-4-6", "version": "20251001" },
+  "runtime": { "platform": "software-only", "measurement": "sha256:0000...0000" },
+  "policy": { "bundle_hash": "sha256:b2c3...", "enforcement_mode": "enforce" },
+  "data_class": "internal",
+  "build_provenance": { "slsa_level": 1, "digest": "sha256:e5f6..." },
+  "appraisal": { "status": "none", "verifier": "https://verifier.example.org" },
+  "transparency": "https://registry.agentrust.io/claim/placeholder",
+  "cnf": { "jwk": { "kty": "OKP", "crv": "Ed25519", "x": "<base64url>" } },
+  "signature": "<base64url>"
+}
+```
+
+All-zero measurement (`sha256:000...000`) is conventional for software-only development records. The `appraisal.status` of `"none"` is correct when no hardware verifier is in the path.
+
+---
+
+## Level 1 — TEE Attestation
+
+Level 1 requires that the signing key be generated inside a verified TEE (AMD SEV-SNP, Intel TDX, NVIDIA H100, or TPM2). The `runtime.platform` field must be one of these values, and `runtime.measurement` must be a non-zero hardware measurement (PCR hash, launch measurement, or equivalent).
+
+**What it proves:** The signing key was generated inside a hardware-isolated enclave whose firmware digest matches the `runtime.measurement`. An attacker who compromises the host OS cannot forge records without breaking the TEE isolation boundary.
+
+**What it does not prove:** The record was published to a public ledger. Audit chains cannot span organizational boundaries without a shared transparency anchor.
+
+**Additional required fields over Level 0:**
+
+| Field | Requirement |
+|-------|-------------|
+| `runtime.platform` | Must be `tpm2`, `sev-snp`, `tdx`, or `opaque` (not `software-only`) |
+| `runtime.measurement` | Non-zero `sha256:` or `sha384:` digest of the TEE launch state |
+| `appraisal.status` | Must be `affirming` (verifier has checked the TEE quote) |
+| `build_provenance.slsa_level` | Must be present (0–4) |
+| `build_provenance.digest` | Must be a valid `sha256:` digest |
+
+The cMCP runtime handles Level 1 record emission automatically when running in a supported TEE. See [Hardware Attestation Platforms](tutorials/hardware-attestation-platforms.md).
+
+---
+
+## Level 2 — Transparency Anchoring
+
+Level 2 adds a SCITT transparency log entry to a Level 1 record. The `transparency` field must be a resolvable HTTPS URI that returns a valid reference manifest from a SCITT-compatible log.
+
+**What it proves:** The record has been durably committed to an append-only transparency log that any party can query. This makes post-hoc audit possible without trusting either the agent or its operator.
+
+**What it does not prove:** That every field in the record is correct — only that the specific record at the URI has not been altered since it was logged.
+
+**Additional required fields over Level 1:**
+
+| Field | Requirement |
+|-------|-------------|
+| `transparency` | Resolvable `https://` URI to a SCITT receipt |
+
+The [SCITT reference implementation](https://github.com/microsoft/scitt-api-emulator) and the [agentrust SCITT registry](https://registry.agentrust.io) are both supported anchors.
+
+**Recommended flow:**
+
+```
+Agent signs Level 1 record
+        ↓
+Submit record to SCITT transparency log → get receipt URI
+        ↓
+Append transparency URI to record (does not invalidate signature)
+        ↓
+Distribute Level 2 record to relying party
+```
+
+The signature covers all fields except `signature` itself. Appending the `transparency` field after the initial signing step requires re-signing. The recommended pattern is to emit a Level 1 record, submit it for transparency, then emit a new Level 2 record with the receipt URI and a fresh signature.
+
+---
+
+## Choosing a level
+
+| If you are... | Use level |
+|---------------|-----------|
+| Building an agent locally or writing tests | 0 |
+| Running agents in production but within a single org | 1 |
+| Sharing records across organizational boundaries | 2 |
+| Meeting a regulated compliance requirement | 1 or 2 (check your framework) |
+
+Relying parties set the minimum acceptable level in their Cedar policy. Records that fail to meet the required level are rejected at the policy enforcement point before the agent is permitted to act.
+
+## Related
+
+- [Trust Levels in the test suite](https://tests.agentrust-io.com/levels)
+- [TRACE Specification — Section 4: Trust Levels](../spec/trace-v0.1.md)
+- [Hardware Attestation Platforms](tutorials/hardware-attestation-platforms.md)
+- [Glossary](glossary.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,8 +148,10 @@ nav:
   - Home: docs/index.md
   - Getting Started:
       - Quickstart: docs/quickstart.md
+      - Trust Levels: docs/trust-levels.md
       - Verification: docs/verification.md
       - Schema Reference: docs/schema.md
+      - Glossary: docs/glossary.md
   - Tutorials:
       - Sign your first trust record: docs/tutorials/signing-your-first-trust-record.md
       - Verify a trust record: docs/tutorials/verifying-a-trust-record.md
@@ -160,6 +162,7 @@ nav:
       - AGT: docs/integration/agt.md
       - cMCP: docs/integration/cmcp.md
   - Platforms:
+      - Overview: docs/platforms/index.md
       - AMD SEV-SNP: docs/platforms/amd-sev-snp.md
       - Intel TDX: docs/platforms/intel-tdx.md
       - NVIDIA H100: docs/platforms/nvidia-h100.md
@@ -172,6 +175,3 @@ nav:
       - Contributing: CONTRIBUTING.md
       - Governance: GOVERNANCE.md
       - Roadmap: ROADMAP.md
-
-extra_javascript:
-  - https://agentrust-io.com/supernav.js


### PR DESCRIPTION
## Summary

- **Trust Levels page** (`docs/trust-levels.md`): defines Level 0/1/2 in one place — what each level proves, what it does not prove, minimum required fields at each level, and a decision table for choosing a level. Closes the audit gap where these levels appeared throughout the docs but were never defined on a single page.
- **Glossary** (`docs/glossary.md`): defines Trust Record, Trust Level, Appraisal, Conformance, EAT, RATS, SCITT, cnf/JWK, RIM, SPIFFE, Transparency, GatewayClaim, JCS.
- **Platforms index** (`docs/platforms/index.md`): overview page for the Platforms nav section. Lists all four TEE platforms, their `runtime.platform` values, and explains how Level 1 verification works. Previously the Platforms nav had no overview entry.
- **Quickstart standalone path**: adds a `sign_record()` example before the AGT `govern()` example so the quickstart is usable without installing AGT.
- **Remove supernav.js** from `mkdocs.yml` (missed in the earlier theme-alignment PR).

## Test plan

- [ ] MkDocs builds without warnings (`mkdocs build --strict`)
- [ ] All three new pages appear in the nav
- [ ] Platforms nav has Overview entry above AMD SEV-SNP
- [ ] Trust Levels page is under Getting Started
- [ ] Glossary page is under Getting Started
- [ ] Quickstart standalone section works before AGT section