### PR TITLE
docs: correct brand name to AgenTrust

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 TRACE
-Copyright 2026 AgentTrust Authors
+Copyright 2026 AgenTrust Authors
 
-This product includes software developed by the AgentTrust project
+This product includes software developed by the AgenTrust project
 (https://github.com/agentrust-io/trace-spec).
 
 ---


### PR DESCRIPTION
Brand display name corrected from AgentTrust to AgenTrust (single T, capital A and T). No code identifiers, slugs, emails, or URLs were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)