### PR TITLE
test(conformance): portable vectors for the RFC 8785 requirement

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,10 @@ Each file is a canonical TRACE v0.1 Trust Record that validates as-is against
 - `action-receipts/`: informative fixture shapes for action-level receipt
   verification. These are not TRACE Trust Records and are not validated against
   `schema/trace-claim.json`.
+- `canonicalization-boundary/`: three signed Trust Records that separate an
+  RFC 8785-conformant canonicalizer from `json.dumps(sort_keys=True)`, which
+  §3.2.2 requires and names as insufficient. These *are* Trust Records and do
+  validate against the schema. See that directory's README.
 
 The schema sets `additionalProperties: false`, so examples must not carry
 non-schema keys such as `_comment`. Keep descriptive notes in this file.

--- a/examples/canonicalization-boundary/01-non-ascii-values.json
+++ b/examples/canonicalization-boundary/01-non-ascii-values.json
@@ -1,0 +1,54 @@
+{
+  "name": "non-ascii-values",
+  "description": "String values outside ASCII, all in the Basic Multilingual Plane. RFC 8785 emits them as literal UTF-8; a serializer that escapes to \\uXXXX signs different bytes and rejects this valid record.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6",
+      "version": "modèle-géant-4.6"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "机密",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+      }
+    },
+    "signature": "WehNEF0FqgUa_c85Hw7jbbz4_d_kg2GEyo4r4p242CNGjTkmmRNvVPuwTfjtKJwbOCuNspqEyrMNgZMOTh-OAA"
+  },
+  "expected": {
+    "outcome": "verified"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact"
+  ]
+}

--- a/examples/canonicalization-boundary/02-non-bmp-values.json
+++ b/examples/canonicalization-boundary/02-non-bmp-values.json
@@ -1,0 +1,54 @@
+{
+  "name": "non-bmp-values",
+  "description": "String values above U+FFFF, encoded as four UTF-8 bytes each. Under ASCII-escaping they become surrogate pairs; either way the bytes differ from RFC 8785's literal UTF-8.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6",
+      "version": "4.6-🤖"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "confidential-🔒",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+      }
+    },
+    "signature": "62CaOUWmDFPmgthTUkJ4cdwxmDQXzYg9hN6KaCB3EHjeDzeLiB_rdVFIRQrDVTzt-clmIoxNs7UxzJMFvWB_Bw"
+  },
+  "expected": {
+    "outcome": "verified"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact"
+  ]
+}

--- a/examples/canonicalization-boundary/03-utf16-key-order.json
+++ b/examples/canonicalization-boundary/03-utf16-key-order.json
@@ -1,0 +1,56 @@
+{
+  "name": "utf16-key-order",
+  "description": "Two object keys whose order under RFC 8785's UTF-16 code-unit sort is the reverse of their code-point order. This is the record that distinguishes a true RFC 8785 serializer from json.dumps with every option set carefully: compact separators and ensure_ascii=False survive vectors 01 and 02, and fail here.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "confidential",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA",
+        "zk😀": "sorts-first-under-rfc-8785",
+        "zk�": "sorts-second-under-rfc-8785"
+      }
+    },
+    "signature": "CjOuPwCnxnwegFjguiSCi-_xPg3iOwnCgyKuKYnV0OorofjPJrkOLn3dUFa-6tVf0z8EDiHaczl6AN46MuBtCQ"
+  },
+  "expected": {
+    "outcome": "verified"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact",
+    "sort_keys_compact_utf8"
+  ]
+}

