### PR TITLE
docs(governance): adopt LF Projects policies and Community Specification structure

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -45,7 +45,7 @@ Upon host organization acceptance, governance transitions from the current Proje
 
 All contributions must be made under the terms of [LICENSE](LICENSE). Contributors must sign commits with the Developer Certificate of Origin (DCO). No contribution may incorporate material covered by a patent the contributor is unwilling to license royalty-free to conforming implementations.
 
-The specification text is licensed under CC BY 4.0. Schema, examples, and code are licensed under Apache 2.0 with Patent Promise (see LICENSE).
+Specification text, schema, examples, and code are licensed under Apache 2.0, the Project License, with Patent Promise. Documentation other than specification text is licensed under CC BY 4.0. Specification text published before the Project License took effect stays available under CC BY 4.0. See [LICENSE](LICENSE).
 
 ## 5. Trademark Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,24 @@ This adds `Signed-off-by: Your Name <you@example.com>`. PRs without DCO sign-off
 
 ### Spec changes (normative text)
 
-Changes to `spec/trace-v0.2.md` that affect what implementations must do.
+Changes to `spec/trace-v0.2.md` that affect what implementations must do. Normative text is any statement using an RFC 2119 keyword in uppercase: what a conformant implementation MUST, SHOULD or MAY do. A normative change binds every implementation of TRACE, including implementations whose authors are not in the discussion.
 
