### PR TITLE
docs(governance): state who may author normative text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ This adds `Signed-off-by: Your Name <you@example.com>`. PRs without DCO sign-off
 
 Changes to `spec/trace-v0.2.md` that affect what implementations must do.
 
+Read [who may author normative text](GOVERNANCE.md#who-may-author-normative-text) first. Normative changes need an organizational sponsor accountable for the requirement. Anyone may propose one, and a Maintainer carries the PR for an accepted proposal that has no sponsor. Everything else in the list below, including informative crosswalks and mappings to external schemas, needs no sponsor.
+
 1. Open a GitHub issue using the **Spec change proposal** template. Describe the problem, the proposed change, and the spec section affected.
 2. Allow 5 business days for comment. Changes touching wire format, cryptographic algorithms, or Trust Record required fields require 14 days.
 3. Submit a PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN — description -->`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Read [who may author normative text](GOVERNANCE.md#who-may-author-normative-text
 
 1. Open a GitHub issue using the **Spec change proposal** template. Describe the problem, the proposed change, and the spec section affected.
 2. Allow 5 business days for comment. Changes touching wire format, cryptographic algorithms, or Trust Record required fields require 14 days.
-3. Submit a PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN — description -->`.
+3. Submit a PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN - description -->`.
 4. Update `CHANGELOG.md`.
 5. Breaking changes (backward-incompatible field removals, algorithm deprecations) require Project Lead approval and an explicit backward-compatibility statement.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,6 +36,20 @@ Final decision authority on specification changes, conformance requirements, AAI
 
 **Voting**: If consensus cannot be reached, Maintainers vote. Simple majority for non-breaking changes; two-thirds for breaking changes. Project Lead has tie-breaking vote.
 
+## Who may author normative text
+
+Normative text is any statement using an RFC 2119 keyword in uppercase: what a conformant implementation MUST, SHOULD or MAY do. A normative change binds every implementation of TRACE, including implementations whose authors are not in the discussion.
+
+**Normative spec changes require an organizational sponsor.** The sponsor is an organization that implements TRACE, or produces the attestation platform the change concerns, and is willing to be named as accountable for the requirement in the PR. In practice that has meant silicon and cloud attestation vendors, platform and framework implementers, and standards bodies carrying the work forward. Reviewers confirm the sponsorship, not the individual's competence.
+
+The reason is maintenance cost, not merit. A MUST is a promise the project keeps for every future version. Evaluating whether it can be implemented, at what cost, across which platforms, needs an organization that will actually implement it and answer for it later. Individual authorship gives the project no way to make that assessment and no one to return to when the requirement proves wrong.
+
+**Anyone may propose a normative change.** Open a Spec change proposal issue. Proposals are evaluated on the technical argument alone. If one is accepted without a sponsor, a Maintainer carries the normative PR and the proposer is credited in the CHANGELOG entry. This is a question of who signs the requirement, not whose idea it was.
+
+**No sponsor is required for** editorial changes, examples, conformance tests, tooling, schema changes tracking an already-merged spec change, and informative additions such as crosswalks and mappings to external schemas. Informative text carries no RFC 2119 keywords and binds no implementation, so it is the right home for a mapping that is still settling. Most contributions are in this set.
+
+A normative PR opened without a sponsor is not rejected on that basis. Reviewers will say so on the PR and either identify a sponsor or convert it to an informative change.
+
 ## Conflict of interest
 
 Maintainers must disclose commercial interest in a proposal before participating in its review. Disclosed conflicts do not disqualify a Maintainer from voting but must be on record in the PR or issue.


### PR DESCRIPTION
## Why

The rule that normative spec changes need an organizational sponsor is applied in review but is written down nowhere. GOVERNANCE.md covers who may *merge* and how long comment periods run, and CONTRIBUTING.md covers the mechanics, but neither says who may *author* a MUST. Contributors therefore meet the rule for the first time as a surprise on their own PR, after doing the work, which is the worst possible moment.

This changes nothing in practice. It writes down what already happens.

## What it says

- Normative text is anything with an uppercase RFC 2119 keyword, and a normative change needs an organizational sponsor willing to be named as accountable for the requirement.
- The reason is maintenance cost rather than merit: a MUST is a promise the project keeps for every future version, and assessing implementability across platforms needs an organization that will implement it and answer for it later.
- **Anyone may propose** a normative change, proposals are judged on the technical argument alone, and where an accepted proposal has no sponsor a Maintainer carries the PR with the proposer credited in the CHANGELOG. That was already the practice and was equally unwritten.
- No sponsor is needed for editorial changes, examples, conformance tests, tooling, schema changes tracking a merged spec change, or informative additions such as crosswalks and mappings to external schemas. Informative text binds no implementation, so it is the right home for a mapping that is still settling. Most contributions fall here.
- An unsponsored normative PR is not rejected on that basis. Reviewers either identify a sponsor or convert it to an informative change.

CONTRIBUTING.md gets a pointer at the top of the spec-change checklist so it is read before the work starts, not after.

Second commit strips a leftover em dash from the `CHANGED:` marker template, missed by the earlier README pass. No spec file uses the marker yet, so the template was the only occurrence.

## Process

GOVERNANCE.md amendments require a PR, a 14-day comment period, and Project Lead approval, per the Amendments section of that same document. Not merging this. The clock starts now and it needs your sign-off.

Worth mirroring into `agent-manifest` afterwards, since the same rule applies there and the same surprise is currently happening on agentrust-io/agent-manifest#270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)