### PR TITLE
docs: add PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,9 @@
+# Privacy
+
+agentrust-trace (the TRACE SDK) collects and transmits no personal data.
+
+It runs locally as a Python library. It processes only the inputs you give it, entirely on your machine, and sends no telemetry, analytics, or usage data to agentrust-io, OPAQUE, or any third party. There is no account, login, or tracking, and no cookies or background network calls.
+
+Any network activity is user-initiated: anchoring a record to a SCITT transparency service happens only when you explicitly call it, to the endpoint you configure.
+
+Uninstalling removes it completely. Questions or corrections: https://github.com/agentrust-io/trace-spec/issues


### PR DESCRIPTION
Adds a factual PRIVACY.md: this project runs locally and collects/transmits no personal data. Provides a truthful privacy URL for directory/marketplace listings.