### PR TITLE
Give the homepage a searchable title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,6 +8,21 @@
   Material already emits the canonical link when site_url is set, so it
   is not repeated here.
 #}
+
+{#
+  The homepage is built from README.md, which mkdocs treats as the site index.
+  Material falls back to site_name when a page has no front-matter title, so the
+  homepage was titled with the bare string "TRACE". Front matter is not an option
+  here: README.md is also the GitHub landing page and YAML would render as noise
+  there. Inner pages keep their own titles through super().
+#}
+{% block htmltitle %}
+  {% if page and page.is_homepage %}
+    <title>Hardware-attested receipts for AI agent actions - {{ config.site_name }}</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
 {% block extrahead %}
   {{ super() }}
 


### PR DESCRIPTION
The homepage `<title>` was the bare string `TRACE`.

Material uses `site_name` verbatim when a page has no front-matter title, so the
strongest ranking signal on the site carried no keywords. `site_description`
already says what TRACE is; the title wasted it.

```
before:  TRACE
after:   Hardware-attested receipts for AI agent actions - TRACE
```

Set in a `htmltitle` block, not front matter: the homepage is built from
`README.md`, which is also the GitHub landing page, so YAML front matter would
render as visible noise on the repo. Inner pages keep their own titles via
`super()`.

## Verification

Replicated the CI docs build from `.github/workflows/docs.yml`, including the
`docs_dir` rewrite, rather than a plain `mkdocs build` (which fails on this repo
because current mkdocs rejects `docs_dir: .`).

| Page | Title |
|---|---|
| `/` | Hardware-attested receipts for AI agent actions - TRACE |
| `/docs/` | Home - TRACE |
| a spec page | Trace v0.1 - TRACE |

## Incidental finding, not fixed here

This site serves two homepages: `/` from `README.md` and `/docs/` from
`docs/index.md`, the latter labelled "Home" in the nav. They are only 4% similar
so it is not duplicate content, but the nav "Home" link points at `/docs/` rather
than the site root. Worth a look separately.

Part of an audit across the AgenTrust sites. See agentrust-io/cmcp#480 and
agentrust-io/ca2a#85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)