### PR TITLE
feat(adapters): TraceSandboxAdapter for sandboxed agent runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ### Added
 
+- **`TraceSandboxAdapter`: Trust Records from a sandboxed agent runtime.** A kernel sandbox confines one agent on one machine. It does not answer, on its own, which agent on which of two hundred machines took an action, what actually ran rather than what the policy said, or how to say either on a host with no secure hardware. The adapter builds a record from what such a runtime already has at session close: sandbox identity, image digest, the effective policy bundle bytes, and the decision log. No change to the runtime is required.
+
+  Unlike `TraceAGTAdapter`, one code path spans Level 0 and Level 1. Passing a `SandboxAttestation` moves the record from `software-only` to the attested platform and nothing else about the call changes, because a sandbox runs wherever the customer runs it and the deployments that most need evidence often have the least hardware.
+
+  A caller cannot claim hardware it does not have: `platform` is only ever set from a supplied attestation, an attestation may not name `software-only`, the platform is validated against the enum on `RuntimeInfo` rather than a copy of it, and the measurement must be a `sha256:`/`sha384:` digest. Sandbox identity and image ride the existing `subject` and `build_provenance.digest`, so no schema change was needed.
+
+  Two defaults differ from the AGT adapter, deliberately. `appraisal.status` is `"none"`, because building a record does not appraise it and `affirming` would put a verdict in the field a consumer reads to find out whether anybody checked. `transparency` is `None` and omitted, which is what an unanchored record should say.
+
+  `tool_transcript.hash` is taken over the RFC 8785 canonical form of the decision log rather than `json.dumps(sort_keys=True)`. The two agree on ASCII and diverge on non-ASCII strings and number formatting; a decision log carries paths and hostnames, and the signature pre-image already uses JCS. See `docs/integration/sandbox-runtime.md` and `examples/sandbox-runtime.json`.
+
 - **`verify_record(..., revocation=...)` enforces key revocation at verification time (#76).** §3.2.1 has always required that "Verifiers MUST consult current revocation status at verification time", but `verify_record()` checked only signature and freshness, so a record signed by a revoked or compromised key kept verifying. The new `revocation` parameter accepts either a container of revoked key identifiers or a callable performing a live CRL, status-endpoint, or SCITT lookup. A listed key is rejected, and a store that cannot answer is also rejected: an unavailable revocation source is not evidence that a key is unrevoked.
 
   Keys are identified by RFC 7638 JWK Thumbprint or `kid`. The check reads the *trusted* key rather than `record["cnf"]["jwk"]`, which is attacker-controlled until the signature verifies.

--- a/docs/integration/sandbox-runtime.md
+++ b/docs/integration/sandbox-runtime.md
@@ -1,0 +1,138 @@
+# Integration: sandboxed agent runtimes
+
+A sandboxed agent runtime confines one agent on one machine. Filesystem, process and
+network isolation at the kernel, an egress policy, and credentials injected so the agent
+never holds them. That answers what a single agent may touch.
+
+It does not answer, on its own, three questions that arrive next:
+
+- **Across the estate.** Which agent, on which of the two hundred machines, took that
+  action, and under whose authority?
+- **From a regulator.** Not what the policy said, but what actually ran, evidenced.
+- **From a sovereign or on-prem buyer.** The same answer on a machine with a TPM, or a
+  confidential VM, or no secure hardware at all.
+
+`TraceSandboxAdapter` answers them from what the runtime already has at session close.
+It requires no change to the runtime.
+
+## Install
+
+```
+pip install agentrust-trace
+```
+
+## Quick start
+
+```python
+from pathlib import Path
+from agentrust_trace import TrustRecord, load_signing_key, sign_record
+from agentrust_trace.adapters import SandboxSessionResult, TraceSandboxAdapter
+
+# Configure once per deployment.
+adapter = TraceSandboxAdapter(
+    model_provider="anthropic",
+    model_id="claude-sonnet-4-6",
+    data_class="confidential",
+)
+
+# Per session, from what the runtime already knows at close.
+session = SandboxSessionResult(
+    sandbox_id="spiffe://runtime.example.org/sandbox/code-review-7f2a",
+    image_digest="sha256:5e8b2d1a...",
+    policy_bundle_bytes=Path("sandbox-policy.yaml").read_bytes(),
+    decisions=runtime.decision_log(),
+)
+
+record = sign_record(adapter.build_trust_record(session), load_signing_key())
+TrustRecord.model_validate(record)
+```
+
+That record is Level 0: signed, offline-verifiable, and honest that no hardware backed
+it. `runtime.platform` reads `software-only`.
+
+## Adding a root of trust
+
+Pass a `SandboxAttestation` and the same call emits Level 1. Nothing else changes.
+
+```python
+from agentrust_trace.adapters import SandboxAttestation
+
+session = SandboxSessionResult(
+    ...,
+    attestation=SandboxAttestation(
+        platform="tpm2",                       # or amd-sev-snp, intel-tdx, nvidia-h100, ...
+        measurement="sha256:3b4c2a1f...",      # supplied by the platform, not computed here
+        firmware_version="7.85",
+    ),
+)
+```
+
+This is the point of the adapter spanning both levels. A sandbox runs wherever the
+customer runs it, and the deployments that most need evidence are often the ones with
+the least hardware. One code path covers a developer laptop and a confidential VM.
+
+**The adapter will not let you claim hardware you do not have.** `platform` is only ever
+set from a supplied attestation; an attestation may not name `software-only`; the
+platform is checked against the enum on `RuntimeInfo` rather than a copy of it; and the
+measurement must be a `sha256:` or `sha384:` digest. A record that says `tpm2` therefore
+carries a measurement something other than this process produced.
+
+## Field mapping
+
+| Record field | Source |
+|---|---|
+| `subject` | `sandbox_id`, a SPIFFE URI or DID |
+| `build_provenance.digest` | `image_digest` |
+| `policy.bundle_hash` | SHA-256 of `policy_bundle_bytes` |
+| `tool_transcript.hash` | SHA-256 of the RFC 8785 canonical form of `decisions` |
+| `tool_transcript.call_count` | `len(decisions)`, or `call_count` if given |
+| `runtime.platform` | `software-only`, or the attestation's platform |
+| `runtime.measurement` | `sha256(image_digest + "\n" + bundle_hash)`, or the attestation's measurement |
+
+The hash helpers are public static methods, so a runtime written in another language can
+reproduce them: `TraceSandboxAdapter.bundle_hash`, `.transcript_hash`,
+`.software_measurement`.
+
+## Three things worth getting right
+
+**The policy bundle must be bytes you can reproduce.** The bundle hash is the load
+bearing field: edit the policy and the record changes. Where a runtime composes policy
+from several files, concatenate them in a defined order and keep that order stable. A
+hash both sides derive differently proves nothing.
+
+**The decision log is canonicalised with JCS, not `json.dumps(sort_keys=True)`.** The two
+agree on ASCII and diverge on non-ASCII strings and number formatting, and a decision log
+carries paths and hostnames. Using the same canonicalisation as the signature pre-image
+keeps the record reproducible across implementations.
+
+**An unappraised record says so.** `appraisal.status` defaults to `"none"`. Building a
+record does not appraise it, and stamping `affirming` on an unappraised record puts a
+verdict in the field a consumer reads to find out whether anybody checked. Set it only
+when an appraisal actually happened.
+
+## Levels
+
+| Level | What you pass | `runtime.platform` |
+|---|---|---|
+| 0 | nothing extra | `software-only` |
+| 1 | a `SandboxAttestation` | the attested platform |
+| 2 | Level 1 plus `transparency=` a SCITT receipt URI | the attested platform |
+
+`transparency` defaults to `None`, which leaves the key out of the record. That is
+correct below Level 2: an unanchored record has no receipt to name.
+
+Note: `schema/trace-claim.json` still lists `transparency` in `required`, so an
+unanchored record validates against the model and not against the published JSON Schema.
+That divergence is tracked in `tests/test_sandbox_adapter.py` and is not introduced by
+this adapter.
+
+## Worked example
+
+`examples/sandbox-runtime.json` is a TPM 2.0 rooted record produced by this adapter,
+validating as-is against the schema.
+
+## Related
+
+- [Integration: AGT](agt.md)
+- [Integration: cMCP](cmcp.md)
+- [Trust levels](../trust-levels.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each file is a canonical TRACE v0.1 Trust Record that validates as-is against
 - `intel-tdx.json`: Intel TDX example.
 - `amd-sev-snp.json`: AMD SEV-SNP example.
 - `nvidia-h100.json`: NVIDIA H100 Confidential Computing example.
+- `tpm2.json`: TPM 2.0 example.
+- `sandbox-runtime.json`: a sandboxed agent runtime, TPM 2.0 rooted. Produced by
+  `TraceSandboxAdapter`; the decision log is a kernel-sandbox policy trace rather
+  than MCP tool calls.
 - `action-receipts/`: informative fixture shapes for action-level receipt
   verification. These are not TRACE Trust Records and are not validated against
   `schema/trace-claim.json`.

--- a/examples/sandbox-runtime.json
+++ b/examples/sandbox-runtime.json
@@ -1,0 +1,49 @@
+{
+  "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+  "iat": 1754400000,
+  "subject": "spiffe://runtime.example.org/sandbox/code-review-7f2a",
+  "model": {
+    "provider": "anthropic",
+    "model_id": "claude-sonnet-4-6",
+    "version": "20251001"
+  },
+  "runtime": {
+    "platform": "tpm2",
+    "measurement": "sha256:3b4c2a1f9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2f1e0d9c8b7a6f5e4d3c2b",
+    "rim_uri": "https://registry.agentrust-io.com/rim/sandbox-runtime-v1",
+    "nonce": "c2FuZGJveC1ydW50aW1lLW5vbmNl",
+    "firmware_version": "7.85"
+  },
+  "policy": {
+    "bundle_hash": "sha256:c34cd643f50840b454569674325334f7d374466fd351d0a0053638f5011cf9b6",
+    "enforcement_mode": "enforce",
+    "version": "sandbox-egress-v3.1",
+    "policy_uri": "https://registry.agentrust-io.com/policy/sandbox-egress-v3.1"
+  },
+  "data_class": "confidential",
+  "tool_transcript": {
+    "hash": "sha256:656c14fc7f3f698acdb9f6f14eb3758d685f63bd9e9e221221486dd1d7624969",
+    "call_count": 4
+  },
+  "build_provenance": {
+    "slsa_level": 2,
+    "builder": "https://github.com/example-org/agent-runtime/.github/workflows/release.yml",
+    "digest": "sha256:5e8b2d1a4f7c0e3b6a9d2f5c8e1b4a7d0f3c6e9b2a5d8f1c4e7b0a3d6f9c2e5b",
+    "provenance_uri": "https://rekor.sigstore.dev/api/v1/log/entries/sandbox-example"
+  },
+  "appraisal": {
+    "status": "affirming",
+    "verifier": "https://www.microsoft.com/pkiops/certs/tpm",
+    "policy_ref": "https://registry.agentrust-io.com/policy/tpm2-appraisal-v1",
+    "timestamp": 1754400000
+  },
+  "cnf": {
+    "jwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+      "kid": "sandbox-runtime-key-2026"
+    }
+  },
+  "transparency": "https://registry.agentrust-io.com/claim/sandbox-runtime-7f2a"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ plugins:
         Integration:
           - docs/integration/agt.md
           - docs/integration/cmcp.md
+          - docs/integration/sandbox-runtime.md
         Platforms:
           - docs/platforms/index.md
   - minify:
@@ -192,6 +193,7 @@ nav:
   - Integration:
       - AGT: docs/integration/agt.md
       - cMCP: docs/integration/cmcp.md
+      - Sandboxed agent runtimes: docs/integration/sandbox-runtime.md
   - Platforms:
       - Overview: docs/platforms/index.md
       - AMD SEV-SNP: docs/platforms/amd-sev-snp.md

--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -1,6 +1,12 @@
 """agentrust-trace — TRACE Trust Record models, validation, and signing."""
 
-from agentrust_trace.adapters import AGTSessionResult, TraceAGTAdapter
+from agentrust_trace.adapters import (
+    AGTSessionResult,
+    SandboxAttestation,
+    SandboxSessionResult,
+    TraceAGTAdapter,
+    TraceSandboxAdapter,
+)
 from agentrust_trace.models import (
     Appraisal,
     BuildProvenance,
@@ -35,6 +41,9 @@ __all__ = [
     "__version__",
     "AGTSessionResult",
     "TraceAGTAdapter",
+    "SandboxAttestation",
+    "SandboxSessionResult",
+    "TraceSandboxAdapter",
     "Appraisal",
     "BuildProvenance",
     "ConfirmationKey",

--- a/src/agentrust_trace/adapters/__init__.py
+++ b/src/agentrust_trace/adapters/__init__.py
@@ -1,5 +1,16 @@
 """First-party adapters that map governance framework outputs to TRACE Trust Records."""
 
 from agentrust_trace.adapters.agt import AGTSessionResult, TraceAGTAdapter
+from agentrust_trace.adapters.sandbox import (
+    SandboxAttestation,
+    SandboxSessionResult,
+    TraceSandboxAdapter,
+)
 
-__all__ = ["AGTSessionResult", "TraceAGTAdapter"]
+__all__ = [
+    "AGTSessionResult",
+    "TraceAGTAdapter",
+    "SandboxAttestation",
+    "SandboxSessionResult",
+    "TraceSandboxAdapter",
+]

--- a/src/agentrust_trace/adapters/sandbox.py
+++ b/src/agentrust_trace/adapters/sandbox.py
@@ -1,0 +1,343 @@
+"""TraceSandboxAdapter — maps a sandboxed agent runtime's session output to a Trust Record.
+
+A sandboxed agent runtime confines one agent on one machine: filesystem, process and
+network isolation at the kernel, an egress policy, and credentials injected without the
+agent holding them. That answers what a single agent may touch. It does not answer, on
+its own, what the agent did, under which rules, on which machine, in a form somebody who
+trusts neither the operator nor the vendor can check.
+
+This adapter closes that gap without changing the runtime. It consumes what the runtime
+already has at session close and emits a signed Trust Record::
+
+    session = SandboxSessionResult(
+        sandbox_id="spiffe://runtime.example.org/sandbox/build-7f2a",
+        image_digest="sha256:" + "a" * 64,
+        policy_bundle_bytes=Path("sandbox-policy.yaml").read_bytes(),
+        decisions=runtime.decision_log(),
+    )
+    record = sign_record(adapter.build_trust_record(session), key)
+
+Two things separate this from :class:`~agentrust_trace.adapters.agt.TraceAGTAdapter`,
+and both come from the deployments this was written for.
+
+**It spans Level 0 and Level 1 from one code path.** A sandbox runs wherever the
+customer runs it: a laptop with a TPM, a confidential VM, a machine with no secure
+hardware at all. Passing a :class:`SandboxAttestation` moves the record from
+``software-only`` to the platform that produced the evidence, and nothing else about
+the call changes. An adapter that could only emit Level 0 would force a second code
+path for the deployments that matter most.
+
+**It will not let a caller claim hardware it does not have.** ``platform`` is only ever
+set from a supplied attestation, an attestation may not name ``software-only``, and the
+platform is checked against the enum on :class:`~agentrust_trace.models.RuntimeInfo`
+rather than a copy of it. A record that says ``tpm2`` therefore carries a measurement
+that something other than this process produced.
+
+Sandbox identity and image are carried in the existing v0.2 fields (``subject`` and
+``build_provenance.digest``). A dedicated ``sandbox`` object belongs in a later profile;
+this adapter deliberately needs no schema change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Literal, get_args
+
+import rfc8785
+
+from agentrust_trace.models import (
+    Appraisal,
+    BuildProvenance,
+    ModelInfo,
+    PolicyInfo,
+    RuntimeInfo,
+    ToolTranscript,
+)
+
+__all__ = ["SandboxAttestation", "SandboxSessionResult", "TraceSandboxAdapter"]
+
+# Read the accepted platforms off the model so this cannot drift from the schema when a
+# new platform lands. A hand-maintained copy is exactly the kind of thing that silently
+# rots and then accepts a platform the verifier rejects.
+_PLATFORMS: frozenset[str] = frozenset(
+    get_args(RuntimeInfo.model_fields["platform"].annotation)
+)
+
+# Mirrors TrustRecord.subject. Checked here so a bad identity fails at the adapter with
+# a message naming the field, rather than at model_validate() several steps later.
+_SUBJECT_RE = re.compile(r"^(spiffe://[^/]+/.+|did:[a-z0-9]+:.+)$")
+
+_DIGEST_RE = re.compile(r"^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$")
+
+
+@dataclass(frozen=True)
+class SandboxAttestation:
+    """Hardware evidence for the machine a sandbox ran on.
+
+    Supply this when the host produced attestation evidence. Omit it and the record is
+    Level 0, marked ``software-only``, which is the honest description of a sandbox on
+    a machine with no root of trust.
+    """
+
+    platform: str
+    """One of the platforms accepted by :class:`~agentrust_trace.models.RuntimeInfo`.
+    ``software-only`` is rejected: an attestation that attests nothing is a contradiction,
+    and omitting the attestation says the same thing without the claim."""
+
+    measurement: str
+    """``sha256:`` or ``sha384:`` digest supplied by the platform, not computed here.
+    Becomes ``runtime.measurement``."""
+
+    rim_uri: str | None = None
+    firmware_version: str | None = None
+    nonce: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.platform == "software-only":
+            raise ValueError(
+                "SandboxAttestation.platform must not be 'software-only'. Omit the "
+                "attestation entirely for an unattested sandbox; the adapter then emits "
+                "platform='software-only' with a measurement derived from the image and "
+                "policy digests, which is what an unattested record should say."
+            )
+        if self.platform not in _PLATFORMS:
+            raise ValueError(
+                f"SandboxAttestation.platform {self.platform!r} is not an accepted "
+                f"platform. Accepted: {', '.join(sorted(_PLATFORMS))}."
+            )
+        if not _DIGEST_RE.match(self.measurement):
+            raise ValueError(
+                f"SandboxAttestation.measurement {self.measurement!r} is not a sha256: or "
+                "sha384: digest. It must be the measurement the platform reported, not a "
+                "value computed by this process."
+            )
+
+
+@dataclass
+class SandboxSessionResult:
+    """One sandbox session, as the runtime has it at close.
+
+    Every field is something a sandboxed runtime already knows. Nothing here requires
+    the runtime to be modified to produce it.
+    """
+
+    sandbox_id: str
+    """SPIFFE URI or DID identifying this sandbox instance. Becomes ``subject``."""
+
+    image_digest: str
+    """Digest of the runtime image the sandbox was launched from. Becomes
+    ``build_provenance.digest``."""
+
+    policy_bundle_bytes: bytes
+    """The effective policy bundle, as bytes. Its SHA-256 becomes ``policy.bundle_hash``,
+    so editing the policy changes the record. Where a runtime composes policy from several
+    files, concatenate them in a defined order and keep that order stable: the hash is only
+    worth something if both sides derive it the same way."""
+
+    decisions: list[dict[str, Any]]
+    """The runtime's decision log for the session, as plain dicts. The RFC 8785 canonical
+    form is hashed into ``tool_transcript.hash``."""
+
+    attestation: SandboxAttestation | None = None
+    """Platform evidence, when the host produced any. ``None`` yields a Level 0 record."""
+
+    call_count: int | None = None
+    """Override for ``tool_transcript.call_count``. Defaults to ``len(decisions)``."""
+
+    iat: int = field(default_factory=lambda: int(time.time()))
+    """Issuance timestamp. Defaults to now."""
+
+    def __post_init__(self) -> None:
+        if not _SUBJECT_RE.match(self.sandbox_id):
+            raise ValueError(
+                f"sandbox_id {self.sandbox_id!r} must be a SPIFFE URI "
+                "('spiffe://<trust-domain>/<path>') or a DID ('did:<method>:<id>'). "
+                "It becomes the record subject, which is what a verifier keys on."
+            )
+        if not _DIGEST_RE.match(self.image_digest):
+            raise ValueError(
+                f"image_digest {self.image_digest!r} must be a sha256: or sha384: digest."
+            )
+
+
+class TraceSandboxAdapter:
+    """Build Trust Records from a sandboxed agent runtime's session output.
+
+    Configure once per deployment with the parts that do not change between sessions,
+    then call :meth:`build_trust_record` per session::
+
+        adapter = TraceSandboxAdapter(
+            model_provider="anthropic",
+            model_id="claude-sonnet-4-6",
+            data_class="confidential",
+        )
+        record = adapter.build_trust_record(session)
+        signed = sign_record(record, key)
+
+    The returned dict is unsigned and carries a placeholder ``cnf.jwk``;
+    :func:`~agentrust_trace.sign.sign_record` populates both. Pass the result to
+    ``TrustRecord.model_validate()`` for structural validation.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_provider: str,
+        model_id: str,
+        model_version: str | None = None,
+        data_class: str = "confidential",
+        enforcement_mode: Literal["enforce", "advisory", "silent"] = "enforce",
+        policy_version: str | None = None,
+        policy_uri: str | None = None,
+        build_provenance_slsa_level: int = 0,
+        build_provenance_builder: str | None = None,
+        build_provenance_uri: str | None = None,
+        appraisal_verifier: str = "https://agentrust-io.com/verify",
+        appraisal_status: Literal["affirming", "warning", "contraindicated", "none"] = "none",
+        appraisal_policy_ref: str | None = None,
+        transparency: str | None = None,
+    ) -> None:
+        """
+        Args:
+            appraisal_status: Defaults to ``"none"``. A record is not appraised by being
+                built, and stamping ``affirming`` on an unappraised record puts a verdict
+                in the field a consumer reads to find out whether anybody checked. Set
+                this only when an appraisal actually happened.
+            transparency: SCITT receipt URI. ``None`` means unanchored, which is correct
+                below Level 2 and leaves the key out of the record.
+            build_provenance_slsa_level: Defaults to 0, meaning no provenance claim. Raise
+                it only when a builder genuinely produced the attested level.
+        """
+        self._model = ModelInfo(
+            provider=model_provider, model_id=model_id, version=model_version
+        )
+        self._data_class = data_class
+        self._enforcement_mode = enforcement_mode
+        self._policy_version = policy_version
+        self._policy_uri = policy_uri
+        self._slsa_level = build_provenance_slsa_level
+        self._builder = build_provenance_builder
+        self._provenance_uri = build_provenance_uri
+        self._appraisal_verifier = appraisal_verifier
+        self._appraisal_status = appraisal_status
+        self._appraisal_policy_ref = appraisal_policy_ref
+        self._transparency = transparency
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build_trust_record(self, session: SandboxSessionResult) -> dict[str, Any]:
+        """Return an unsigned Trust Record for *session*.
+
+        Level 0 when ``session.attestation`` is ``None``, Level 1 when it is supplied.
+        """
+        bundle_hash = self.bundle_hash(session.policy_bundle_bytes)
+        runtime = self._runtime(session, bundle_hash)
+
+        record: dict[str, Any] = {
+            "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+            "iat": session.iat,
+            "subject": session.sandbox_id,
+            "model": self._model.model_dump(exclude_none=True),
+            "runtime": runtime.model_dump(exclude_none=True),
+            "policy": PolicyInfo(
+                bundle_hash=bundle_hash,
+                enforcement_mode=self._enforcement_mode,
+                version=self._policy_version,
+                policy_uri=self._policy_uri,
+            ).model_dump(exclude_none=True),
+            "data_class": self._data_class,
+            "tool_transcript": ToolTranscript(
+                hash=self.transcript_hash(session.decisions),
+                call_count=(
+                    session.call_count
+                    if session.call_count is not None
+                    else len(session.decisions)
+                ),
+            ).model_dump(exclude_none=True),
+            "build_provenance": BuildProvenance(
+                slsa_level=self._slsa_level,
+                digest=session.image_digest,
+                builder=self._builder,
+                provenance_uri=self._provenance_uri,
+            ).model_dump(exclude_none=True),
+            "appraisal": Appraisal(
+                status=self._appraisal_status,
+                verifier=self._appraisal_verifier,
+                policy_ref=self._appraisal_policy_ref,
+                timestamp=session.iat,
+            ).model_dump(exclude_none=True),
+            # Placeholder until sign_record() writes the real confirmation key.
+            "cnf": {
+                "jwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                },
+            },
+        }
+        if self._transparency is not None:
+            record["transparency"] = self._transparency
+        return record
+
+    # ------------------------------------------------------------------
+    # Hash helpers, public so a non-Python runtime can reproduce them
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def bundle_hash(policy_bundle_bytes: bytes) -> str:
+        """SHA-256 of the policy bundle bytes, exactly as supplied."""
+        return "sha256:" + hashlib.sha256(policy_bundle_bytes).hexdigest()
+
+    @staticmethod
+    def transcript_hash(decisions: list[dict[str, Any]]) -> str:
+        """SHA-256 over the RFC 8785 canonical form of the decision log.
+
+        JCS, not ``json.dumps(sort_keys=True)``. The two agree on ASCII input and diverge
+        on non-ASCII strings and on number formatting, and a decision log carries
+        user-controlled strings. Using the same canonicalisation as the signature
+        pre-image (see :func:`~agentrust_trace.sign.sign_record`) keeps a record
+        reproducible by an implementation in another language.
+        """
+        return "sha256:" + hashlib.sha256(rfc8785.dumps(decisions)).hexdigest()
+
+    @staticmethod
+    def software_measurement(image_digest: str, bundle_hash: str) -> str:
+        """The measurement for an unattested sandbox.
+
+        ``sha256(image_digest + "\\n" + bundle_hash)`` over UTF-8, both operands in their
+        ``sha256:``-prefixed form. Deliberately simple so another implementation can
+        reproduce it without a JSON library.
+
+        This binds the record to the composition that was observed. It is not hardware
+        evidence and does not pretend to be: the record carries
+        ``platform: "software-only"``, which the model documents as never to be mistaken
+        for hardware-backed evidence.
+        """
+        return (
+            "sha256:"
+            + hashlib.sha256(f"{image_digest}\n{bundle_hash}".encode()).hexdigest()
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _runtime(self, session: SandboxSessionResult, bundle_hash: str) -> RuntimeInfo:
+        att = session.attestation
+        if att is None:
+            return RuntimeInfo(
+                platform="software-only",
+                measurement=self.software_measurement(session.image_digest, bundle_hash),
+            )
+        return RuntimeInfo(
+            platform=att.platform,  # type: ignore[arg-type]
+            measurement=att.measurement,
+            rim_uri=att.rim_uri,
+            firmware_version=att.firmware_version,
+            nonce=att.nonce,
+        )

--- a/tests/test_sandbox_adapter.py
+++ b/tests/test_sandbox_adapter.py
@@ -1,0 +1,370 @@
+"""Unit tests for TraceSandboxAdapter, SandboxSessionResult and SandboxAttestation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, get_args
+
+import pytest
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from pydantic import ValidationError
+
+from agentrust_trace import (
+    RuntimeInfo,
+    TrustRecord,
+    generate_key,
+    key_to_jwk,
+    sign_record,
+    validate_json,
+    verify_record,
+)
+from agentrust_trace.adapters import (
+    SandboxAttestation,
+    SandboxSessionResult,
+    TraceSandboxAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SANDBOX_ID = "spiffe://runtime.example.org/sandbox/build-7f2a"
+IMAGE_DIGEST = "sha256:" + "a" * 64
+BUNDLE_BYTES = b"network:\n  egress: deny-all\nfilesystem:\n  write: /work\n"
+DECISIONS: list[dict[str, Any]] = [
+    {"tool": "fs.read", "path": "/work/src", "decision": "permit"},
+    {"tool": "net.connect", "host": "api.example.org", "decision": "deny"},
+]
+TPM_MEASUREMENT = "sha256:" + "b" * 64
+TRANSPARENCY = "https://registry.agentrust-io.com/claim/sandbox-abc123"
+
+
+def _make_adapter(**overrides: Any) -> TraceSandboxAdapter:
+    defaults: dict[str, Any] = {
+        "model_provider": "anthropic",
+        "model_id": "claude-sonnet-4-6",
+        "model_version": "20251001",
+        "data_class": "confidential",
+    }
+    defaults.update(overrides)
+    return TraceSandboxAdapter(**defaults)
+
+
+def _make_session(**overrides: Any) -> SandboxSessionResult:
+    defaults: dict[str, Any] = {
+        "sandbox_id": SANDBOX_ID,
+        "image_digest": IMAGE_DIGEST,
+        "policy_bundle_bytes": BUNDLE_BYTES,
+        "decisions": DECISIONS,
+    }
+    defaults.update(overrides)
+    return SandboxSessionResult(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Structural validity
+# ---------------------------------------------------------------------------
+
+def test_build_produces_a_structurally_valid_record() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    TrustRecord.model_validate(record)
+
+
+def test_record_carries_the_session_identity_and_image() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    assert record["subject"] == SANDBOX_ID
+    assert record["build_provenance"]["digest"] == IMAGE_DIGEST
+
+
+def test_signed_record_verifies_against_the_trusted_key() -> None:
+    key = generate_key()
+    record = sign_record(_make_adapter().build_trust_record(_make_session()), key)
+    verify_record(record, key_to_jwk(key))
+    TrustRecord.model_validate(record)
+
+
+def test_a_tampered_record_fails_verification() -> None:
+    """The point of signing: editing the policy hash after the fact must not verify."""
+    key = generate_key()
+    record = sign_record(_make_adapter().build_trust_record(_make_session()), key)
+    record["policy"]["bundle_hash"] = "sha256:" + "f" * 64
+    with pytest.raises(InvalidSignature):
+        verify_record(record, key_to_jwk(key))
+
+
+# ---------------------------------------------------------------------------
+# 2. Level 0: no attestation
+# ---------------------------------------------------------------------------
+
+def test_without_attestation_the_record_is_software_only() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    assert record["runtime"]["platform"] == "software-only"
+
+
+def test_software_measurement_binds_image_and_policy() -> None:
+    """The Level 0 measurement must be reproducible from its two named inputs."""
+    record = _make_adapter().build_trust_record(_make_session())
+    bundle_hash = TraceSandboxAdapter.bundle_hash(BUNDLE_BYTES)
+    expected = (
+        "sha256:"
+        + hashlib.sha256(f"{IMAGE_DIGEST}\n{bundle_hash}".encode()).hexdigest()
+    )
+    assert record["runtime"]["measurement"] == expected
+
+
+def test_software_measurement_changes_with_the_policy() -> None:
+    """Editing the policy must move the measurement, or it is not binding anything."""
+    a = _make_adapter().build_trust_record(_make_session())
+    b = _make_adapter().build_trust_record(
+        _make_session(policy_bundle_bytes=BUNDLE_BYTES + b"  extra: true\n")
+    )
+    assert a["runtime"]["measurement"] != b["runtime"]["measurement"]
+    assert a["policy"]["bundle_hash"] != b["policy"]["bundle_hash"]
+
+
+def test_software_measurement_changes_with_the_image() -> None:
+    a = _make_adapter().build_trust_record(_make_session())
+    b = _make_adapter().build_trust_record(
+        _make_session(image_digest="sha256:" + "c" * 64)
+    )
+    assert a["runtime"]["measurement"] != b["runtime"]["measurement"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Level 1: attestation supplied
+# ---------------------------------------------------------------------------
+
+def test_attestation_sets_platform_and_measurement_verbatim() -> None:
+    session = _make_session(
+        attestation=SandboxAttestation(platform="tpm2", measurement=TPM_MEASUREMENT)
+    )
+    record = _make_adapter().build_trust_record(session)
+    assert record["runtime"]["platform"] == "tpm2"
+    assert record["runtime"]["measurement"] == TPM_MEASUREMENT
+    TrustRecord.model_validate(record)
+
+
+def test_attestation_optional_fields_reach_the_record() -> None:
+    session = _make_session(
+        attestation=SandboxAttestation(
+            platform="amd-sev-snp",
+            measurement=TPM_MEASUREMENT,
+            rim_uri="https://example.org/rim/1",
+            firmware_version="1.55",
+            nonce="bm9uY2U",
+        )
+    )
+    runtime = _make_adapter().build_trust_record(session)["runtime"]
+    assert runtime["rim_uri"] == "https://example.org/rim/1"
+    assert runtime["firmware_version"] == "1.55"
+    assert runtime["nonce"] == "bm9uY2U"
+
+
+def test_the_same_session_is_level_0_or_level_1_by_attestation_alone() -> None:
+    """One code path spans both levels. Only the attestation differs."""
+    adapter = _make_adapter()
+    level0 = adapter.build_trust_record(_make_session())
+    level1 = adapter.build_trust_record(
+        _make_session(attestation=SandboxAttestation("tpm2", TPM_MEASUREMENT))
+    )
+    assert level0["policy"] == level1["policy"]
+    assert level0["tool_transcript"] == level1["tool_transcript"]
+    assert level0["runtime"]["platform"] != level1["runtime"]["platform"]
+
+
+# ---------------------------------------------------------------------------
+# 4. A caller must not be able to claim hardware it does not have
+# ---------------------------------------------------------------------------
+
+def test_attestation_rejects_software_only_as_a_platform() -> None:
+    with pytest.raises(ValueError, match="must not be 'software-only'"):
+        SandboxAttestation(platform="software-only", measurement=TPM_MEASUREMENT)
+
+
+def test_attestation_rejects_an_unknown_platform() -> None:
+    with pytest.raises(ValueError, match="is not an accepted platform"):
+        SandboxAttestation(platform="totally-secure-enclave", measurement=TPM_MEASUREMENT)
+
+
+@pytest.mark.parametrize(
+    "measurement",
+    ["not-a-digest", "sha256:short", "", "md5:" + "a" * 32, "sha256:" + "A" * 64],
+)
+def test_attestation_rejects_a_measurement_that_is_not_a_digest(measurement: str) -> None:
+    with pytest.raises(ValueError, match="is not a sha256: or sha384: digest"):
+        SandboxAttestation(platform="tpm2", measurement=measurement)
+
+
+def test_accepted_platforms_are_read_from_the_model() -> None:
+    """Guards against a hand-maintained copy drifting from RuntimeInfo."""
+    from agentrust_trace.adapters.sandbox import _PLATFORMS
+
+    assert _PLATFORMS == frozenset(
+        get_args(RuntimeInfo.model_fields["platform"].annotation)
+    )
+    assert "software-only" in _PLATFORMS  # accepted by the model, refused by attestation
+
+
+# ---------------------------------------------------------------------------
+# 5. Session input validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "sandbox_id",
+    ["build-7f2a", "https://example.org/sandbox/1", "spiffe://example.org", "", "did:x"],
+)
+def test_sandbox_id_must_be_a_spiffe_uri_or_did(sandbox_id: str) -> None:
+    with pytest.raises(ValueError, match="must be a SPIFFE URI"):
+        _make_session(sandbox_id=sandbox_id)
+
+
+@pytest.mark.parametrize("sandbox_id", [SANDBOX_ID, "did:web:example.org:sandbox:1"])
+def test_valid_sandbox_ids_are_accepted(sandbox_id: str) -> None:
+    assert _make_session(sandbox_id=sandbox_id).sandbox_id == sandbox_id
+
+
+def test_image_digest_must_be_a_digest() -> None:
+    with pytest.raises(ValueError, match="must be a sha256: or sha384: digest"):
+        _make_session(image_digest="latest")
+
+
+def test_a_bad_sandbox_id_fails_at_the_adapter_not_at_model_validate() -> None:
+    """The error names the field, rather than surfacing several steps later."""
+    with pytest.raises(ValueError, match="sandbox_id"):
+        _make_session(sandbox_id="build-7f2a")
+
+
+# ---------------------------------------------------------------------------
+# 6. Transcript hashing uses JCS
+# ---------------------------------------------------------------------------
+
+def test_transcript_hash_is_jcs_over_the_decision_log() -> None:
+    expected = "sha256:" + hashlib.sha256(rfc8785.dumps(DECISIONS)).hexdigest()
+    assert TraceSandboxAdapter.transcript_hash(DECISIONS) == expected
+
+
+def test_transcript_hash_diverges_from_naive_sorted_json_on_non_ascii() -> None:
+    """The reason JCS is used rather than json.dumps(sort_keys=True).
+
+    A decision log carries user-controlled strings. json.dumps with ensure_ascii escapes
+    non-ASCII to \\uXXXX; JCS emits raw UTF-8. Two implementations that disagree here
+    produce different transcript hashes for the same log, and cross-language verification
+    breaks.
+    """
+    decisions = [{"tool": "fs.read", "path": "/work/café", "decision": "permit"}]
+    naive = (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(
+                decisions, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            ).encode()
+        ).hexdigest()
+    )
+    assert TraceSandboxAdapter.transcript_hash(decisions) != naive
+
+
+def test_transcript_hash_is_stable_under_key_order() -> None:
+    a = [{"tool": "fs.read", "decision": "permit"}]
+    b = [{"decision": "permit", "tool": "fs.read"}]
+    assert TraceSandboxAdapter.transcript_hash(a) == TraceSandboxAdapter.transcript_hash(b)
+
+
+def test_call_count_defaults_to_the_decision_count_and_can_be_overridden() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    assert record["tool_transcript"]["call_count"] == len(DECISIONS)
+
+    record = _make_adapter().build_trust_record(_make_session(call_count=99))
+    assert record["tool_transcript"]["call_count"] == 99
+
+
+def test_an_empty_decision_log_is_representable() -> None:
+    record = _make_adapter().build_trust_record(_make_session(decisions=[]))
+    assert record["tool_transcript"]["call_count"] == 0
+    TrustRecord.model_validate(record)
+
+
+# ---------------------------------------------------------------------------
+# 7. Appraisal is not claimed by default
+# ---------------------------------------------------------------------------
+
+def test_appraisal_status_defaults_to_none() -> None:
+    """Building a record does not appraise it, so the field must not say it did."""
+    record = _make_adapter().build_trust_record(_make_session())
+    assert record["appraisal"]["status"] == "none"
+
+
+def test_appraisal_status_is_configurable_when_one_actually_happened() -> None:
+    record = _make_adapter(appraisal_status="affirming").build_trust_record(
+        _make_session()
+    )
+    assert record["appraisal"]["status"] == "affirming"
+
+
+def test_slsa_level_defaults_to_zero() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    assert record["build_provenance"]["slsa_level"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. Transparency
+# ---------------------------------------------------------------------------
+
+def test_transparency_is_absent_when_unanchored() -> None:
+    record = _make_adapter().build_trust_record(_make_session())
+    assert "transparency" not in record
+
+
+def test_transparency_is_present_when_configured() -> None:
+    record = _make_adapter(transparency=TRANSPARENCY).build_trust_record(_make_session())
+    assert record["transparency"] == TRANSPARENCY
+    validate_json(record)
+
+
+def test_an_anchored_record_passes_the_published_json_schema() -> None:
+    record = _make_adapter(transparency=TRANSPARENCY).build_trust_record(
+        _make_session(attestation=SandboxAttestation("tpm2", TPM_MEASUREMENT))
+    )
+    validate_json(sign_record(record, generate_key()))
+
+
+def test_unanchored_record_is_model_valid_but_the_json_schema_still_requires_transparency() -> None:
+    """Documents a live divergence between the model and schema/trace-claim.json.
+
+    0.5.1 made ``transparency`` optional on the model, because a Level 0 or Level 1
+    record is not anchored and has no receipt to name. The published JSON Schema still
+    lists ``transparency`` in ``required``. Until that is reconciled, an unanchored
+    record validates against the model and not against the schema.
+
+    This test exists so the divergence is visible and fails loudly the day it is fixed,
+    rather than being rediscovered by a downstream implementer.
+    """
+    import jsonschema
+
+    record = _make_adapter().build_trust_record(_make_session())
+    TrustRecord.model_validate(record)
+    with pytest.raises(jsonschema.ValidationError, match="transparency"):
+        validate_json(record)
+
+
+# ---------------------------------------------------------------------------
+# 9. Determinism
+# ---------------------------------------------------------------------------
+
+def test_the_same_session_builds_the_same_record() -> None:
+    adapter = _make_adapter()
+    session = _make_session(iat=1800000000)
+    assert adapter.build_trust_record(session) == adapter.build_trust_record(session)
+
+
+def test_enforcement_mode_reaches_the_record() -> None:
+    record = _make_adapter(enforcement_mode="advisory").build_trust_record(
+        _make_session()
+    )
+    assert record["policy"]["enforcement_mode"] == "advisory"
+
+
+def test_an_invalid_enforcement_mode_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _make_adapter(enforcement_mode="whatever").build_trust_record(_make_session())


### PR DESCRIPTION
## What this changes

Adds `TraceSandboxAdapter`, a first-party adapter that builds Trust Records from a **sandboxed agent runtime**: the class of runtime that confines one agent on one machine with kernel isolation (Landlock, seccomp), an egress policy, and injected credentials.

That confinement answers what a single agent may touch. It does not answer, on its own:

- **across the estate** — which agent, on which of two hundred machines, took an action, under whose authority
- **from a regulator** — not what the policy said, but what actually ran, evidenced
- **from a sovereign or on-prem buyer** — the same answer on a TPM host, a confidential VM, or a machine with no secure hardware

The adapter answers all three from what the runtime already has at session close. **No change to the runtime is required**, and no schema change was needed.

## Design notes

**One code path spans Level 0 and Level 1.** `TraceAGTAdapter` hardcodes `software-only`. This adapter takes an optional `SandboxAttestation`; supplying it moves the record to the attested platform and nothing else about the call changes. A sandbox runs wherever the customer runs it, and the deployments that most need evidence often have the least hardware. An adapter that could only emit Level 0 would force a second code path for exactly those.

**A caller cannot claim hardware it does not have.** `platform` is only ever set from a supplied attestation; an attestation may not name `software-only`; the platform is checked against `get_args(RuntimeInfo.model_fields["platform"].annotation)` rather than a hand-maintained copy, with a test guarding the drift; and the measurement must be a `sha256:`/`sha384:` digest. A record reading `tpm2` therefore carries a measurement something other than this process produced.

**Two defaults differ from the AGT adapter, deliberately.**

- `appraisal.status` defaults to `"none"`, not `"affirming"`. Building a record does not appraise it, and `affirming` would put a verdict in the field a consumer reads to find out whether anybody checked.
- `transparency` defaults to `None` and is omitted. That is what an unanchored record should say below Level 2.

**`tool_transcript.hash` uses RFC 8785, not `json.dumps(sort_keys=True)`.** The two agree on ASCII and diverge on non-ASCII strings and number formatting. A decision log carries paths and hostnames, and `sign.py` already canonicalises the signature pre-image with JCS for the reason its docstring gives. A test asserts the divergence on non-ASCII input so the choice is not silently reverted.

Sandbox identity and image ride the existing `subject` and `build_provenance.digest`. A dedicated `sandbox` object belongs in a later profile.

## Type of change

- [ ] Editorial (typo, link fix, clarification — no normative effect)
- [x] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [x] Example addition

Additive only. No normative text, no schema field, no existing behaviour altered.

## Spec section

None modified. `docs/integration/sandbox-runtime.md` is a new informative integration guide alongside `agt.md` and `cmcp.md`.

## Testing

43 new tests, 148 passing overall. Coverage includes: structural validity and sign/verify round trip; a tampered record failing verification; the Level 0 measurement being reproducible from its two named inputs and moving when either changes; attestation fields reaching the record verbatim; every rejection path for a dishonest platform or measurement claim; the platform-enum drift guard; JCS vs naive-sorted-JSON divergence on non-ASCII; key-order stability; determinism.

## Two pre-existing issues surfaced, not introduced

1. **`transparency` model/schema divergence.** 0.5.1 made `transparency` optional on the model because an unanchored record has no receipt to name, but `schema/trace-claim.json` still lists it in `required`. An unanchored record therefore validates against the model and not against the published schema. `test_unanchored_record_is_model_valid_but_the_json_schema_still_requires_transparency` documents this and will fail loudly the day it is reconciled, rather than being rediscovered downstream. Happy to split the schema fix into its own PR.

2. **`ruff check src` reports `UP038` in `sign.py:356`** on `main`, unrelated to this change. Left alone to keep this PR additive.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [x] `CHANGELOG.md` updated
- [ ] Breaking changes marked — n/a
- [ ] Backward compatibility statement — n/a, additive only
- [x] `examples/sandbox-runtime.json` generated by the adapter and validated against `schema/trace-claim.json`
- [x] `ruff` and `mypy` clean on all changed files
- [x] mkdocs nav updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
