### PR TITLE
feat: add azure-cvm-sev-snp platform (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
+
+- **`azure-cvm-sev-snp` platform** — Azure confidential VMs run AMD SEV-SNP behind a Hyper-V paravisor: the SNP report is read from the vTPM (the guest does not control `REPORT_DATA`), so the runtime binding rides a vTPM AK-signed quote rather than the SNP `report_data`. Given its own `runtime.platform` value (distinct from `amd-sev-snp`) so a consumer keying on `runtime.platform` knows the root of trust is vTPM-rooted, not direct-silicon. Added to the `RuntimeInfo` model and the JSON schema enum. Hardware-validated on a live Azure SEV-SNP VM via cMCP.
 
 - `delegation` (optional object): the A2A profile delegation-link block, carrying `parent_record_hash` (digest of the parent hop's Trust Record) and `credential_id` (the delegation credential this hop acted under). A chain of records linked this way forms an offline-verifiable delegation DAG. Backward-compatible: existing records without `delegation` remain valid. This is a MINOR (additive) change and the foundation of the forthcoming A2A profile; A2A is now stable at v1.x, clearing the prior blocker.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -39,7 +39,7 @@ Binds the execution environment. Platform-specific fields vary by TEE type.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `platform` | string | **yes** | One of: `amd-sev-snp`, `intel-tdx`, `nvidia-h100`, `nvidia-blackwell`, `tpm-2.0`, `software-only` |
+| `platform` | string | **yes** | One of: `amd-sev-snp`, `azure-cvm-sev-snp`, `intel-tdx`, `nvidia-h100`, `nvidia-blackwell`, `tpm-2.0`, `software-only` |
 | `measurement` | string | **yes** | Hardware measurement hash (`sha384:` for SEV-SNP/TDX, `sha256:` for TPM) |
 | `rim_uri` | string | no | Reference Integrity Manifest URI for hardware verification |
 | `firmware_version` | string | no | TEE firmware version |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentrust-trace"
-version = "0.3.0"
+version = "0.4.0"
 description = "TRACE v0.1 — hardware-attested governance records for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -73,6 +73,7 @@
           "enum": [
             "intel-tdx",
             "amd-sev-snp",
+            "azure-cvm-sev-snp",
             "nvidia-h100",
             "nvidia-blackwell",
             "aws-nitro",

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -25,6 +25,12 @@ class RuntimeInfo(BaseModel):
     platform: Literal[
         "intel-tdx",
         "amd-sev-snp",
+        # Azure confidential VM: AMD SEV-SNP behind a Hyper-V paravisor. The SNP
+        # report is read from the vTPM (the guest does not control REPORT_DATA),
+        # so the runtime binding rides a vTPM AK-signed quote rather than the SNP
+        # report_data. Distinct from amd-sev-snp so a consumer keying on
+        # runtime.platform knows the binding is vTPM-rooted, not direct-silicon.
+        "azure-cvm-sev-snp",
         "nvidia-h100",
         "nvidia-blackwell",
         "aws-nitro",

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -73,6 +73,7 @@
           "enum": [
             "intel-tdx",
             "amd-sev-snp",
+            "azure-cvm-sev-snp",
             "nvidia-h100",
             "nvidia-blackwell",
             "aws-nitro",


### PR DESCRIPTION
Adds a distinct `azure-cvm-sev-snp` value to the `RuntimeInfo` platform Literal and the JSON schema enum, releasing as **v0.4.0**.

## Why
Azure confidential VMs run AMD SEV-SNP behind a Hyper-V paravisor. The SNP report is read from the vTPM and the guest does **not** control `REPORT_DATA` (the paravisor binds the vTPM AK there), so the runtime binding rides a vTPM AK-signed quote rather than the SNP `report_data`. Giving it its own `runtime.platform` value (distinct from `amd-sev-snp`) means a consumer keying on `runtime.platform` knows the root of trust is **vTPM-rooted, not direct-silicon**.

This was hardware-validated on a live Azure SEV-SNP VM during the cMCP work (agentrust-io/cmcp#407), which previously mapped Azure onto `amd-sev-snp` to avoid this release. With v0.4.0 published, cMCP switches to the distinct value.

## Changes
- `RuntimeInfo.platform` Literal + both JSON schema enums (`src/agentrust_trace/schema/trace-v0.1.json`, `schema/trace-claim.json`)
- docs/schema.md platform list; CHANGELOG; version 0.3.0 → 0.4.0

Backward compatible (additive enum value). 89 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)