--- a/examples/canonicalization-boundary/README.md
+++ b/examples/canonicalization-boundary/README.md
@@ -1,0 +1,73 @@
+# Canonicalization boundary vectors
+
+Spec section 3.2.2 requires an RFC 8785-conformant canonicalizer and names
+`json.dumps(sort_keys=True)` as insufficient.
+
+**What already existed.** `tests/test_sign.py` carries four literal-byte known-answer
+tests over `_canonical_bytes` — non-ASCII escaping, number formatting, whitespace and
+key sorting, and a comparison against the reference library. They are good tests and
+they do catch a regression in this library.
+
+**What these vectors add.** Two things those tests cannot do:
+
+1. **They are portable.** A known-answer test over a private function is runnable only
+   from Python, by this package. The roadmap targets Go, Rust and TypeScript verifiers
+   for v1.0, and none of them can run `test_sign.py`. These are signed records: any
+   implementation runs them against its own verifier. Every *other* record in the
+   repository is ASCII-only with schema-fixed keys, where all serializers agree
+   byte-for-byte — so no existing record's acceptance depends on canonicalizing
+   correctly.
+2. **One of them separates key ordering, which nothing else does.**
+   `test_jcs_distinguishes_unicode_key_order_from_json_dumps` compares `{"z": 1,
+   "\U0001f600": 2}`. Under RFC 8785's UTF-16 code-unit sort and under Python's
+   code-point sort that object serializes in the *same* order — its own docstring says
+   so — and the test detects divergence through `ensure_ascii` escaping instead. A
+   canonicalizer that sorts by code point but emits raw UTF-8 passes it. Vector `03`
+   is the first object in the repository whose two orderings actually disagree.
+
+Each record is schema-valid and correctly signed over its RFC 8785 bytes, so a
+conformant verifier accepts it, and a verifier built on any ad-hoc form computes
+different signing bytes and rejects a valid record.
+
+## The ladder
+
+Each form fixes the previous one's divergence and still fails somewhere:
+
+| Form | Diverges because | Caught by |
+|---|---|---|
+| `json.dumps(o, sort_keys=True)` | Default separators insert spaces | every vector (and any signed record) |
+| `… separators=(",", ":")` | `ensure_ascii` escapes non-ASCII as `\uXXXX`; RFC 8785 emits literal UTF-8 | `01`, `02`, `03` |
+| `… separators=(",", ":"), ensure_ascii=False` | Python sorts keys by code point; RFC 8785 sorts by UTF-16 code units. The orders differ exactly when a key contains a supplementary-plane character | `03` only |
+
+`03-utf16-key-order.json` is the load-bearing vector: it is the only record in this
+repository that distinguishes a true RFC 8785 serializer from `json.dumps` with every
+option chosen carefully. Its two extra `cnf.jwk` members (RFC 7517 permits additional
+JWK members, and `cnf.jwk` is the one schema object open to them) are `zk` followed by
+U+1F600 and `zk` followed by U+FFFD — U+1F600 is `D83D DE00` in UTF-16, so it sorts
+*before* U+FFFD by code units and *after* it by code points.
+
+## What each fixture carries
+
+- `record` — a complete, schema-valid, signed v0.2 Trust Record.
+- `trusted_key` — the Ed25519 JWK to verify against.
+- `expected.outcome` — `verified`, always. These are positive vectors; the negative
+  behaviour (rejection) is what a non-conformant verifier does to them.
+- `diverges_under` — which ad-hoc forms compute different bytes for this record.
+  `tests/test_canonicalization_boundary.py` recomputes this list on every run rather
+  than trusting it, and separately asserts that the set as a whole still catches every
+  form on the ladder.
+
+`iat` is fixed so the set regenerates byte-for-byte; run with freshness disabled or
+with `iat`'s instant supplied as "now". `gen_boundary_vectors.py` regenerates the set.
+
+## What there is deliberately no vector for
+
+RFC 8785's IEEE 754 number serialization (the other divergence the spec warns about)
+is **unreachable in a schema-valid v0.2 record**: no field in `schema/trace-claim.json`
+is typed `number`, and integers up to 2^53 serialize identically everywhere. The test
+suite pins this with `test_number_divergence_is_still_unreachable`, which fails the day
+a numeric field enters the schema — at which point the correct response is a
+number-formatting vector here, not an edit to the test.
+
+These vectors exercise accepted normative text (the section 3.2.2 MUST), not a
+proposal; they carry no proposal marker.

