### PR TITLE
docs: add on-premises section to intel-tdx, add Related footer to cmcp integration

### DIFF
--- a/docs/integration/cmcp.md
+++ b/docs/integration/cmcp.md
@@ -136,3 +136,13 @@ trace:
 cMCP embeds AGT. The Cedar policy engine, SPIFFE identity, and Merkle audit chain are AGT. cMCP adds the TEE boundary, hardware key generation, and Level 2 TRACE emission.
 
 When cMCP emits a Level 2 record for a session, it supersedes any Level 0 record AGT might have emitted for the same session. The two records are linked by shared `subject` and `tool_transcript.hash`.
+
+## Related
+
+| What | Where |
+|------|-------|
+| Trust level guarantees | [Trust Levels](../trust-levels.md) |
+| Hardware attestation platforms | [Platforms overview](../platforms/index.md) |
+| Step-by-step cMCP integration tutorial | [Integrating with cMCP](../tutorials/integrating-with-cmcp.md) |
+| cMCP source and deployment | [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) |
+| AGT integration | [Integration: AGT](agt.md) |

--- a/docs/platforms/intel-tdx.md
+++ b/docs/platforms/intel-tdx.md
@@ -51,6 +51,18 @@ The verifier:
 | Azure | DCesv5, ECesv5 (Intel TDX preview) |
 | On-premises | Intel Xeon Scalable 4th Gen (Sapphire Rapids) and newer |
 
+## On-premises deployment
+
+For on-premises Intel TDX (e.g., Supermicro SYS-121H with Xeon Scalable 4th Gen), the cMCP gateway runs as a TD and uses Intel's PCCS (Platform Certificate Caching Service) or the Intel Trust Authority for attestation verification. No cloud dependency is required — deploy PCCS locally to air-gap the attestation path. See [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) for the Helm chart.
+
+```yaml
+# cmcp.yaml (on-premises TDX)
+attestation:
+  platform: intel-tdx
+  pccs_url: https://pccs.internal.example.org:8081  # your local PCCS
+  rim_cache: /var/cache/trace/rims
+```
+
 ## Example record
 
 See [`examples/intel-tdx.json`](https://github.com/agentrust-io/trace-spec/blob/main/examples/intel-tdx.json).


### PR DESCRIPTION
## Summary

- **intel-tdx.md**: adds an On-premises deployment section matching the equivalent section on amd-sev-snp.md. Covers Xeon Scalable 4th Gen support and local PCCS configuration with a minimal cmcp.yaml example.
- **integration/cmcp.md**: adds a Related table footer linking to Trust Levels, Platforms overview, cMCP integration tutorial, cMCP GitHub repo, and AGT integration page. The page previously ended mid-paragraph with no navigation out.

## Test plan

- [ ] MkDocs builds without warnings
- [ ] intel-tdx.md On-premises section renders correctly
- [ ] cmcp.md Related table renders correctly with all links valid