### PR TITLE
docs: standardize OPAQUE brand capitalization

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,4 +8,4 @@ To add your organization, open a pull request editing this file.
 
 | Organization | Usage |
 |---|---|
-| Opaque Systems | Founding contributor — developed the initial specification, reference implementation, and TRACE registry infrastructure |
+| OPAQUE Systems | Founding contributor — developed the initial specification, reference implementation, and TRACE registry infrastructure |

--- a/docs/platforms/amd-sev-snp.md
+++ b/docs/platforms/amd-sev-snp.md
@@ -58,7 +58,7 @@ agentrust-trace verify-hardware session.trace.json \
 
 ## On-premises deployment
 
-For on-premises SEV-SNP (e.g., Supermicro H13 with EPYC Genoa), Opaque ships the verifier with the platform — same cryptographic guarantees as cloud deployments, no cloud attestation service dependency. See [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) for the Helm chart.
+For on-premises SEV-SNP (e.g., Supermicro H13 with EPYC Genoa), OPAQUE ships the verifier with the platform — same cryptographic guarantees as cloud deployments, no cloud attestation service dependency. See [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) for the Helm chart.
 
 ## Example record
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ repo_url: https://github.com/agentrust-io/trace-spec
 repo_name: agentrust-io/trace-spec
 edit_uri: edit/main/
 docs_dir: .
-copyright: "© 2026 Opaque Systems — CC BY 4.0"
+copyright: "© 2026 OPAQUE Systems — CC BY 4.0"
 
 exclude_docs: |
   .github/


### PR DESCRIPTION
Standardizes the OPAQUE brand name to all-caps in human-facing prose only: the ADOPTERS contributor table, the AMD SEV-SNP platform doc, and the site copyright footer in mkdocs.yml. Lowercase `opaque` code/provider keys (e.g. the `runtime.platform` value and the platforms table) are intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)