### PR TITLE
fix(models): transparency is optional below Level 2

### DIFF
--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -157,7 +157,20 @@ class TrustRecord(BaseModel):
     delegation: Delegation | None = None
     build_provenance: BuildProvenance
     appraisal: Appraisal
-    transparency: Annotated[str, Field(min_length=1)]
+    transparency: Annotated[str, Field(min_length=1)] | None = None
+    """SCITT receipt URI resolving to the inclusion proof on the transparency log.
+
+    Optional in the model, and required by conformance at **Level 2**, where
+    `TR-ANC` runs (`agentrust-trace-tests`). A Level 0 or Level 1 record is not
+    anchored, so it has no receipt to name, and the model must be able to
+    represent that. Enforcing a non-empty value here regardless of level made the
+    model stricter than both the conformance suite and `schema/trace-claim.json`,
+    which sets no minimum length.
+
+    Use `None` for an unanchored record rather than an empty string: `""` is not a
+    URI, and a field that looks populated but resolves to nothing is worse than an
+    absent one.
+    """
     cnf: ConfirmationKey
     signature: Annotated[str, Field(pattern=r"^[A-Za-z0-9_-]+$")] | None = None
     """Optional embedded signature (base64url, no padding) by the cnf key over the

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -204,3 +204,28 @@ def test_delegation_extra_field_rejected() -> None:
     }
     with pytest.raises(ValidationError):
         TrustRecord.model_validate(data)
+
+
+def test_transparency_optional_for_unanchored_records() -> None:
+    """A Level 0/1 record has no receipt to name, so its absence must be representable.
+
+    Conformance requires `transparency` at Level 2, where TR-ANC runs. Requiring a
+    non-empty value in the model regardless of level made it stricter than both the
+    conformance suite and schema/trace-claim.json, and left an unanchored record
+    unrepresentable.
+    """
+    data = _load("intel-tdx.json")
+    data.pop("transparency", None)
+    assert TrustRecord.model_validate(data).transparency is None
+
+    data = _load("intel-tdx.json")
+    data["transparency"] = None
+    assert TrustRecord.model_validate(data).transparency is None
+
+
+def test_transparency_rejects_empty_string() -> None:
+    """`None` means unanchored; `""` is a URI-shaped lie and stays rejected."""
+    data = _load("intel-tdx.json")
+    data["transparency"] = ""
+    with pytest.raises(ValidationError):
+        TrustRecord.model_validate(data)


### PR DESCRIPTION
Found while fixing microsoft/agent-governance-toolkit#3454, which could not construct a Trust Record at all.

## Three artifacts disagreed, and the model was the outlier

| Artifact | On `transparency` |
|---|---|
| `schema/trace-claim.json` | required, **no** `minLength`, so `""` passes |
| `agentrust-trace-tests` runner | `TR-ANC` runs at **Level 2 only**; its message reads "transparency field is required at Level 2" |
| `models.py` | `min_length=1` **unconditionally** |

A Level 0 or Level 1 record is not anchored to a transparency log, so it has no receipt URI to name, and the model left that state unrepresentable. AGT hit it directly: its documented Phase 1 design emits an unanchored record, and after moving to 0.5.0 every emit raised `ValidationError: transparency  String should have at least 1 character`.

## The change

`transparency: Annotated[str, Field(min_length=1)] | None = None`

`None` means unanchored. **Empty string stays rejected**, deliberately: `""` is not a URI, and a field that looks populated but resolves to nothing is worse in a trust record than an absent one. That distinction is what the second test pins.

The layering this restores is the one the suite already assumes: the model expresses structure, the conformance suite enforces level requirements. `signature` is already optional in the model for the same reason, with the spec requiring the binding.

## Verification

91 pass. Confirmed against a real record that `None` and an omitted field both validate while `""` raises, then confirmed AGT's own emitters produce a valid record against this build (156 governance tests, including the four that were failing).

Needs a 0.5.1 release: AGT pins `>=0.5.0,<0.6.0` and cannot go green until this is on PyPI.