### PR TITLE
docs(roadmap): bring the roadmap up to what actually shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,39 +1,39 @@
 # Roadmap
 
-## Now — v0.1 draft (June 2026)
+Status as of August 2026. Spec **v0.2** is current ([`spec/trace-v0.2.md`](spec/trace-v0.2.md)); the `agentrust-trace` reference SDK is at **0.6.0** and the conformance suite (`agentrust-io/trace-tests`) at **0.4.1**.
 
-Announced at Confidential Computing Summit, San Francisco, June 23 2026.
+## Shipped — v0.2 (July–August 2026)
 
-**In scope:**
-- Full Trust Record schema: `subject`, `model`, `runtime`, `policy`, `data_class`, `tool_transcript`, `build_provenance`, `appraisal`, `transparency`, `cnf`
-- Wire formats: EAT/JWT and CBOR-COSE
-- Hardware roots: NVIDIA H100/Blackwell, Intel TDX, AMD SEV-SNP, Azure MAA, GCP Confidential Space, AWS Nitro
-- JSON Schema and three hardware examples
-- Reference implementation: cMCP Phase 1 (Cedar policy enforcement, TRACE Level 2 emission)
+- **EAT profile URI cutover** to `tag:agentrust-io.com,2026:trace-v0.2`. The v0.1 identifier named a domain this project never controlled, which RFC 4151 does not permit, so it was invalid rather than misspelled. A v0.2 verifier requires the new URI and rejects the old one; `verify_record()` enforces the cutover before any cryptographic work. Records issued under v0.1 stay verifiable against `spec/trace-v0.1.md` and the published 0.4.x releases.
+- **`delegation` link block** (`parent_record_hash` + `credential_id`), optional and additive. A chain of records linked this way forms an offline-verifiable delegation DAG. This is the foundation the A2A profile binds to, not the profile itself.
+- **`transparency` is optional below Level 2.** A Level 0 or Level 1 record is unanchored and has no receipt to name; that state was previously unrepresentable.
+- **`azure-cvm-sev-snp` platform**, distinct from `amd-sev-snp`, because Azure runs SEV-SNP behind a Hyper-V paravisor and the runtime binding rides a vTPM AK-signed quote rather than a guest-controlled `REPORT_DATA`. A consumer keying on `runtime.platform` can tell the two roots apart.
+- **Revocation at verification time** (`verify_record(..., revocation=...)`). §3.2.1 always required it; the verifier did not do it. A revocation source that cannot answer is rejected rather than treated as a pass.
+- **OWASP Agentic AI Top 10 cross-walk** — [`docs/crosswalks/owasp-agentic-top-10.md`](docs/crosswalks/owasp-agentic-top-10.md).
+- **Acta decision-receipt cross-walk** — [`docs/crosswalks/acta-decision-receipts.md`](docs/crosswalks/acta-decision-receipts.md).
+- **Producer adapters** for AGT, cMCP, and sandboxed agent runtimes, one code path spanning Level 0 and Level 1.
+- **Platform bindings documented** for AMD SEV-SNP, Intel TDX, and NVIDIA H100 ([`docs/platforms/`](docs/platforms/)). This SDK verifies the record; verification of the attestation evidence itself lives in `cmcp` and `agent-manifest`, both of which have been run against genuine hardware quotes.
+- **Reference implementation.** cMCP enforces Cedar policy inside the TEE and emits signed GatewayClaims carrying `policy`, `data_class`, and `tool_transcript`.
 
-**Not in v0.1:** MCP profile (normative), A2A profile, vendor platform annexes, OWASP/ATLAS cross-walks, encrypted claims envelope.
+## Next — v0.3
 
