### PR TITLE
docs: correct the standards home and the profile-status text in three places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Changed
+
+- **The spec, the README and the roadmap named three different standards homes between them.** §6.1 proposed splitting TRACE between CoSAI and the Linux Foundation entity hosting MCP; the README said "Targeting AAIF"; neither is where this is going. TRACE is being formed at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC" (see #127). §6.1 is rewritten, the README line is corrected, and §7 Q1 is marked resolved rather than deleted so a reader tracking it can see how it landed.
+
+- **§4.1 described the MCP and A2A profiles as "targeted for v0.2" in the v0.2 document.** Neither shipped in v0.2. Both are now stated as targeted for v0.3, and the A2A entry says what did land: the `delegation` link block, as the foundation the binding rules will attach to. §7 Q6 (A2A timing) is marked resolved, since A2A stabilizing at v1.x was the blocker it asked about.
+
+- **§7 was headed "These need input before v0.2".** Now v1.0. No normative text, schema, or record field changed.
+
 ## [0.6.0] — 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ signed = sign_record(record, key=signing_key)
 
 ## Standards alignment
 
-Targeting the [Agentic AI Foundation (AAIF)](https://agenticai.foundation) at the Linux Foundation. Active standardization track in [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
+Being formed at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC". Related standardization track in [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
 
 ## Frequently asked questions
 

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -19,7 +19,7 @@ One normative change, and it is breaking.
 
 `agentrust.io` was never a domain this project controlled; it resolves to third-party parked addresses. RFC 4151 permits a tag URI only where the minting authority controlled the named domain on the stated date, so the v0.1 identifier was not merely misspelled, it was invalid: it asserted authority over a name belonging to someone else, who could at any point stand up a conflicting definition at it.
 
-Everything else in this document is unchanged from v0.1. No field was added, removed, or re-typed.
+Everything else in the record format is unchanged from v0.1. No field was added, removed, or re-typed. The non-normative sections have moved on: §6.1 now names the Linux Foundation series as the host, and §7 marks two open questions resolved.
 
 **Cutover, not coexistence.** A v0.2 verifier MUST require `tag:agentrust-io.com,2026:trace-v0.2` and MUST reject the v0.1 identifier. It MUST NOT accept both. A dual-accepting verifier would leave the invalid identifier live indefinitely, which is the thing being fixed, and would let a record minted under a domain we do not own continue to pass as conformant.
 
@@ -331,8 +331,8 @@ TRACE is a **profile**, not a parallel stack. It binds existing primitives into 
 - **SPIFFE / SPIRE** — workload identity. The SVID is bound to the TEE measurement so identity is rooted in hardware.
 - **SCITT** — append-only transparency log. TRACE defines a SCITT profile for Trust Record inclusion (Signed Statement registration, Receipt format, key rotation semantics).
 - **EAR (draft-ietf-rats-ar4si)** — verifier output format. Separates *what was claimed* from *what was accepted*.
-- **MCP** — Model Context Protocol tool surface. TRACE adds (a) cryptographic binding of the transcript hash into the EAT envelope and (b) a per-call `data_class` classification. MCP profile targeted for v0.2.
-- **A2A** — Agent-to-Agent communication. TRACE adds transcript binding and cross-protocol identity threading via SPIFFE SVID. A2A profile targeted for v0.2.
+- **MCP** — Model Context Protocol tool surface. TRACE adds (a) cryptographic binding of the transcript hash into the EAT envelope and (b) a per-call `data_class` classification. The normative MCP profile is not in this version; it is targeted for v0.3.
+- **A2A** — Agent-to-Agent communication. TRACE adds transcript binding and cross-protocol identity threading via SPIFFE SVID. The `delegation` link block (§3.1) landed in v0.2 as the foundation; the normative A2A binding rules are targeted for v0.3.
 - **AIBOM (SPDX 3.0 AI Profile, CycloneDX 1.7 ML-BOM)** — component inventory for models, datasets, dependencies. Referenced by digest from `model`.
 - **C2PA** — adjacent, not absorbed. Where a TRACE'd execution produces media, the output may carry a C2PA manifest that references the Trust Record.
 
@@ -384,11 +384,13 @@ the reference implementation at the MCP tool-call boundary.
 
 ## 6. Governance
 
-### 6.1 Proposed host
+### 6.1 Host
 
-**CoSAI** (Coalition for Secure AI) for the technical workstream; the **Linux Foundation entity hosting the Model Context Protocol** for spec, IP, trademark, and conformance mark. Co-locating TRACE governance with the protocol whose attestation surface TRACE most directly profiles inherits LF's IP and trademark machinery.
+**The Linux Foundation**, as its own series: "TRACE Specification, a Series of LF Projects, LLC". Formation is in progress; on completion, governance transitions to a Technical Steering Committee as defined in `CHARTER.md`, and spec, IP, trademark, and conformance mark sit with the series.
 
-Other standards bodies participate as technical-liaison partners: OpenSSF (SLSA stewardship), CNCF (SPIFFE/SPIRE stewardship), IETF (RATS, EAT, SCITT, EAR working groups).
+This supersedes the earlier proposal to split the technical workstream to CoSAI and the spec, IP and trademark to the Linux Foundation entity hosting the Model Context Protocol. That arrangement made TRACE a guest of two hosts, neither of which owned the conformance mark outright.
+
+Other standards bodies participate as technical-liaison partners: OpenSSF (SLSA stewardship), CNCF (SPIFFE/SPIRE stewardship), IETF (RATS, EAT, SCITT, EAR working groups), CoSAI (WS4 interoperability).
 
 ### 6.2 Target contributing organizations
 
@@ -407,14 +409,14 @@ Anthropic, NVIDIA, Intel, AMD, Microsoft, Google, Linux Foundation, Confidential
 
 ## 7. Open Questions
 
-These need input before v0.2:
+These need input before v1.0. Two are now resolved and are kept here, marked, so a reader tracking them can see how they landed.
 
-1. **Host organization.** CoSAI, Linux Foundation, or a federated arrangement?
+1. ~~**Host organization.** CoSAI, Linux Foundation, or a federated arrangement?~~ **Resolved:** the Linux Foundation, as TRACE's own series. See §6.1.
 2. **AI-agent profile vs general profile.** One inclusive profile or split agent execution and generic confidential workload from day one?
 3. **Transparency log operator(s).** One canonical SCITT log, federated logs, or BYO with conformance criteria?
 4. **Policy language.** TRACE binds a policy *hash*. Does v1.0 also specify a policy *language* (Cedar, Rego, custom DSL), or stay language-agnostic?
 5. **Privacy of the record.** Records may contain sensitive classifications. Standardize encrypted-claims envelope (JWE / COSE-Encrypt) from v1.0?
-6. **A2A profile timing.** Ship A2A as a peer profile to MCP in v1.0, or wait for A2A to stabilize?
+6. ~~**A2A profile timing.** Ship A2A as a peer profile to MCP in v1.0, or wait for A2A to stabilize?~~ **Resolved:** A2A is stable at v1.x, which cleared the blocker. The `delegation` link block landed in v0.2 and the normative binding rules are targeted for v0.3, as a peer profile to MCP.
 7. **Relationship to IETF AIIP.** Absorb, supersede, or coexist with draft-ritz-aiip?
 
 ---


### PR DESCRIPTION
Stale-text sweep, follow-up to #132.

## Standards home

Three documents named three different homes. `spec/trace-v0.2.md` §6.1 proposed splitting TRACE between CoSAI (technical workstream) and the LF entity hosting MCP (spec, IP, trademark); `README.md` said "Targeting AAIF"; the roadmap said something else again. None is where this is going.

TRACE is being formed at the Linux Foundation as its own series, **"TRACE Specification, a Series of LF Projects, LLC"**, which #127 is preparing `GOVERNANCE.md` for. §6.1 is rewritten and says what it supersedes and why. The README line is corrected. CoSAI stays named as a technical-liaison partner, which is accurate.

## Profile status

§4.1 described the MCP and A2A profiles as "targeted for v0.2" **inside the v0.2 document**. Neither shipped in v0.2. Both now say v0.3, and the A2A entry names what did land: the `delegation` link block, as the foundation the binding rules attach to.

## Open questions

§7 was headed "These need input before v0.2" in v0.2. Now v1.0. Q1 (host organization) and Q6 (A2A profile timing) are marked resolved **in place with strikethrough rather than deleted**, so anyone tracking those questions can see how they landed. The remaining five are untouched.

## Deliberately not changed

§6.3 still says CC BY 4.0 for specifications. The LF General Project Policies block makes Apache-2.0 the project license for code *and* specifications, but that relicense is a live question on #127 with a contributor-consent dependency. Not something to change quietly in a sweep.

No normative text, schema, or record field changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)