### PR TITLE
chore(release): 0.6.0, and stop __version__ drifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-08-07
+
+### Fixed
+
+- **`__version__` reported the wrong number for four releases.** It was a literal that drifted from `pyproject.toml` at #36 and was never corrected, so v0.3.0, v0.4.0, v0.5.0 and v0.5.1 each shipped a wheel reporting `0.2.0` at runtime. Anyone pinning or logging on `agentrust_trace.__version__` got the wrong answer, and nothing failed. It now derives from installed package metadata, which makes the two unable to disagree, and `tests/test_version.py` pins the source tree against `pyproject.toml` and requires the changelog to carry a section for the declared version before a tag is cut.
+
+- **The package description advertised TRACE v0.1.** The PyPI summary still named the superseded profile.
+
 ### Added
 
 - **`TraceSandboxAdapter`: Trust Records from a sandboxed agent runtime.** A kernel sandbox confines one agent on one machine. It does not answer, on its own, which agent on which of two hundred machines took an action, what actually ran rather than what the policy said, or how to say either on a host with no secure hardware. The adapter builds a record from what such a runtime already has at session close: sandbox identity, image digest, the effective policy bundle bytes, and the decision log. No change to the runtime is required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentrust-trace"
-version = "0.5.1"
-description = "TRACE v0.1 — hardware-attested governance records for AI agents"
+version = "0.6.0"
+description = "TRACE v0.2 — hardware-attested governance records for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -1,5 +1,7 @@
 """agentrust-trace — TRACE Trust Record models, validation, and signing."""
 
