### PR TITLE
ci: pin gh-action-pypi-publish to commit SHA (v1.14.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,4 +42,4 @@ jobs:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
Pins the PyPI publish action from the mutable `@release/v1` tag to commit SHA `cef2210` (v1.14.0), matching cmcp/ca2a/agent-manifest. OIDC trusted publishing and PEP 740 attestations are unchanged (on by default in v1.11+). Last action-pinning item from the agentrust-io supply-chain audit (catalog Appendix B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)