### PR TITLE
fix: remove commercial-program language and soften founding-member claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Initial public draft. Announced at Confidential Computing Summit, San Francisco.
 
 ### Open questions
 
-Seven open questions requiring founding-member input before v0.2 are documented in §7 of the spec.
+Seven open questions requiring community input before v0.2 are documented in §7 of the spec.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,4 +45,4 @@ Driven by founding-member feedback and open questions from §7 of the spec.
 
 ## Influencing the roadmap
 
-Open a GitHub issue with the `spec` or `roadmap` label. Founding-member and vendor feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope.
+Open a GitHub issue with the `spec` or `roadmap` label. Contributor and community feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope.

--- a/spec/trace-v0.1.md
+++ b/spec/trace-v0.1.md
@@ -320,7 +320,9 @@ the reference implementation at the MCP tool-call boundary.
 
 Other standards bodies participate as technical-liaison partners: OpenSSF (SLSA stewardship), CNCF (SPIFFE/SPIRE stewardship), IETF (RATS, EAT, SCITT, EAR working groups).
 
-### 6.2 Invited founding members
+### 6.2 Target contributing organizations
+
+The following organizations have been identified as natural contributors to this standard based on their work in confidential computing, AI safety, and open governance. Formal participation is subject to each organization's independent decision.
 
 Anthropic, NVIDIA, Intel, AMD, Microsoft, Google, Linux Foundation, Confidential Computing Consortium, ATRC, TII, AI71.
 


### PR DESCRIPTION
## Summary

- **spec/trace-v0.1.md §6.2**: Renames "Invited founding members" to "Target contributing organizations" and adds a clarifying sentence that listing an organization does not imply acceptance. The previous heading implied Anthropic, NVIDIA, Intel, AMD, Microsoft, Google et al. had been formally invited and potentially accepted — a false-endorsement risk before those organizations have issued any statements.
- **ROADMAP.md**: "Founding-member and vendor feedback" → "Contributor and community feedback"
- **CHANGELOG.md**: "founding-member input" → "community input"

## Test plan

- [ ] CI passes
- [ ] §6.2 section heading no longer says "Invited"
- [ ] Disclaimer sentence renders correctly in MkDocs