+from importlib import metadata as _metadata
+
 from agentrust_trace.adapters import (
     AGTSessionResult,
     SandboxAttestation,
@@ -36,7 +38,17 @@ from agentrust_trace.validate import (
     validate_json,
 )
 
-__version__ = "0.2.0"
+try:
+    __version__ = _metadata.version("agentrust-trace")
+except _metadata.PackageNotFoundError:  # source tree, not installed
+    __version__ = "0.0.0+unknown"
+"""Read from installed package metadata rather than hardcoded.
+
+A literal here drifted from ``pyproject.toml`` at #36 and stayed wrong through
+v0.3.0, v0.4.0, v0.5.0 and v0.5.1, so four releases reported ``0.2.0`` at runtime.
+Deriving it from the metadata makes that class of drift impossible; a test pins the
+two together for the source tree.
+"""
 
 __all__ = [
     "__version__",

--- a/src/agentrust_trace/sign.py
+++ b/src/agentrust_trace/sign.py
@@ -400,7 +400,7 @@ def verify_record(
     # Freshness: bound the age of the record against its issued-at timestamp.
     if max_age_seconds is not None:
         iat = record.get("iat")
-        if not isinstance(iat, (int, float)) or isinstance(iat, bool):
+        if not isinstance(iat, int | float) or isinstance(iat, bool):
             raise ValueError("record has no valid integer 'iat' for freshness check")
         age = time.time() - iat
         if age > max_age_seconds:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,86 @@
+"""The package version must be one number, in one place.
+
+``__version__`` was a literal that drifted from ``pyproject.toml`` at #36 and was never
+corrected, so v0.3.0, v0.4.0, v0.5.0 and v0.5.1 each shipped a wheel reporting ``0.2.0``
+at runtime. Anyone pinning or logging on ``agentrust_trace.__version__`` got the wrong
+answer, and nothing failed.
+
+It now derives from installed package metadata, so a built artifact cannot disagree with
+itself. These tests guard the parts that are still possible to get wrong: reintroducing a
+hardcoded literal, bumping ``pyproject.toml`` without cutting a changelog section, or
+tagging a version that is not semver.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import tomllib
+from importlib import metadata
+
+import pytest
+
+import agentrust_trace
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_PYPROJECT = _ROOT / "pyproject.toml"
+_INIT = _ROOT / "src" / "agentrust_trace" / "__init__.py"
+
+
+def _declared_version() -> str:
+    with _PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+def test_version_is_not_hardcoded() -> None:
+    """The regression that shipped four wrong releases: a literal in the source.
+
+    Environment independent, unlike comparing the two numbers, so this is the test that
+    actually holds the line.
+    """
+    source = _INIT.read_text(encoding="utf-8")
+    literal = re.search(r'^__version__\s*=\s*["\']\d+\.\d+\.\d+', source, re.MULTILINE)
+    assert literal is None, (
+        "__version__ is assigned a hardcoded version literal. Derive it from package "
+        "metadata instead; a literal here drifted from pyproject.toml for four releases "
+        "and nothing caught it."
+    )
+
+
+def test_declared_version_is_semver() -> None:
+    assert re.fullmatch(r"\d+\.\d+\.\d+", _declared_version())
+
+
+def test_changelog_documents_the_declared_version() -> None:
+    """A release absent from the changelog is a release nobody can read.
+
+    The tag is what publishes to PyPI, so this has to fail before the tag, not after.
+    """
+    declared = _declared_version()
+    changelog = (_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert f"## [{declared}]" in changelog, (
+        f"CHANGELOG.md has no '## [{declared}]' section. Cut the release section before "
+        "tagging."
+    )
+
+
+def test_module_version_matches_pyproject() -> None:
+    """Meaningful only when the installed distribution is this source tree.
+
+    CI installs with ``pip install -e .``, so it runs. A working copy with a stale wheel
+    from PyPI alongside it would otherwise report a mismatch that says nothing about the
+    code under test, so that case is skipped rather than failed.
+    """
+    try:
+        dist = metadata.distribution("agentrust-trace")
+    except metadata.PackageNotFoundError:
+        pytest.skip("agentrust-trace is not installed in this environment")
+
+    installed_root = pathlib.Path(str(dist.locate_file("agentrust_trace"))).resolve()
+    if installed_root != (_ROOT / "src" / "agentrust_trace").resolve():
+        pytest.skip(
+            f"installed distribution resolves to {installed_root}, not this source "
+            "tree; the comparison would test the environment, not the code"
+        )
+
+    assert agentrust_trace.__version__ == _declared_version()


### PR DESCRIPTION
## What this changes

Cuts **0.6.0** and fixes a version bug that has been shipping for four releases.

## The bug

`__version__` was a hardcoded literal. It drifted from `pyproject.toml` at #36 and was never corrected, so **v0.3.0, v0.4.0, v0.5.0 and v0.5.1 each published a wheel reporting `0.2.0` at runtime**. Anyone pinning or logging on `agentrust_trace.__version__` got the wrong answer, and nothing anywhere failed.

It now derives from installed package metadata, so a built artifact cannot disagree with itself.

`tests/test_version.py` guards what is still possible to get wrong:

- **`test_version_is_not_hardcoded`** — the actual regression, and environment independent, so it is the test that holds the line
- **`test_changelog_documents_the_declared_version`** — the tag is what publishes to PyPI, so a missing changelog section has to fail *before* the tag
- **`test_declared_version_is_semver`**
- **`test_module_version_matches_pyproject`** — skips unless the installed distribution resolves to this source tree, since a working copy with a stale PyPI wheel alongside it would otherwise report a mismatch that says nothing about the code

## What is in 0.6.0

| PR | |
|---|---|
| #130 | `TraceSandboxAdapter` for sandboxed agent runtimes |
| #125 | `verify_record()` enforces the v0.2 profile cutover |
| #126 | Portable RFC 8785 conformance vectors |
| #122 | Conformance vectors for seven unexercised receipt rules |
| #98 | Acta decision receipts crosswalk |
| this | Version fix, description fix |

## Why MINOR and not MAJOR

#125 makes `verify_record()` reject records it previously accepted, which looks breaking. Under this project's own policy MAJOR means "breaking changes to wire format or required Trust Record fields", and #125 changes neither: it enforces a cutover `spec/trace-v0.2.md` §2 already declared normative and the changelog already announced. MINOR is the right call, and the behaviour change is prominent in the 0.6.0 notes.

## Also

- Package description said "TRACE v0.1"; the PyPI summary has been advertising the superseded profile.
- One `isinstance` call in `sign.py` modernised (UP038). The pinned CI ruff does not flag it yet, a current ruff does, and a routine dependency bump would otherwise turn CI red.

## Checklist

- [x] DCO sign-off
- [x] `CHANGELOG.md` section cut for 0.6.0
- [x] 190 passed, 1 skipped; ruff and mypy clean
- [ ] Tag `v0.6.0` after merge, which triggers `publish.yml` and OIDC trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
