### PR TITLE
fix(verify): enforce key revocation at verification time (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Added
+
+- **`verify_record(..., revocation=...)` enforces key revocation at verification time (#76).** §3.2.1 has always required that "Verifiers MUST consult current revocation status at verification time", but `verify_record()` checked only signature and freshness, so a record signed by a revoked or compromised key kept verifying. The new `revocation` parameter accepts either a container of revoked key identifiers or a callable performing a live CRL, status-endpoint, or SCITT lookup. A listed key is rejected, and a store that cannot answer is also rejected: an unavailable revocation source is not evidence that a key is unrevoked.
+
+  Keys are identified by RFC 7638 JWK Thumbprint or `kid`. The check reads the *trusted* key rather than `record["cnf"]["jwk"]`, which is attacker-controlled until the signature verifies.
+
+  Additive and backward compatible: `revocation` defaults to `None`, which leaves verification purely offline and unchanged. That mode cannot prove non-revocation, now stated in `LIMITATIONS.md` and `docs/verification.md`. No normative text, schema, or record field changed.
+
+- **`jwk_thumbprint(jwk)`**: RFC 7638 JWK Thumbprint (RFC 8037 §2 for OKP), exported so callers can key a revocation list on the same identifier the verifier derives.
+
 ## [0.5.1] — 2026-07-28
 
 ### Fixed

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -25,6 +25,9 @@ Hardware attestation proves the TRACE signing key and policy engine were measure
 **Revocation of the signing key after issuance**
 If the TRACE signing key is compromised after records are issued, existing records remain cryptographically valid. Key monitoring, rapid revocation, and transparency log integration are the required controls — TRACE provides the anchoring mechanism but cannot detect compromise itself.
 
+**Pure offline verification cannot prove non-revocation**
+Signature validity is permanent; trust is not. Nothing inside a record can retract the key that signed it, so a record signed by a since-revoked key verifies offline forever. Spec §3.2.1 accordingly requires verifiers to consult current revocation status at verification time, which is by definition an online step. `verify_record()` takes a `revocation` store, either a container of revoked identifiers or a callable performing a live CRL, status-endpoint, or SCITT lookup. It rejects a listed key, and fails closed when the store cannot answer. Without that store, verification is offline and its result means "this record was validly signed by this key", not "this key is still trusted".
+
 ## What Level 0 does not provide
 
 Level 0 (software-only signing) is suitable for development, internal audit trails, and staging environments. It does not satisfy:

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,6 +1,6 @@
 # Verification Protocol
 
-TRACE Trust Records are independently verifiable offline — no call to the issuer, no API, no trust-me-the-log-is-real.
+TRACE Trust Records are independently verifiable offline — no call to the issuer, no API, no trust-me-the-log-is-real. The one thing offline verification cannot establish is that the signing key is *still* trusted; see [Checking revocation status](#checking-revocation-status).
 
 ## Five-step verification
 
@@ -69,6 +69,40 @@ status = record["appraisal"]["status"]
 assert status == "affirming", f"Appraisal failed: {status}"
 print(f"✓ Appraisal: {status}")
 ```
+
+## Checking revocation status
+
+The five steps above are self-contained: given the record and a trusted key, they run with no network. That is the property TRACE is built for, and it has exactly one gap. A signature is valid forever, so a record signed by a key that was later compromised and revoked still passes every offline step. Nothing inside the record can withdraw the key that signed it.
+
+[§3.2.1 of the spec](../spec/trace-v0.2.md) therefore requires the online half: *"Verifiers MUST consult current revocation status at verification time."*
+
+`verify_record()` takes a `revocation` store to do this. Pass a container of revoked identifiers, or a callable that performs a live lookup:
+
+```python
+from agentrust_trace import jwk_thumbprint, verify_record
+
+# A revocation list the caller already holds.
+verify_record(record, trusted_jwk, revocation={"kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"})
+
+# Or a live CRL / status endpoint / SCITT lookup.
+def is_revoked(key_id: str) -> bool:
+    return httpx.get(f"https://crl.example.org/keys/{key_id}").json()["revoked"]
+
+verify_record(record, trusted_jwk, revocation=is_revoked)
+```
+
+Keys are identified by their RFC 7638 JWK Thumbprint (`jwk_thumbprint(jwk)`) or by `kid`; a match on either rejects the record. The check reads the **trusted** key, not `record["cnf"]["jwk"]`: the embedded key is attacker-controlled until the signature verifies, so keying the lookup on it would let a revoked issuer present an unlisted thumbprint.
+
+Both failure modes raise `ValueError`, including a store that cannot answer:
+
+| Outcome | Result |
+|---|---|
+| Key listed as revoked | Rejected |
+| Store raises (endpoint down, timeout) | Rejected; an unavailable source is not evidence a key is unrevoked |
+| Key absent from the store | Verification continues |
+| No `revocation` passed | Check skipped; verification is offline and proves nothing about current key status |
+
+The last row is the honest default. Omitting the store is a legitimate mode, since air-gapped audit of archived records has no other option, but the result means "this record was validly signed by this key", not "this key is still trusted".
 
 ## Verifying hardware-rooted records
 
@@ -151,6 +185,7 @@ external outcome claim.
 
 Verification proves *what happened during the recorded session* under the stated policy, in the stated environment. It does not:
 
+- Prove the signing key is still trusted; offline verification cannot prove non-revocation, so pass a `revocation` store
 - Prove the agent's internal reasoning was sound
 - Prove the policy was correctly authored for the intent
 - Prove tool call *contents* (only the hash of the transcript is in v0.1)

--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -14,7 +14,9 @@ from agentrust_trace.models import (
     TrustRecord,
 )
 from agentrust_trace.sign import (
+    RevocationStore,
     generate_key,
+    jwk_thumbprint,
     key_to_jwk,
     load_key,
     load_signing_key,
@@ -43,10 +45,12 @@ __all__ = [
     "RuntimeInfo",
     "ToolTranscript",
     "TrustRecord",
+    "RevocationStore",
     "SCHEMA",
     "iter_errors",
     "validate_json",
     "generate_key",
+    "jwk_thumbprint",
     "key_to_jwk",
     "load_key",
     "load_signing_key",

--- a/src/agentrust_trace/sign.py
+++ b/src/agentrust_trace/sign.py
@@ -10,13 +10,29 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 import os
 import warnings
-from typing import Any
+from collections.abc import Callable, Container
+from typing import Any, TypeAlias
 
 import rfc8785
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+RevocationStore: TypeAlias = Container[str] | Callable[[str], bool]
+"""Caller-supplied source of key revocation status, consulted by ``verify_record``.
+
+Either form is accepted:
+
+- a container of revoked key identifiers (``set``, ``frozenset``, ``list``, or any
+  object supporting ``in``), for a revocation list the caller already holds; or
+- a callable taking one key identifier and returning ``True`` when that key is
+  revoked, for a live CRL, OCSP-style status endpoint, or SCITT log lookup.
+
+An identifier is either the RFC 7638 JWK Thumbprint of the trusted key (see
+``jwk_thumbprint``) or its ``kid``; a match on either revokes the key.
+"""
 
 
 def generate_key() -> Ed25519PrivateKey:
@@ -47,15 +63,120 @@ def load_signing_key() -> Ed25519PrivateKey:
     return generate_key()
 
 
+def _okp_jwk(raw_public_bytes: bytes) -> dict[str, str]:
+    """Return the OKP / Ed25519 public JWK for raw 32-byte public key material."""
+    x = base64.urlsafe_b64encode(raw_public_bytes).rstrip(b"=").decode()
+    return {"kty": "OKP", "crv": "Ed25519", "x": x}
+
+
 def key_to_jwk(key: Ed25519PrivateKey) -> dict[str, str]:
     """Return the public JWK dict for *key* (OKP / Ed25519)."""
-    pub = key.public_key()
-    raw = pub.public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw,
+    return _okp_jwk(
+        key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
     )
-    x = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
-    return {"kty": "OKP", "crv": "Ed25519", "x": x}
+
+
+def _jwk_from_public_key(pub: Any) -> dict[str, str]:
+    """Return the public JWK for an ``Ed25519PublicKey``.
+
+    Needed only by the revocation check, which is keyed on the trusted key's
+    identifiers. Callers may pass a key object rather than a JWK, so the JWK is
+    reconstructed here rather than requiring one at the call site.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    if not isinstance(pub, Ed25519PublicKey):
+        raise ValueError(
+            "revocation checking needs the trusted key as an Ed25519PublicKey or a JWK "
+            f"dict, so its identifiers can be derived; got {type(pub).__name__}"
+        )
+    return _okp_jwk(
+        pub.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+# RFC 7638 §3.2 (extended for OKP by RFC 8037 §2): the required members of each key
+# type, which are the only ones hashed into a thumbprint. RFC 7638 also defines the
+# member set for "oct"; it is omitted deliberately, because an oct JWK carries a
+# symmetric secret and every key this module handles is a public confirmation key.
+_THUMBPRINT_MEMBERS: dict[str, tuple[str, ...]] = {
+    "EC": ("crv", "kty", "x", "y"),
+    "OKP": ("crv", "kty", "x"),
+    "RSA": ("e", "kty", "n"),
+}
+
+
+def jwk_thumbprint(jwk: dict[str, Any]) -> str:
+    """Return the RFC 7638 JWK Thumbprint of *jwk*: base64url SHA-256, no padding.
+
+    The thumbprint is computed over only the required members for the key type, in
+    lexicographic order with no whitespace, so it is stable across JWKs that differ
+    in optional members such as ``kid``, ``alg``, or ``use``. That makes it the
+    identifier a revocation list can be keyed on when the issuer publishes no ``kid``.
+
+    Member names are ASCII, so the RFC 8785 (JCS) serialization used here is
+    byte-identical to the code-point ordering RFC 7638 §3.3 specifies.
+
+    Raises ``ValueError`` for an unknown ``kty`` or a missing required member.
+    """
+    kty = jwk.get("kty")
+    if not isinstance(kty, str) or kty not in _THUMBPRINT_MEMBERS:
+        raise ValueError(
+            f"cannot compute a JWK thumbprint for kty {kty!r}; "
+            f"expected one of {sorted(_THUMBPRINT_MEMBERS)}"
+        )
+
+    members: dict[str, Any] = {}
+    for name in _THUMBPRINT_MEMBERS[kty]:
+        value = jwk.get(name)
+        if not isinstance(value, str) or not value:
+            raise ValueError(
+                f"jwk with kty={kty!r} is missing required thumbprint member {name!r}"
+            )
+        members[name] = value
+
+    return base64.urlsafe_b64encode(
+        hashlib.sha256(_canonical_bytes(members)).digest()
+    ).rstrip(b"=").decode()
+
+
+def _key_identifiers(jwk: dict[str, Any]) -> list[str]:
+    """Return the identifiers a revocation store may list this key under."""
+    identifiers = [jwk_thumbprint(jwk)]
+    kid = jwk.get("kid")
+    if isinstance(kid, str) and kid and kid not in identifiers:
+        identifiers.append(kid)
+    return identifiers
+
+
+def _check_not_revoked(jwk: dict[str, Any], revocation: RevocationStore) -> None:
+    """Raise ``ValueError`` if *jwk* is revoked, or if its status cannot be determined.
+
+    Both outcomes fail closed. An unreachable revocation source is not evidence
+    that a key is unrevoked, so a store that raises is treated as a rejection
+    rather than passed over.
+    """
+    for identifier in _key_identifiers(jwk):
+        try:
+            revoked = revocation(identifier) if callable(revocation) else identifier in revocation
+        except Exception as exc:
+            raise ValueError(
+                f"revocation status for key {identifier!r} could not be determined: {exc}. "
+                "Verification fails closed: an unavailable revocation source is not "
+                "evidence that the key is unrevoked."
+            ) from exc
+        if revoked:
+            raise ValueError(
+                f"signing key is revoked (listed as {identifier!r}); the record is rejected. "
+                "A signature made by a revoked key stays cryptographically valid, so the "
+                "verifier is the only place this can be caught."
+            )
 
 
 def _canonical_bytes(d: dict[str, Any]) -> bytes:
@@ -136,6 +257,7 @@ def verify_record(
     allow_embedded_key: bool = False,
     max_age_seconds: int | None = 86400,
     expected_nonce: str | None = None,
+    revocation: RevocationStore | None = None,
 ) -> None:
     """Verify an Ed25519 signature on a signed TRACE Trust Record.
 
@@ -144,8 +266,8 @@ def verify_record(
 
     Raises ``InvalidSignature`` if the signature does not verify, and ``ValueError``
     for every other rejection (no signature, no trusted key, malformed input,
-    unsupported JWK type, stale record, or nonce mismatch). Returns ``None`` on
-    success. All checks fail closed.
+    unsupported JWK type, stale record, nonce mismatch, or revoked key). Returns
+    ``None`` on success. All checks fail closed.
 
     Trust anchoring (fail closed):
         Without a trusted key, the record cannot vouch for itself, so verification
@@ -159,6 +281,19 @@ def verify_record(
         ``expected_nonce`` is given, it is compared in constant time against
         ``record["runtime"]["nonce"]``. A stale record or nonce mismatch raises
         ``ValueError``.
+
+    Revocation (fail closed):
+        ``spec/trace-v0.2.md`` §3.2.1 requires a verifier to consult current
+        revocation status at verification time. Pass a ``revocation`` store, either
+        a container of revoked key identifiers or a callable performing a live
+        CRL/status/SCITT lookup. The trusted key is rejected if it is listed, or if
+        the store cannot answer. Identifiers are the key's RFC 7638 thumbprint
+        (``jwk_thumbprint``) and its ``kid``.
+
+        ``revocation=None`` (the default) skips the check and keeps verification
+        purely offline. Offline verification cannot prove non-revocation: a
+        signature made by a compromised key stays cryptographically valid forever,
+        and nothing inside the record can retract it. See ``LIMITATIONS.md``.
     """
     import time
     from hmac import compare_digest
@@ -197,6 +332,23 @@ def verify_record(
         pub = _pubkey_from_jwk(public_key_or_jwk)
     else:
         pub = public_key_or_jwk
+
+    # Revocation: signature validity is permanent, trust is not. A key compromised
+    # after issuance still produces records that verify, so the only place the
+    # withdrawal of trust can be applied is here, at verification time.
+    #
+    # The check is keyed on the TRUSTED key, never on record["cnf"]["jwk"]: cnf.jwk
+    # is attacker-controlled until the signature verifies, so keying on it would let
+    # a revoked issuer present an unlisted thumbprint and pass. With
+    # allow_embedded_key=True the two are the same object, and that path is already
+    # documented as proving internal consistency only.
+    if revocation is not None:
+        trusted_jwk = (
+            public_key_or_jwk
+            if isinstance(public_key_or_jwk, dict)
+            else _jwk_from_public_key(pub)
+        )
+        _check_not_revoked(trusted_jwk, revocation)
 
     # Freshness: bound the age of the record against its issued-at timestamp.
     if max_age_seconds is not None:

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -9,7 +9,14 @@ import rfc8785
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-from agentrust_trace import TrustRecord, generate_key, key_to_jwk, sign_record, verify_record
+from agentrust_trace import (
+    TrustRecord,
+    generate_key,
+    jwk_thumbprint,
+    key_to_jwk,
+    sign_record,
+    verify_record,
+)
 from agentrust_trace.sign import _canonical_bytes
 
 
@@ -231,6 +238,160 @@ def test_verify_record_rejects_malformed_signature():
     record["signature"] = "!!!not base64!!!"
     with pytest.raises(ValueError, match="base64url"):
         verify_record(record, key_to_jwk(key))
+
+
+# --- RFC 7638 JWK thumbprints -----------------------------------------------
+
+
+def test_jwk_thumbprint_rfc8037_known_answer():
+    """Known-answer vector from RFC 8037 Appendix A.3 (Ed25519 JWK thumbprint).
+
+    Pinning the published vector proves the member set, ordering, and encoding
+    match the RFC, so a thumbprint computed here is the same identifier a
+    revocation list published by anyone else is keyed on.
+    """
+    jwk = {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+    }
+    assert jwk_thumbprint(jwk) == "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"
+
+
+def test_jwk_thumbprint_ignores_optional_members():
+    """Only the required members are hashed, so kid/alg/use do not change the value."""
+    key = generate_key()
+    bare = key_to_jwk(key)
+    decorated = {**bare, "kid": "key-2026-07", "alg": "EdDSA", "use": "sig"}
+    assert jwk_thumbprint(decorated) == jwk_thumbprint(bare)
+
+
+def test_jwk_thumbprint_distinguishes_keys():
+    assert jwk_thumbprint(key_to_jwk(generate_key())) != jwk_thumbprint(
+        key_to_jwk(generate_key())
+    )
+
+
+def test_jwk_thumbprint_rejects_unknown_kty():
+    with pytest.raises(ValueError, match="kty"):
+        jwk_thumbprint({"kty": "unknown", "x": "abc"})
+
+
+def test_jwk_thumbprint_rejects_missing_member():
+    with pytest.raises(ValueError, match="missing required thumbprint member 'x'"):
+        jwk_thumbprint({"kty": "OKP", "crv": "Ed25519"})
+
+
+# --- Revocation at verification time (#76) ----------------------------------
+
+
+def test_verify_record_rejects_revoked_key_by_thumbprint():
+    """A record signed by a listed key is rejected even though its signature is valid."""
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    trusted = key_to_jwk(key)
+    revoked = {jwk_thumbprint(trusted)}
+
+    # Sanity: the same record verifies when the key is not revoked.
+    verify_record(record, trusted, revocation=set())
+
+    with pytest.raises(ValueError, match="revoked"):
+        verify_record(record, trusted, revocation=revoked)
+
+
+def test_verify_record_passes_when_other_keys_revoked():
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    other = jwk_thumbprint(key_to_jwk(generate_key()))
+    verify_record(record, key_to_jwk(key), revocation={other})  # must not raise
+
+
+def test_verify_record_rejects_revoked_key_by_kid():
+    """A store keyed on kid works for issuers that publish one."""
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    trusted = {**key_to_jwk(key), "kid": "issuer-key-3"}
+    with pytest.raises(ValueError, match="issuer-key-3"):
+        verify_record(record, trusted, revocation={"issuer-key-3"})
+
+
+def test_verify_record_revocation_accepts_callable_store():
+    """A callable store models a live CRL / status / SCITT lookup."""
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    trusted = key_to_jwk(key)
+    seen: list[str] = []
+
+    def is_revoked(identifier: str) -> bool:
+        seen.append(identifier)
+        return False
+
+    verify_record(record, trusted, revocation=is_revoked)  # must not raise
+    assert seen == [jwk_thumbprint(trusted)]
+
+    with pytest.raises(ValueError, match="revoked"):
+        verify_record(record, trusted, revocation=lambda _identifier: True)
+
+
+def test_verify_record_fails_closed_when_revocation_source_errors():
+    """An unreachable revocation source is a rejection, not a pass.
+
+    This is the whole point of checking: if a lookup failure fell through to
+    "verified", an attacker holding a revoked key would only need to make the
+    status endpoint unreachable.
+    """
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+
+    def unreachable(_identifier: str) -> bool:
+        raise ConnectionError("status endpoint unreachable")
+
+    with pytest.raises(ValueError, match="could not be determined"):
+        verify_record(record, key_to_jwk(key), revocation=unreachable)
+
+
+def test_verify_record_revocation_works_with_public_key_object():
+    """The trusted key may be an Ed25519PublicKey; its JWK is derived for the check."""
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    pub = Ed25519PublicKey.from_public_bytes(_b64url_decode(key_to_jwk(key)["x"]))
+
+    verify_record(record, pub, revocation=set())  # must not raise
+    with pytest.raises(ValueError, match="revoked"):
+        verify_record(record, pub, revocation={jwk_thumbprint(key_to_jwk(key))})
+
+
+def test_verify_record_revocation_rejects_underivable_trusted_key():
+    """A trusted key whose identifiers cannot be derived is refused, not skipped."""
+
+    class OpaqueKey:
+        def verify(self, signature: bytes, data: bytes) -> None:
+            return None
+
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    with pytest.raises(ValueError, match="revocation checking needs"):
+        verify_record(record, OpaqueKey(), revocation=set())
+
+
+def test_verify_record_revocation_checked_against_trusted_key_not_record():
+    """cnf.jwk is attacker-controlled until the signature verifies, so it is not the
+    identifier the revocation check reads. A revoked issuer cannot escape the list by
+    embedding some other key in the record."""
+    revoked_key = generate_key()
+    record = sign_record(_fresh_record(), revoked_key)
+    record["cnf"]["jwk"] = key_to_jwk(generate_key())  # unlisted key, planted
+
+    trusted = key_to_jwk(revoked_key)
+    with pytest.raises(ValueError, match="revoked"):
+        verify_record(record, trusted, revocation={jwk_thumbprint(trusted)})
+
+
+def test_verify_record_without_revocation_store_stays_offline():
+    """The default remains pure offline verification: no store, no check, no error."""
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    verify_record(record, key_to_jwk(key))  # must not raise
 
 
 # --- RFC 8785 (JCS) canonicalization ----------------------------------------


### PR DESCRIPTION
## What this changes

Closes #76.

`verify_record()` checked signature and freshness but never consulted revocation or transparency state, so a record signed by a revoked or compromised key kept verifying. This is a gap against the spec's own normative text, not a new requirement: §3.2.1 already says *"Verifiers MUST consult current revocation status at verification time"*.

A signature stays cryptographically valid forever and nothing inside a record can retract the key that made it, so the verifier is the only place withdrawal of trust can be applied.

### The revocation store

`verify_record(..., revocation=...)` accepts either form:

```python
# A revocation list the caller already holds.
verify_record(record, trusted_jwk, revocation={"kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"})

# Or a live CRL / status endpoint / SCITT lookup.
verify_record(record, trusted_jwk, revocation=lambda key_id: crl.is_revoked(key_id))
```

| Outcome | Result |
|---|---|
| Key listed as revoked | Rejected (`ValueError`) |
| Store raises (endpoint down, timeout) | Rejected; an unavailable source is not evidence a key is unrevoked |
| Key absent from the store | Verification continues |
| No `revocation` passed | Check skipped; offline verification, unchanged |

Failing closed on an unreachable store is the part that matters: if a lookup failure fell through to "verified", an attacker holding a revoked key would only need to make the status endpoint unreachable.

### Two design points worth review

**The check reads the trusted key, not `record["cnf"]["jwk"]`.** The embedded key is attacker-controlled until the signature verifies, so keying the lookup on it would let a revoked issuer present an unlisted thumbprint and pass. There is a test pinning this.

**Identifiers are the RFC 7638 JWK Thumbprint or `kid`.** Thumbprints work when an issuer publishes no `kid`, and are stable across JWKs differing in optional members. `jwk_thumbprint()` is exported so a caller can key a list on the same identifier the verifier derives; it is pinned against the RFC 8037 Appendix A.3 known-answer vector.

### Scope

Deliberately **not** in this PR:

- No normative text, schema, or record field changed. This implements an existing MUST in the library, so it is not a spec change and needs no comment period.
- `revocation` defaults to `None` rather than being required. Making it mandatory is a breaking API change for every consumer (cMCP, ca2a) and is better decided alongside #67, which designs the `TraceRevocation` claim and the entry-ID anchor. This PR gives the verify path the hook; #67 can decide what feeds it.
- Transparency/SCITT state is reachable through the callable form, but no SCITT client is added here.

Documented rather than left implied: `docs/verification.md` opens with "independently verifiable offline", which is true and is exactly why non-revocation is the one thing it cannot establish. That page and `LIMITATIONS.md` now say so directly.

## Type of change

- [ ] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

None of the listed categories fit, so I have left them unticked rather than claim one inaccurately. This is a library and docs change that implements an existing normative MUST. No spec text, schema, or record field is modified. Happy to tick whichever box you consider correct.

## Spec section

3.2.1 (Signing and key management), implemented rather than modified. No spec text changed.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [x] `CHANGELOG.md` updated
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text (not applicable, no breaking change)
- [x] Backward compatibility statement included: additive keyword argument defaulting to `None`, so offline verification is byte-for-byte unchanged

## Verification

- 105 tests pass, 14 new. Every new line covered (`sign.py` misses are pre-existing).
- `ruff check src tests` and `mypy src/agentrust_trace` (strict) clean.
- Backward compatibility checked against a downstream consumer: the cMCP suite passes unchanged with the patched package installed, 893 passed and 8 skipped, before and after.