--- a/examples/canonicalization-boundary/gen_boundary_vectors.py
+++ b/examples/canonicalization-boundary/gen_boundary_vectors.py
@@ -1,0 +1,178 @@
+"""Generate canonicalization boundary vectors (spec section 3.2.2).
+
+The spec: "Implementations MUST use an RFC 8785-conformant library. Using
+`json.dumps(sort_keys=True)` (Python) or equivalent ad-hoc sorting is insufficient."
+No published test material exercised that sentence: every existing record is
+ASCII-only with schema-fixed keys, and on such records every ad-hoc serializer agrees
+with RFC 8785 byte-for-byte, so an implementation using one passes everything.
+
+These are the records on which they disagree. Each is schema-valid and correctly
+signed over its RFC 8785 bytes, and each carries ``diverges_under`` — the ad-hoc
+canonicalizations whose output differs, so that a verifier built on them computes
+different bytes and rejects a valid record. ``tests/test_canonicalization_boundary.py``
+recomputes that list rather than trusting it.
+
+The ad-hoc forms make a ladder, each rung needing a sharper vector to expose:
+
+- ``sort_keys_default`` — ``json.dumps(record, sort_keys=True)``. Inserts spaces after
+  separators; any record at all diverges.
+- ``sort_keys_compact`` — adds ``separators=(",", ":")``. Correct on ASCII; escapes
+  non-ASCII as ``\\uXXXX`` where RFC 8785 emits literal UTF-8.
+- ``sort_keys_compact_utf8`` — adds ``ensure_ascii=False``. Correct on every record in
+  this repository except one: RFC 8785 sorts object keys by UTF-16 code units, Python
+  sorts str by code point, and the two orders differ exactly when a key contains a
+  supplementary-plane character.
+
+There is no vector for RFC 8785's IEEE 754 number serialization: the v0.2 schema types
+no field as ``number``, so the divergence is unreachable in a schema-valid record. The
+test suite pins that fact so a future numeric field demands a vector here.
+
+Deterministic key, so the set regenerates byte-for-byte. Public test material.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import rfc8785
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+OUT = Path("examples/canonicalization-boundary")
+V0_2 = "tag:agentrust-io.com,2026:trace-v0.2"
+
+SEED = hashlib.sha256(b"trace-spec canonicalization-boundary fixture key").digest()
+KEY = Ed25519PrivateKey.from_private_bytes(SEED)
+
+
+def b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def public_jwk() -> dict[str, str]:
+    raw = KEY.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    return {"kty": "OKP", "crv": "Ed25519", "x": b64u(raw)}
+
+
+BASE_RECORD: dict[str, Any] = {
+    "eat_profile": V0_2,
+    # Fixed, so the fixture is reproducible. Verifiers running these vectors must
+    # disable the freshness check or supply this instant as "now"; canonicalization
+    # is the property under test, not staleness.
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-6",
+    },
+    "runtime": {
+        "platform": "software-only",
+        "measurement": "sha256:" + "00" * 32,
+    },
+    "policy": {
+        "bundle_hash": "sha256:" + "aa" * 32,
+        "enforcement_mode": "enforce",
+    },
+    "data_class": "confidential",
+    "build_provenance": {
+        "slsa_level": 0,
+        "digest": "sha256:" + "bb" * 32,
+    },
+    "appraisal": {
+        "status": "affirming",
+        "verifier": "https://verifier.example/v1",
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+}
+
+
+def signed(record: dict[str, Any]) -> dict[str, Any]:
+    body = dict(record)
+    body["cnf"] = {"jwk": {**public_jwk(), **body.get("cnf", {}).get("jwk", {})}}
+    body["signature"] = b64u(KEY.sign(rfc8785.dumps(body)))
+    return body
+
+
+def vector(
+    name: str,
+    description: str,
+    record: dict[str, Any],
+    diverges_under: list[str],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": description,
+        "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an "
+        "RFC 8785-conformant library",
+        "profile": "trace.canonicalization.boundary.v0",
+        "trusted_key": public_jwk(),
+        "record": signed(record),
+        "expected": {"outcome": "verified"},
+        "diverges_under": diverges_under,
+    }
+
+
+def main() -> None:
+    out: list[tuple[str, dict[str, Any]]] = []
+
+    r = copy.deepcopy(BASE_RECORD)
+    r["model"]["version"] = "modèle-géant-4.6"
+    r["data_class"] = "机密"
+    out.append(("01-non-ascii-values.json", vector(
+        "non-ascii-values",
+        "String values outside ASCII, all in the Basic Multilingual Plane. RFC 8785 "
+        "emits them as literal UTF-8; a serializer that escapes to \\uXXXX signs "
+        "different bytes and rejects this valid record.",
+        r,
+        ["sort_keys_default", "sort_keys_compact"],
+    )))
+
+    r = copy.deepcopy(BASE_RECORD)
+    r["model"]["version"] = "4.6-🤖"
+    r["data_class"] = "confidential-🔒"
+    out.append(("02-non-bmp-values.json", vector(
+        "non-bmp-values",
+        "String values above U+FFFF, encoded as four UTF-8 bytes each. Under "
+        "ASCII-escaping they become surrogate pairs; either way the bytes differ from "
+        "RFC 8785's literal UTF-8.",
+        r,
+        ["sort_keys_default", "sort_keys_compact"],
+    )))
+
+    r = copy.deepcopy(BASE_RECORD)
+    # cnf.jwk is the one object in the schema open to additional members (RFC 7517
+    # permits them), so it is where a key-ordering divergence can live in a
+    # schema-valid record. U+1F600 is D83D DE00 in UTF-16, so it sorts before U+FFFD
+    # by code units (RFC 8785) and after it by code points (Python str, and any
+    # sorted() on decoded strings).
+    r["cnf"] = {"jwk": {
+        "zk\U0001f600": "sorts-first-under-rfc-8785",
+        "zk�": "sorts-second-under-rfc-8785",
+    }}
+    out.append(("03-utf16-key-order.json", vector(
+        "utf16-key-order",
+        "Two object keys whose order under RFC 8785's UTF-16 code-unit sort is the "
+        "reverse of their code-point order. This is the record that distinguishes a "
+        "true RFC 8785 serializer from json.dumps with every option set carefully: "
+        "compact separators and ensure_ascii=False survive vectors 01 and 02, and "
+        "fail here.",
+        r,
+        ["sort_keys_default", "sort_keys_compact", "sort_keys_compact_utf8"],
+    )))
+
+    for name, doc in out:
+        (OUT / name).write_text(
+            json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        print("wrote", name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonicalization_boundary.py
+++ b/tests/test_canonicalization_boundary.py
@@ -1,0 +1,133 @@
+"""Canonicalization boundary vectors (spec section 3.2.2).
+
+The spec requires an RFC 8785-conformant library and names
+``json.dumps(sort_keys=True)`` as insufficient. On every other record in this
+repository the two agree byte-for-byte, so nothing distinguished an implementation
+that complied from one that did not. These vectors are the records on which they
+disagree: schema-valid, correctly signed, and rejected by any verifier whose
+canonicalizer is one of the ad-hoc forms below.
+
+Each fixture declares ``diverges_under``. The declaration is recomputed here, not
+trusted: a vector that stopped diverging would otherwise keep documenting a
+distinction it no longer makes.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import rfc8785
+
+from agentrust_trace import verify_record
+from agentrust_trace.validate import validate_json
+
+REPO_ROOT = Path(__file__).parent.parent
+FIXTURE_DIR = REPO_ROOT / "examples" / "canonicalization-boundary"
+FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+
+# The ladder of ad-hoc canonicalizations, least careful first. Each rung fixes the
+# previous rung's divergence and still fails on at least one vector; the last is
+# json.dumps with every option set as well as it can be.
+ADHOC: dict[str, Callable[[Any], bytes]] = {
+    "sort_keys_default": lambda o: json.dumps(o, sort_keys=True).encode(),
+    "sort_keys_compact": lambda o: json.dumps(
+        o, sort_keys=True, separators=(",", ":")
+    ).encode(),
+    "sort_keys_compact_utf8": lambda o: json.dumps(
+        o, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode(),
+}
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _signing_input(record: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in record.items() if k != "signature"}
+
+
+def test_vector_set_is_complete() -> None:
+    assert [path.name for path in FIXTURE_PATHS] == [
+        "01-non-ascii-values.json",
+        "02-non-bmp-values.json",
+        "03-utf16-key-order.json",
+    ]
+
+
+@pytest.mark.parametrize("path", FIXTURE_PATHS, ids=lambda p: p.stem)
+def test_vector_is_schema_valid_and_verifies(path: Path) -> None:
+    """The record is an ordinary valid Trust Record; only its bytes are unusual.
+
+    A vector that failed schema validation would let an implementation reject it for
+    the wrong reason and still look conformant.
+    """
+    fixture = _load(path)
+    validate_json(fixture["record"])
+    verify_record(
+        fixture["record"],
+        fixture["trusted_key"],
+        # iat is fixed for reproducibility; canonicalization, not freshness, is the
+        # property under test.
+        max_age_seconds=None,
+    )  # must not raise
+
+
+@pytest.mark.parametrize("path", FIXTURE_PATHS, ids=lambda p: p.stem)
+def test_declared_divergence_is_the_measured_divergence(path: Path) -> None:
+    """``diverges_under`` is recomputed, never trusted."""
+    fixture = _load(path)
+    body = _signing_input(fixture["record"])
+    canonical = rfc8785.dumps(body)
+    measured = sorted(
+        name for name, dumps in ADHOC.items() if dumps(body) != canonical
+    )
+    assert measured == sorted(fixture["diverges_under"]), (
+        f"{path.name}: declared divergence does not match measurement. A verifier "
+        "reading the declaration would draw the wrong conclusion about which "
+        "canonicalizers this vector can catch."
+    )
+
+
+def test_every_adhoc_form_is_caught_by_some_vector() -> None:
+    """The set as a whole must kill every rung of the ladder.
+
+    If the most careful form ever stops diverging on all vectors, the set can no
+    longer distinguish a conformant canonicalizer from json.dumps, and the spec's
+    MUST is back to being unenforced.
+    """
+    killed = {name for path in FIXTURE_PATHS for name in _load(path)["diverges_under"]}
+    assert killed == set(ADHOC)
+
+
+def test_number_divergence_is_still_unreachable() -> None:
+    """No schema field is typed ``number``, so RFC 8785's IEEE 754 serialization
+    cannot diverge inside a schema-valid record and no vector exercises it.
+
+    This pins the claim. The day a numeric field enters the schema, this fails, and
+    the correct response is a number-formatting vector in this set, not an edit here.
+    """
+    schema = json.loads(
+        (REPO_ROOT / "schema" / "trace-claim.json").read_text(encoding="utf-8")
+    )
+
+    def types(node: Any) -> set[str]:
+        found: set[str] = set()
+        if isinstance(node, dict):
+            declared = node.get("type")
+            if isinstance(declared, str):
+                found.add(declared)
+            elif isinstance(declared, list):
+                found.update(t for t in declared if isinstance(t, str))
+            for value in node.values():
+                found |= types(value)
+        elif isinstance(node, list):
+            for item in node:
+                found |= types(item)
+        return found
+
+    assert "number" not in types(schema)


### PR DESCRIPTION
## What this is not

§3.2.2 requires an RFC 8785-conformant canonicalizer and names `json.dumps(sort_keys=True)` as insufficient. **`tests/test_sign.py` already covers that**, with four literal-byte known-answer tests over `_canonical_bytes`. I swapped the canonicalizer for each ad-hoc form in turn to check, and every one of them fails those tests. This PR is not reporting a hole in them and does not replace them.

I mention it because my first read of this was that the requirement was untested, and that was wrong — I had not read `test_sign.py` before concluding it.

## What it adds

**1. Portability.** A known-answer test over a private function runs only from Python, in this package. `ROADMAP.md` targets Go, Rust and TypeScript verification libraries for v1.0, and none of them can run `test_sign.py`. These three fixtures are signed Trust Records: another implementation runs them against its own verifier and finds out whether its canonicalizer agrees.

That matters because **no existing record in the repository can tell.** Every example is ASCII-only with schema-fixed keys, and on such records every serializer produces identical bytes — so an implementation built on ad-hoc sorting verifies all of them correctly.

**2. One vector separates key ordering, which nothing here currently does.**

`test_jcs_distinguishes_unicode_key_order_from_json_dumps` compares `{"z": 1, "\U0001f600": 2}`. Under RFC 8785's UTF-16 code-unit sort and under Python's code-point sort, that object serializes in the **same order** — the test's own docstring notes it ("order matches here") — so what it actually detects is the `ensure_ascii` escaping, which it hardcodes on the comparison side:

```python
>>> obj = {"z": 1, "\U0001f600": 2}
>>> rfc8785.dumps(obj) == json.dumps(obj, sort_keys=True, separators=(",",":"), ensure_ascii=False).encode()
True          # a code-point sorter emitting raw UTF-8 passes this test
```

Vector `03` uses two keys sharing a `zk` prefix and differing only after it, where the orderings genuinely disagree:

```python
# Escapes throughout, so nothing depends on how your terminal renders it.
>>> obj = {"zk\U0001f600": 1, "zk\uFFFD": 2}   # U+1F600 is D83D DE00 in UTF-16
>>> rfc8785.dumps(obj)
b'{"zk\xf0\x9f\x98\x80":1,"zk\xef\xbf\xbd":2}'    # D83D < FFFD
>>> json.dumps(obj, sort_keys=True, separators=(",",":"), ensure_ascii=False).encode()
b'{"zk\xef\xbf\xbd":2,"zk\xf0\x9f\x98\x80":1}'    # 0xFFFD < 0x1F600
```

`cnf.jwk` is the one schema object open to additional members, which RFC 7517 permits, so this is expressible in a schema-valid record.

## The ladder

| Ad-hoc form | Fails on |
|---|---|
| `json.dumps(o, sort_keys=True)` | any record |
| `… separators=(",", ":")` | `01`, `02`, `03` |
| `… separators=(",", ":"), ensure_ascii=False` | `03` only |

Each fixture declares `diverges_under`; the test **recomputes** it rather than trusting it, and separately asserts the set as a whole still kills every rung — so a vector that quietly stopped discriminating fails rather than passing while documenting a distinction it no longer makes.

## Deliberately no number-formatting vector

RFC 8785's IEEE 754 serialization is the other divergence §3.2.2 warns about, and it is **unreachable inside a schema-valid record**: no field in `schema/trace-claim.json` is typed `number`, and integers below 2^53 serialize identically everywhere. `test_number_divergence_is_still_unreachable` pins that and fails the day a numeric field is added, at which point the right response is a vector here rather than an edit to the test.

## Verification

- 114 tests pass (105 before, plus 9)
- `ruff check src tests examples` clean; verified on Python 3.11 and 3.14
- `gen_boundary_vectors.py` regenerates the set byte-for-byte; only public JWKs appear in the files
- Every fixture is schema-valid and verifies through `verify_record`, so none can pass or fail for an unrelated reason
- No normative text, schema, or record field changed. Test material only.
- DCO signed

