### PR TITLE
fix(models): block private key parameters in cnf.jwk

### DIFF
--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _DIGEST_RE = r"^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$"
+_JWK_PRIVATE_PARAMS = frozenset({"d", "p", "q", "dp", "dq", "qi", "k"})
 
 DigestStr = Annotated[str, Field(pattern=_DIGEST_RE)]
 
@@ -97,7 +98,14 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
+            extra = self.model_extra or {}
+        private = _JWK_PRIVATE_PARAMS & extra.keys()
+        if private:
+            raise ValueError(
+                f"cnf.jwk must not contain private key parameters: {sorted(private)}"
+            )
         return self
+        
 
 
 class ConfirmationKey(BaseModel):

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -104,8 +104,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"cnf.jwk must not contain private key parameters: {sorted(private)}"
             )
-        return self
-        
+        return self    
 
 
 class ConfirmationKey(BaseModel):

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -99,7 +99,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
-            extra = dict(self.model_extra) if self.model_extra else {}
+        extra = dict(self.model_extra) if self.model_extra else {}
         private = _JWK_PRIVATE_PARAMS & extra.keys()
         if private:
             raise ValueError(

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -98,7 +98,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
-            extra = self.model_extra or {}
+            extra: dict[str, object] = self.model_extra or {}
         private = _JWK_PRIVATE_PARAMS & extra.keys()
         if private:
             raise ValueError(

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -104,7 +104,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"cnf.jwk must not contain private key parameters: {sorted(private)}"
             )
-        return self    
+        return self
 
 
 class ConfirmationKey(BaseModel):

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-from typing import Annotated, Literal,cast
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -99,7 +99,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
-            extra = cast(dict[str, object], self.model_extra or {})
+            extra = self.model_extra or {}  # type: ignore[has-type]
         private = _JWK_PRIVATE_PARAMS & extra.keys()
         if private:
             raise ValueError(

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
+
+from typing import Annotated, Literal,cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -98,7 +99,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
-            extra: dict[str, object] = self.model_extra or {}
+            extra = cast(dict[str, object], self.model_extra or {})
         private = _JWK_PRIVATE_PARAMS & extra.keys()
         if private:
             raise ValueError(

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -99,7 +99,7 @@ class JWK(BaseModel):
             raise ValueError(
                 f"jwk with kty={self.kty!r} must carry key material: missing {', '.join(missing)}"
             )
-            extra = self.model_extra or {}  # type: ignore[has-type]
+            extra = dict(self.model_extra) if self.model_extra else {}
         private = _JWK_PRIVATE_PARAMS & extra.keys()
         if private:
             raise ValueError(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,3 +150,10 @@ def test_okp_jwk_with_key_material_accepted() -> None:
     }
     record = TrustRecord.model_validate(data)
     assert record.cnf.jwk.x is not None
+
+def test_jwk_private_key_d_rejected() -> None:
+    """cnf.jwk must not contain private key parameter d (RFC 8747 §3)."""
+    data = _load("intel-tdx.json")
+    data["cnf"]["jwk"]["d"] = "PRIVATE_KEY_MATERIAL"
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)


### PR DESCRIPTION
## What this changes

JWK._require_key_material only enforced that public key fields were present — it never blocked private key parameters (d, p, q, dp, dq, qi, k) from being stored in cnf.jwk. With extra="allow" on the model, a record carrying private key material passed model_validate() silently. Added _JWK_PRIVATE_PARAMS constant and a check in the validator that raises if any private parameter is present. Added one regression test.

## Type of change

- [ ] Editorial (typo, link fix, clarification — no normative effect)
- [x ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

 §3.2.1 Signing and key management

## Checklist

- [ ] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)