-## Next — v0.2 (Q3 2026)
-
-Driven by founding-member feedback and open questions from §7 of the spec.
-
-- **MCP profile** — normative claim shape and binding rules for MCP tool-call transcripts (`tool_transcript`); proposed for upstream contribution to MCP spec governance
-- **A2A profile** — same, for Google Agent-to-Agent. The optional `delegation` link block (`parent_record_hash` + `credential_id`) has landed in the record as the foundation; A2A is now stable at v1.x, so the normative binding rules are the remaining work
-- **Vendor platform annexes** — co-authored informative claim-mapping docs for NVIDIA NRAS, Intel Trust Authority, AMD CoRIM, Azure MAA, GCP Confidential Space
-- **OWASP Agentic AI Top 10 cross-walk** — which TRACE claim evidences which control for each of the 10 ASIs
-- **MITRE ATLAS cross-walk** — TRACE claim coverage mapped to relevant ATLAS tactics
-- **Encrypted claims envelope** — normative profile for JWE / COSE-Encrypt when `data_class` requires confidential transport to verifiers (open question §7 Q5)
-- **Reference to IETF AIIP** — coordinate with draft-ritz-aiip and determine disposition (open question §7 Q7)
-- **cMCP Phase 2** — policy enforcement and `tool_transcript` binding; first full Trust Records
+- **MCP profile (normative)** — claim shape and binding rules for MCP tool-call transcripts. The `tool_transcript` claim exists and is bound; what is missing is the normative rule set, for upstream contribution to MCP spec governance.
+- **A2A profile (normative)** — binding rules over the `delegation` block now that A2A is stable at v1.x, including the mutual case. cA2A is the reference implementation.
+- **Anchor and inclusion-proof format** — the normative format that lets a third party verify an anchor without trusting the registry operator. Specified but not published; the registry repository is private. This is the gap that makes "verifiable without trusting the operator" a claim about the future rather than the present, and it is the highest priority item on this page. Tracked in [#111](https://github.com/agentrust-io/trace-spec/issues/111).
+- **Attested memory and persistent state** — a claim for agent memory integrity at runtime, digesting the whole store rather than a manifest of it. Nothing in the ecosystem measures agent memory today; every runtime treats the agent as stateless between actions.
+- **MITRE ATLAS cross-walk** — TRACE claim coverage mapped to relevant ATLAS tactics.
+- **Encrypted claims envelope** — normative profile for JWE / COSE-Encrypt where `data_class` requires confidential transport to verifiers (open question §7 Q5).
+- **Vendor platform annexes** — co-authored informative claim-mapping docs for NVIDIA NRAS, Intel Trust Authority, AMD CoRIM, Azure MAA, GCP Confidential Space. Co-editor seats are open (§4.4); the informative platform docs in `docs/platforms/` are ours, not vendor-co-authored.
+- **Disposition on IETF AIIP** — coordinate with `draft-ritz-aiip`: absorb, supersede, or coexist (open question §7 Q7).
 
 ## Later — v1.0 standard (2027)
 
-- TSC governance under CoSAI / Linux Foundation
+- TSC governance at the standards home (AAIF under the Linux Foundation; §6.1 of the spec predates that decision and is corrected separately)
 - All §7 open questions resolved
 - Complete conformance certification program
 - Post-quantum signature profile (ML-DSA, tracking NIST SP 800-208)
-- MCP and A2A profiles ratified and proposed to respective upstream governance bodies
-- AAIF-assigned canonical profile URI replacing the provisional v0.1 tag URI
+- MCP and A2A profiles ratified and proposed to their respective upstream governance bodies
+- A canonical profile URI assigned by the standards home, replacing the provisional tag URI
 - Multi-language verification libraries (Python, TypeScript, Go, Rust)
 
 ## What TRACE will not do
@@ -45,4 +45,4 @@ Driven by founding-member feedback and open questions from §7 of the spec.
 
 ## Influencing the roadmap
 
-Open a GitHub issue with the `spec` or `roadmap` label. Contributor and community feedback from the CC Summit period (June–September 2026) has priority for v0.2 scope.
+Open a GitHub issue with the `spec` or `roadmap` label. Items land here when they are implemented and tested, not when they are planned; anything above the "Next" line is exercisable today.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Status as of August 2026. Spec **v0.2** is current ([`spec/trace-v0.2.md`](spec/
 
 ## Later — v1.0 standard (2027)
 
-- TSC governance at the standards home (AAIF under the Linux Foundation; §6.1 of the spec predates that decision and is corrected separately)
+- TSC governance under "TRACE Specification, a Series of LF Projects, LLC" (formation in progress, see [#127](https://github.com/agentrust-io/trace-spec/pull/127); §6.1 of the spec still names the superseded CoSAI plus LF-MCP-entity plan and is corrected there)
 - All §7 open questions resolved
 - Complete conformance certification program
 - Post-quantum signature profile (ML-DSA, tracking NIST SP 800-208)


### PR DESCRIPTION
Response-plan list 1, P1.

`ROADMAP.md` opened with "Now — v0.1 draft (June 2026)" and listed the MCP profile, the A2A profile and cMCP Phase 2 under "Next — v0.2 (Q3 2026)". The repo ships spec v0.2, SDK 0.6.0, and a 0.4.1 conformance suite. The roadmap is the second file a serious evaluator opens and it said the project was two months behind where it is.

## What changed

Now/Next/Later re-cut against the code rather than against the plan.

**Shipped** now lists what landed: the profile URI cutover and its enforcement in `verify_record()`, the `delegation` link block, `transparency` optional below Level 2, the `azure-cvm-sev-snp` platform, revocation at verification time, the OWASP and Acta cross-walks, and the AGT/cMCP/sandbox producer adapters.

**Two corrections of substance**, not just dates:

- The `delegation` block is described as the foundation the A2A profile binds to, not as the profile. The normative binding rules are the outstanding work, and the old text let a reader conclude otherwise.
- The anchor and inclusion-proof format (#111) is named as the highest-priority item on the page. Until it publishes, "verifiable without trusting the operator" is a claim about the future, and the roadmap should say so where an evaluator will read it.

**One accuracy fix.** The platform bullet describes what this repo does: the SDK verifies the record; verification of attestation evidence lives in `cmcp` and `agent-manifest`.

Added to Next: attested memory and persistent state, per the response plan.

## Follow-up not in this PR

Two places in `spec/trace-v0.2.md` are stale in the same way and need their own change:

- §4.1 still says the MCP and A2A profiles are "targeted for v0.2", and §7 is headed "These need input before v0.2".
- §6.1 names CoSAI plus the LF entity hosting MCP as the proposed host. The org profile now names AAIF under the Linux Foundation as the single path (agentrust-io/.github#28). This roadmap notes the discrepancy rather than quietly resolving it, since normative spec text is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