-Read [who may author normative text](GOVERNANCE.md#who-may-author-normative-text) first. Normative changes need an organizational sponsor accountable for the requirement. Anyone may propose one, and a Maintainer carries the PR for an accepted proposal that has no sponsor. Everything else in the list below, including informative crosswalks and mappings to external schemas, needs no sponsor.
+**Anyone may propose a Normative Change, however only Normative Contributions with an organizational sponsor willing to implement and maintain that element in the specification will be accepted.**
 
-1. Open a GitHub issue using the **Spec change proposal** template. Describe the problem, the proposed change, and the spec section affected.
-2. Allow 5 business days for comment. Changes touching wire format, cryptographic algorithms, or Trust Record required fields require 14 days.
-3. Submit a PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN - description -->`.
-4. Update `CHANGELOG.md`.
-5. Breaking changes (backward-incompatible field removals, algorithm deprecations) require Project Lead approval and an explicit backward-compatibility statement.
+The sponsor is an organization that implements TRACE, or produces the attestation platform the change concerns, and is willing to be named as accountable for the requirement in the PR. In practice that has meant silicon and cloud attestation vendors, platform and framework implementers, and standards bodies carrying the work forward. Reviewers confirm the sponsorship, not the individual's competence.
+
+The reason is maintenance cost, not merit. A MUST is a promise the project keeps for every future version. Evaluating whether it can be implemented, at what cost, across which platforms, needs an organization that will actually implement it and answer for it later.
+
+Steps for a normative contribution:
+
+1. Open a GitHub issue using the **Spec change proposal** template. Describe the problem, the proposed change, and the spec section affected. Proposals are evaluated on the technical argument alone, sponsored or not.
+2. Allow a minimum 5 business days for comment. Breaking changes, including anything touching wire format, cryptographic algorithms, or Trust Record required fields, carry a minimum 30-day comment period. See [Backward compatibility](GOVERNANCE.md#backward-compatibility) for the conditions under which a breaking change is considered at all.
+3. Name the sponsoring organization in the PR. If a proposal is accepted without a sponsor, a Maintainer may sponsor and carry the PR, and the proposer is credited in the `CHANGELOG.md` entry. A normative PR opened without a sponsor is not rejected on that basis: reviewers will say so on the PR and either identify a sponsor or convert it to an informative change.
+4. Submit the PR. Mark changed normative text with an HTML comment: `<!-- CHANGED: #NNN - description -->`.
+5. Update `CHANGELOG.md`.
+6. Breaking changes require Project Lead approval and an explicit backward-compatibility statement naming what breaks and what implementers must do.
+
+**No sponsor is required for** editorial changes, examples, conformance tests, tooling, schema changes tracking an already-merged spec change, and informative additions such as crosswalks and mappings to external schemas. Informative text carries no RFC 2119 keywords and binds no implementation, so it is the right home for a mapping that is still settling. Most contributions are in this set.
 
 ### Schema changes (schema/trace-claim.json)
 
@@ -44,9 +53,15 @@ TRACE will publish vendor-co-authored claim-mapping annexes (§4.4 of the spec) 
 
 ## Review timeline
 
-- Editorial PRs: 3 business days
-- Non-breaking spec changes: 7 business days
-- Breaking or wire-format changes: 14 business days + Project Lead sign-off
+Comment periods are minimums. The project takes as much time as it needs to reach a consensus decision.
+
+- Non-breaking spec changes: a minimum 5 business days for comment
+- Breaking or wire-format changes: a minimum 30-day comment period + Project Lead sign-off
+
+Maintainer response targets are commitments to you, not minimums. Ping the PR if one is missed.
+
+- Editorial PRs: reviewed within 3 business days
+- Spec change PRs: reviewed within 7 business days
 
 ## Style
 
@@ -57,4 +72,6 @@ TRACE will publish vendor-co-authored claim-mapping annexes (§4.4 of the spec) 
 
 ## License
 
-By contributing you agree that your contributions will be licensed under the terms in [LICENSE](LICENSE).
+Anyone who submits a PR, files an issue, or participates in discussion on the repository is a Contributor bound by the license terms.
+
+Code and specification contributions are made under the Apache License, Version 2.0, the Project License. Documentation contributions other than specification text are made under CC BY 4.0. You keep the copyright in your contributions: no contributor is asked to assign copyright to the project. See [LICENSE](LICENSE) and [General Project Policies](GOVERNANCE.md#general-project-policies).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,54 +1,109 @@
 # Governance
 
+## General Project Policies
+
+TRACE Specification has been established as TRACE Specification a Series of LF Projects, LLC. Policies applicable to TRACE Specification and participants in the TRACE Specification project, including guidelines on the usage of trademarks, are located at https://www.lfprojects.org/policies/. Governance changes approved as per the provisions of this governance document must also be approved by LF Projects, LLC.
+
+TRACE Specification participants acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the project.
+
+Except as described below, all code and specification contributions to the project must be made using the Apache License, Version 2.0 available at http://www.apache.org/licenses/LICENSE-2.0 (the "Project License").
+
+All outbound code and specifications will be made available under the Project License. The Maintainers may approve the use of an alternative open license or licenses for inbound or outbound contributions on an exception basis.
+
+All documentation (excluding specifications) will be made available under the Creative Commons Attribution 4.0 International license, available at: https://creativecommons.org/licenses/by/4.0.
+
+Specification text published before this policy took effect stays available under the license it was published under. See [LICENSE](LICENSE).
+
 ## Roles
 
 ### Contributor
 
-Anyone who submits a PR, files an issue, or participates in discussion. No formal appointment required. Must follow the [Code of Conduct](CODE_OF_CONDUCT.md) and sign commits with DCO.
+Anyone who submits a PR, files an issue, or participates in discussion on the repository is a Contributor bound by the license terms. No formal appointment is required. Contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md) and sign commits with DCO.
 
 ### Reviewer
 
-Trusted contributors with triage and review rights. Can approve PRs but cannot merge breaking spec changes without Project Lead approval.
+Trusted Contributors with triage and review rights. Reviewers can approve PRs but cannot merge breaking spec changes without Project Lead approval.
 
-**Advancement**: 3+ merged substantive PRs. Nominated by any Maintainer, confirmed by Project Lead.
+**Advancement**: 3+ merged substantive PRs. Nominated by any Maintainer, confirmed by the Project Lead.
 
 ### Maintainer
 
 Full merge rights. Responsible for reviewing PRs in their area within 7 business days. See [MAINTAINERS.md](MAINTAINERS.md).
 
-**Advancement**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec design questions. Nominated by any Maintainer, confirmed by Project Lead.
+**Advancement**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec design questions. Nominated by any Maintainer, confirmed by the Project Lead.
 
 ### Project Lead
 
-Final decision authority on specification changes, conformance requirements, AAIF submission scope, and Maintainer appointments. Currently: Imran Siddique (OPAQUE Systems).
+The Project Lead is responsible for determining Consensus among Contributors regarding specification changes, conformance requirements, advancement of the project or its deliverables to other organizations, role appointments, and other project decisions. If Consensus can't be determined, the Project Lead may call for a majority vote of the Maintainers. The current Project Lead is listed in [MAINTAINERS.md](MAINTAINERS.md).
 
-**Succession**: If the Project Lead is unavailable for 30+ days without notice, active Maintainers vote to appoint an interim lead.
+**Succession**: Active Maintainers vote to appoint a new Project Lead if the then-current Project Lead steps down or is unavailable for more than 30 days without notifying the Maintainers.
 
-## Decision-making
+## Decision Making
+
+### Consensus-based decision making
+
+The Project makes decisions through a consensus process ("Approval" or "Approved"). While the agreement of all Contributors is preferred, it is not required for consensus. Rather, the Project Lead will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Project Contributors and nature of support and objections. The Project Lead will document evidence of consensus in accordance with these requirements.
+
+### Appeal process
+
+Decisions may be appealed via a pull request or an issue, and that appeal will be considered by the Project Lead in good faith, who will respond in writing within a reasonable time.
+
+### Review periods by change class
+
+Review periods are minimums. The Project takes as much time as it needs to reach a consensus decision, and a period does not expire a discussion that is still live.
 
 **Editorial changes** (typos, broken links, clarifications that do not affect normative requirements): Maintainer review + merge.
 
-**Non-breaking spec changes** (new optional fields, new OPTIONAL conformance behavior, informative additions): open issue, 5-day comment period, Maintainer review, merge.
+**Non-breaking spec changes** (new optional fields, new OPTIONAL conformance behavior, informative additions): open issue, a minimum 5 business days for comment, Maintainer review, merge.
 
-**Breaking spec changes** (backward-incompatible field changes, algorithm additions to the required set, conformance level redefinition): open issue, 14-day comment period, no unresolved objections from Maintainers, Project Lead sign-off.
+**Breaking spec changes** (backward-incompatible field changes, algorithm additions to the required set, conformance level redefinition): open issue, a minimum 30-day comment period, no unresolved objections from Maintainers, Project Lead sign-off. See [Backward compatibility](#backward-compatibility).
 
 **Wire format changes**: treated as breaking regardless of backward-compatibility argument.
 
-**Voting**: If consensus cannot be reached, Maintainers vote. Simple majority for non-breaking changes; two-thirds for breaking changes. Project Lead has tie-breaking vote.
+**Voting**: If Consensus cannot be determined, the Project Lead may call for a majority vote of the Maintainers. Two-thirds of Maintainers are required for breaking changes. The Project Lead has the tie-breaking vote.
 
-## Who may author normative text
+## Specification Development Process
 
-Normative text is any statement using an RFC 2119 keyword in uppercase: what a conformant implementation MUST, SHOULD or MAY do. A normative change binds every implementation of TRACE, including implementations whose authors are not in the discussion.
+### Pre-Draft
 
-**Normative spec changes require an organizational sponsor.** The sponsor is an organization that implements TRACE, or produces the attestation platform the change concerns, and is willing to be named as accountable for the requirement in the PR. In practice that has meant silicon and cloud attestation vendors, platform and framework implementers, and standards bodies carrying the work forward. Reviewers confirm the sponsorship, not the individual's competence.
+Any Contributor may submit a proposed initial draft document as a candidate Draft Specification of the Project. The Project Lead will designate each submission as a "Pre-Draft" document.
 
-The reason is maintenance cost, not merit. A MUST is a promise the project keeps for every future version. Evaluating whether it can be implemented, at what cost, across which platforms, needs an organization that will actually implement it and answer for it later. Individual authorship gives the project no way to make that assessment and no one to return to when the requirement proves wrong.
+### Draft
 
-**Anyone may propose a normative change.** Open a Spec change proposal issue. Proposals are evaluated on the technical argument alone. If one is accepted without a sponsor, a Maintainer carries the normative PR and the proposer is credited in the CHANGELOG entry. This is a question of who signs the requirement, not whose idea it was.
+Each Pre-Draft document must first be Approved to become a "Draft Specification". Once the Project approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
 
-**No sponsor is required for** editorial changes, examples, conformance tests, tooling, schema changes tracking an already-merged spec change, and informative additions such as crosswalks and mappings to external schemas. Informative text carries no RFC 2119 keywords and binds no implementation, so it is the right home for a mapping that is still settling. Most contributions are in this set.
+A Draft Specification is not stable. Normative requirements, wire formats, and conformance criteria may change, including incompatibly, while a specification is in Draft. Implementers should expect change and should not treat a Draft as a long-lived interoperability target. Every Draft carries this status in its header.
 
-A normative PR opened without a sponsor is not rejected on that basis. Reviewers will say so on the PR and either identify a sponsor or convert it to an informative change.
+### Final
+
+Once the Project believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to "Final" status.
+
+A Final specification is stable. Its normative content does not change except through errata, which are corrections that do not alter what a conformant implementation must do. New requirements are made in a new version, not in the published one. Conformance claims are made against a Final version, and the conformance suite tracks Final versions.
+
+### Deprecated
+
+A Final specification is marked "Deprecated" when it has been superseded and the Project no longer intends to maintain it. A Deprecated version stays published and readable. It receives no further errata, and the Project states in the deprecation notice how long conformance claims against that version continue to be recognized.
+
+### Publication and submission
+
+Upon designation of a Draft Specification as Final, the Project Lead will publish it in a manner agreed upon by the Project Contributors. Publication in a publicly accessible manner must include the terms under which the specification is being made available.
+
+No Draft Specification or Final specification may be submitted to another standards development organization without Approval of the Project. Upon reaching Approval, the Project Lead will coordinate the submission. Project Contributors that developed that specification agree to grant the copyright rights necessary to make those submissions.
+
+## Backward compatibility
+
+TRACE does not break backward compatibility in a Final specification. Implementers build against published requirements, and a requirement that changes underneath them costs them work they did not choose. Additive change is the default: new capability arrives as an optional field, an optional conformance behavior, or a new conformance level, so that an existing conformant implementation stays conformant.
+
+A breaking change is a last resort. The Project will consider one only where the existing requirement cannot be left standing:
+
+- a cryptographic algorithm or construction is broken, or is withdrawn by the body that issued it
+- a requirement creates a security or privacy defect that cannot be corrected compatibly
+- an identifier or wire construct is invalid under the external standard it claims to conform to
+- a requirement is not implementable on a platform within the specification's stated scope
+
+A breaking change carries a minimum 30-day comment period, an explicit backward-compatibility statement naming what breaks and what implementers must do, and Project Lead sign-off. Where the change can be staged, the affected element is marked Deprecated in one version before it is removed in a later one.
+
+Draft specifications are exempt: see [Draft](#draft).
 
 ## Conflict of interest
 
@@ -58,10 +113,14 @@ Maintainers must disclose commercial interest in a proposal before participating
 
 Vendor-co-authored platform-mapping annexes (§4.4 of the spec) are informative. They are reviewed by the vendor author and one TRACE Maintainer. Annexes do not require the full spec-change process.
 
-## Foundation transition
+## Non-Confidential, Restricted Disclosure
 
-TRACE is targeting co-hosting under CoSAI (technical workstream) and the Linux Foundation entity hosting MCP (spec, IP, trademark, conformance mark). On acceptance, governance transitions to a Technical Steering Committee (TSC) as defined in [CHARTER.md](CHARTER.md). Until then, this document is the governance authority.
+Information disclosed in connection with any Project activity, including but not limited to meetings, Contributions, and submissions, is not confidential, regardless of any markings or statements to the contrary. Notwithstanding the foregoing, if the Project is collaborating via a private repository, the Contributors will not make any public disclosures of that information contained in that private repository without the Approval of the Project.
+
+## Linux Foundation hosting
+
+TRACE Specification is hosted at the Linux Foundation as a Series of LF Projects, LLC. Project formation is underway: the Technical Charter and Project Contribution Agreement are being executed with LF Projects, LLC. This document is the governance authority until the Technical Charter takes effect, at which point governance transitions to a Technical Steering Committee as described in [CHARTER.md](CHARTER.md), and the Technical Charter controls where the two differ.
 
 ## Amendments
 
-Amendments to this document require a PR, 14-day comment period, and Project Lead approval.
+Amendments to this document require a PR, a minimum 14-day comment period, and Project Lead approval. Per [General Project Policies](#general-project-policies), governance changes approved under this document must also be approved by LF Projects, LLC.

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,22 @@
-The TRACE specification and this repository use a dual license:
+TRACE Specification, a Series of LF Projects, LLC.
 
-SPECIFICATION TEXT (spec/*.md, README.md, CHANGELOG.md)
-=========================================================
-Creative Commons Attribution 4.0 International (CC BY 4.0)
-https://creativecommons.org/licenses/by/4.0/
-
-You are free to share and adapt the specification text for any purpose,
-including commercial, provided you give appropriate credit, link to the
-license, and indicate if changes were made.
-
-SCHEMA, EXAMPLES, AND CODE (schema/, examples/, .github/)
-==========================================================
+PROJECT LICENSE
+===============
 Apache License, Version 2.0
 https://www.apache.org/licenses/LICENSE-2.0
 
-Copyright 2026 OPAQUE Systems, Inc.
+Except as described below, all code and specification contributions to the
+project are made under the Apache License, Version 2.0 (the "Project
+License"), and all outbound code and specifications are made available under
+the Project License. This covers:
+
+  spec/          specification text
+  schema/        JSON Schema
+  examples/      example Trust Records
+  src/, tests/   reference implementation and tests
+  .github/       workflows and templates
+
+Copyright 2026 OPAQUE Systems, Inc. and the TRACE Specification contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use these files except in compliance with the License.
@@ -28,10 +30,43 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+DOCUMENTATION (EXCLUDING SPECIFICATIONS)
+========================================
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+https://creativecommons.org/licenses/by/4.0/
+
+All documentation other than specification text is made available under
+CC BY 4.0. This covers README.md, CHANGELOG.md, docs/, and the project
+process documents (GOVERNANCE.md, CONTRIBUTING.md, CHARTER.md, and the
+other top-level Markdown files).
+
+You are free to share and adapt this material for any purpose, including
+commercial, provided you give appropriate credit, link to the license, and
+indicate if changes were made.
+
+PRIOR PUBLICATION UNDER CC BY 4.0
+=================================
+Before this policy took effect, TRACE specification text was published under
+CC BY 4.0. Those grants stand:
+
+  spec/trace-v0.1.md is published under CC BY 4.0 and stays under CC BY 4.0.
+  It is a superseded version and is retained for reference.
+
+  Copies of any TRACE specification version already distributed under
+  CC BY 4.0 remain usable under CC BY 4.0 by their recipients. Relicensing
+  is forward-looking and does not withdraw a grant already made.
+
+Portions of spec/trace-v0.1.md carried forward into later specification
+versions remain available under CC BY 4.0 until the contributors of those
+portions have recorded their consent to the Project License. Where both
+licenses apply to the same text, a recipient may rely on either.
+
 PATENT PROMISE
 ==============
 OPAQUE Systems, Inc. grants a royalty-free, worldwide, non-exclusive
 license under any patent claims it controls that are necessarily infringed
 by a conforming implementation of this specification, for the purpose of
 implementing or operating a product that conforms to this specification.
-This promise applies to v0.1 and all subsequent versions of TRACE.
+This promise applies to v0.1 and all subsequent versions of TRACE. It is
+made in addition to, and does not narrow, the patent grant in Section 3 of
+the Apache License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/agentrust-io/cmcp">Reference Impl</a>
 </p>
 
-[![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-lightgrey.svg)](LICENSE)
 [![Spec](https://img.shields.io/badge/Spec-v0.1-0ea5e9)](spec/trace-v0.2.md)
 [![PyPI](https://img.shields.io/pypi/v/agentrust-trace)](https://pypi.org/project/agentrust-trace/)
 [![CI](https://github.com/agentrust-io/trace-spec/actions/workflows/ci.yml/badge.svg)](https://github.com/agentrust-io/trace-spec/actions/workflows/ci.yml)

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -7,7 +7,7 @@
 | Authors | Rishabh Poddar, Aaron Fulkerson (OPAQUE Systems) |
 | Target announcement | Confidential Computing Summit, San Francisco — 23 June 2026 |
 | Reference implementation | [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) — Confidential MCP |
-| License | CC BY 4.0 |
+| License | Apache 2.0 (see [LICENSE](../LICENSE)) |
 
 > **Note:** This is a pre-ratification draft. Fields, wire formats, and conformance requirements are subject to change before v1.0. Send feedback to: open an issue on this repository.
 
@@ -398,7 +398,7 @@ Anthropic, NVIDIA, Intel, AMD, Microsoft, Google, Linux Foundation, Confidential
 
 ### 6.3 IP and licensing
 
-- **Specifications:** CC BY 4.0.
+- **Specifications:** Apache 2.0, the Project License. Text carried forward from v0.1 also remains available under CC BY 4.0.
 - **Reference code:** Apache 2.0.
 - **Test suite:** Apache 2.0, mandatory for conformance claims.
 - **Conformance mark:** managed by host org.


### PR DESCRIPTION
Brings `GOVERNANCE.md` into the shape the Linux Foundation requires to host TRACE Specification as a Series of LF Projects, LLC. Implements the formation guidance from Jory Burson (LF VP of Standards), 7 Aug 2026.

Sources used: the LF formation instructions document (§ "General Project Policies") and [CommunitySpecification/Community_Specification 05-governance.md](https://github.com/CommunitySpecification/Community_Specification/blob/main/05-governance.md).

## Required by LF

The **General Project Policies** block is inserted verbatim at the top of `GOVERNANCE.md`, unedited.

## Community Specification sections

The three sections LF named, with the substitutions requested (`Maintainer` → `Project Lead`, `Working Group Participants` → `Project Contributors`, `Working Group` → `Project`):

- **Decision Making** — consensus-based decision making, appeal process.
- **Specification Development Process** — Pre-Draft, Draft, **Final**, **Deprecated**, each stating what stability it implies for implementers. Community Spec's "Approved Specification" is rendered as **Final**.
- **Non-Confidential, Restricted Disclosure**.

"Ways of Working" (the ANSI due-process section) was not adopted; it was not in the ask.

## Other changes from the review

| Feedback | Change |
|---|---|
| Contributor role wording | Adopted verbatim |
| Project Lead role wording | Adopted verbatim |
| Breaking changes: 14 days is too short, message the conditions | New **Backward compatibility** section. Compatibility is not broken in a Final spec; four conditions listed under which a break would be considered at all; review raised from 14 to **a minimum 30 days**, matching `CHARTER.md` |
| Rephrase fixed periods as "a minimum {N}-day review" | Done for all comment periods. Maintainer *response* targets are left as targets, since "minimum" reads backwards on a commitment we make to contributors |
| Move Normative Text conditions to CONTRIBUTING.md | Moved, led by your sentence. Steps for a normative contribution now listed there |

The **Foundation transition** section is rewritten. It said TRACE was targeting CoSAI and the LF entity hosting MCP, which is not where this is going.

## Licensing: please confirm

Two items for LF, both flagged rather than assumed.

**1. The relicense.** The required language makes Apache-2.0 the Project License for "all code and specification contributions" and puts CC BY 4.0 on "documentation (excluding specifications)". TRACE shipped the inverse: spec text CC BY 4.0, code Apache-2.0. This PR moves to the LF default rather than asking for the Maintainer exception. `LICENSE`, the README badge, `CHARTER.md` §4 and `spec/trace-v0.2.md` are updated. Grants already made under CC BY 4.0 are not withdrawn.

**2. Consent for carried-forward text.** `spec/trace-v0.1.md` includes §3.3.2, contributed by an outside contributor (@carloshvp, #92 and #94) under the CC BY 4.0 terms in force at the time. That text is present in `spec/trace-v0.2.md`. Relicensing it to Apache-2.0 needs their consent, which has not been sought yet. Until it is recorded, `LICENSE` states that portions carried forward from v0.1 remain available under CC BY 4.0 and a recipient may rely on either license. `spec/trace-v0.1.md` itself stays CC BY 4.0 as a superseded version.

Happy to take either as a review comment.

## Not in this PR

- `CHARTER.md` beyond the licensing sentence. LF is supplying the Technical Charter template, so the existing charter is left for that pass.
- `MAINTAINERS.md` needs no change; it already lists the Project Lead, as the new role text requires.