### PR TITLE
fix(spec): move the registry host in the v0.2 examples

### DIFF
--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -166,7 +166,7 @@ Each field is independently verifiable. Sub-records (e.g., per-tool-call transcr
   "tool_transcript": {
     "hash": "sha256:d4e5f6a7b8c9d0e1...",
     "call_count": 3,
-    "transcript_uri": "https://registry.agentrust.io/transcript/..."
+    "transcript_uri": "https://registry.agentrust-io.com/transcript/..."
   },
   "build_provenance": {
     "slsa_level": 2,
@@ -178,7 +178,7 @@ Each field is independently verifiable. Sub-records (e.g., per-tool-call transcr
     "verifier": "https://trust-authority.example.org",
     "policy_ref": "https://trust-authority.example.org/policy/agent-v1"
   },
-  "transparency": "https://registry.agentrust.io/claim/trace-2026-06-23T09:15:42Z-f2a8d1",
+  "transparency": "https://registry.agentrust-io.com/claim/trace-2026-06-23T09:15:42Z-f2a8d1",
   "cnf": {
     "jwk": {
       "kty": "EC",


### PR DESCRIPTION
Follow-up to #107, catching my own miss.

`spec/trace-v0.2.md` was created by copying v0.1 and correcting the profile URI. That left two example URIs still on `registry.agentrust.io`:

- `"transcript_uri": "https://registry.agentrust.io/transcript/..."`
- `"transparency": "https://registry.agentrust.io/claim/..."`

A spec whose stated purpose is correcting one identifier on a domain we do not control, while printing two more of them in its own examples, is not much of a correction.

The two remaining `agentrust.io` mentions are deliberate: they quote the v0.1 identifier in the "Changes from v0.1" section, which is the one place it belongs.