### PR TITLE
docs(spec): publish the registry anchor and inclusion-proof format (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Added
+
+- **`spec/registry-anchor-v1.md`: the registry anchor and inclusion-proof format is now public (#111).** The format was already normative and already written so a conforming verifier could be built from it alone, but it lived in `trace-registry`, which is private. The effect was that the one document an external verifier needs was the one they could not read, and an inclusion proof nobody outside can check is not transparency. It is published here, in the public spec home, as @l33tdawg proposed in the discussion that raised this.
+
+  §0 leads with the trap, because it is the one that costs an implementer a day and gives no useful error: TRACE canonicalizes with **RFC 8785 (JCS)** for *signing* and with **sorted-key JSON** for the *anchor leaf*. The two agree on ASCII-only records with integer numbers, which is most records, which is exactly what makes assuming JCS at the leaf dangerous.
+
+  §8 states conformance, including the requirement that the append-only property be externally checkable rather than asserted. An operator that issues verifiable proofs but publishes nothing an outsider can audit is running a log, not a transparency log.
+
+### Fixed
+
+- **Four documents told readers to send signed records to a domain this project does not own.** `docs/integration/agt.md`, `docs/integration/cmcp.md`, `docs/trust-levels.md` and `docs/verification.md` still named `registry.agentrust.io`, which resolves to third-party parked addresses. This is the same defect the v0.2 profile cutover fixed in the identifier, missed in the prose. Moved to `registry.agentrust-io.com`, which is what the SDK's adapters already emit. The v0.1 spec keeps its original values; it is a superseded document and a record of what was published.
+
+- **The anchoring tutorial documented an API that does not exist.** It instructed readers to POST signed Trust Records to a SCITT HTTP endpoint at the parked domain above and to read a `receipt_uri` from the response. There is no such endpoint. Rewritten against the actual mechanism: submit to staging, retrieve an inclusion proof, and verify that proof yourself against the published entry. It also still described `transparency` as a required string, which 0.5.1 changed. The page carries a dated note saying what it used to say, because anyone who built against it deserves to know nothing they sent was received.
+
 ### Changed
 
 - **The spec, the README and the roadmap named three different standards homes between them.** §6.1 proposed splitting TRACE between CoSAI and the Linux Foundation entity hosting MCP; the README said "Targeting AAIF"; neither is where this is going. TRACE is being formed at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC" (see #127). §6.1 is rewritten, the README line is corrected, and §7 Q1 is marked resolved rather than deleted so a reader tracking it can see how it landed.

--- a/docs/integration/agt.md
+++ b/docs/integration/agt.md
@@ -45,7 +45,7 @@ adapter = TraceAGTAdapter(
     model_id="claude-sonnet-4-6",
     model_version="20251001",
     build_provenance_digest="sha256:e5f6a7b8...",
-    transparency="https://registry.agentrust.io/claim/...",
+    transparency="https://registry.agentrust-io.com/claim/...",
 )
 
 session = AGTSessionResult(

--- a/docs/integration/cmcp.md
+++ b/docs/integration/cmcp.md
@@ -114,7 +114,7 @@ Or let cMCP push it to the transparency registry automatically:
 # cmcp.yaml
 trace:
   emit: true
-  registry: https://registry.agentrust.io
+  registry: https://registry.agentrust-io.com
   scitt_anchor: true
 ```
 

--- a/docs/trust-levels.md
+++ b/docs/trust-levels.md
@@ -81,7 +81,7 @@ Level 2 adds a SCITT transparency log entry to a Level 1 record. The `transparen
 |-------|-------------|
 | `transparency` | Resolvable `https://` URI to a SCITT receipt |
 
-The [SCITT reference implementation](https://github.com/microsoft/scitt-api-emulator) and the [agentrust SCITT registry](https://registry.agentrust.io) are both supported anchors.
+The [SCITT reference implementation](https://github.com/microsoft/scitt-api-emulator) and the [agentrust SCITT registry](https://registry.agentrust-io.com) are both supported anchors.
 
 **Recommended flow:**
 

--- a/docs/tutorials/anchoring-to-the-registry.md
+++ b/docs/tutorials/anchoring-to-the-registry.md
@@ -1,44 +1,43 @@
 # Anchoring a Trust Record to the TRACE registry
 
-After signing a Trust Record, you should anchor it to the TRACE transparency registry. The anchor receipt proves that the record existed at a specific time and has not been altered since — tamper evidence that holds even if the operator who produced the record is later compromised.
+After signing a Trust Record, you can anchor it to the TRACE transparency registry. The anchor proves the record existed at a specific time and has not been altered since, which is tamper evidence that holds even if the operator who produced the record is later compromised.
 
 **What you need:** A signed Trust Record (from [Signing your first trust record](signing-your-first-trust-record.md)).
 
-**What you'll do:** Submit the record to the registry, receive a SCITT receipt, and set the `transparency` field to the canonical receipt URI.
+**What you'll do:** Submit the record, get back an inclusion proof, and check that proof yourself against the published registry entry.
+
+!!! warning "This tutorial was rewritten on 2026-08-08"
+    It previously described POSTing records to a SCITT HTTP API at a registry endpoint. That endpoint does not exist, and the hostname it named was on a domain this project has never controlled, the same defect that forced the [v0.2 profile URI cutover](../../spec/trace-v0.2.md). Anchoring works as described below. If you built against the old page, nothing you sent was received by us.
 
 ---
 
 ## Why transparency anchoring matters
 
-A Trust Record carries a signature from the issuer's key. A verifier holding that key can confirm the record has not been modified — but only if the key is trustworthy. If the issuer is later compromised, an attacker could forge records backdated to before the compromise.
+A Trust Record carries a signature from the issuer's key. A verifier holding that key can confirm the record has not been modified, but only if the key is trustworthy. If the issuer is later compromised, an attacker holding the key could forge records backdated to before the compromise.
 
-The `transparency` field solves this with a different trust root: an append-only log operated by an independent party. Once a record is registered, its content is fixed in the log at that timestamp. A verifier checks that the record's digest matches the log entry — no trust in the operator required.
+Anchoring solves this with a different trust root: an append-only log whose history a third party can inspect. Once a record is anchored, its exact bytes are fixed in the log at that timestamp. A verifier recomputes the Merkle root from the record and its proof and compares it to the published entry. No trust in the operator is required, and no call back to the issuer is needed.
 
-TRACE uses SCITT ([draft-ietf-scitt-architecture](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/)) as its transparency log substrate.
+The normative format is [TRACE Registry Anchor Format v1](../../spec/registry-anchor-v1.md). Read §0 of it before you implement anything: TRACE uses **RFC 8785 (JCS)** to canonicalize a record for *signing* and **sorted-key JSON** to canonicalize it for the *anchor leaf*. Assuming JCS at the leaf produces proofs that never verify, and the failure has no useful diagnostic.
 
 ---
 
 ## The `transparency` field
 
-In the `TrustRecord` schema, `transparency` is a required string:
+In the `TrustRecord` schema, `transparency` is optional below Level 2:
 
 ```python
-transparency: Annotated[str, Field(min_length=1)]
+transparency: str | None
 ```
 
-It holds the canonical URI of the registry entry — the URL at which any verifier can independently retrieve the SCITT receipt and confirm the record's inclusion.
+`None` means the record is unanchored, which is the honest state for a Level 0 or Level 1 record. An empty string is rejected: `""` is not a URI, and a field that looks populated but resolves to nothing is worse in a trust record than an absent one.
 
-Example value from the spec:
-
-```
-https://registry.agentrust-io.com/claim/trace-2026-06-23T09:15:42Z-f2a8d1
-```
+Where present, it identifies the registry entry anchoring the record. At Level 2 and above, a verifier must be able to retrieve that entry and check inclusion without contacting you.
 
 ---
 
-## Step 1 — Build and sign the record with a placeholder
+## Step 1 — Sign the record
 
-During development, use a placeholder for `transparency` so you can construct and sign a valid record before anchoring:
+Sign as normal. You do not need a placeholder for `transparency`; leave it unset until you have an anchor.
 
 ```python
 import time
@@ -50,115 +49,80 @@ record = {
     "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
     "iat": int(time.time()),
     "subject": "spiffe://example.org/agent/my-agent",
-    "model": {
-        "provider": "anthropic",
-        "model_id": "claude-sonnet-4-6",
-    },
-    "runtime": {
-        "platform": "software-only",
-        "measurement": "sha256:" + "0" * 64,
-    },
-    "policy": {
-        "bundle_hash": "sha256:" + "a" * 64,
-        "enforcement_mode": "enforce",
-    },
+    "model": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+    "runtime": {"platform": "software-only", "measurement": "sha256:" + "0" * 64},
+    "policy": {"bundle_hash": "sha256:" + "a" * 64, "enforcement_mode": "enforce"},
     "data_class": "internal",
-    "build_provenance": {
-        "slsa_level": 0,
-        "digest": "sha256:" + "b" * 64,
-    },
-    "appraisal": {
-        "status": "none",
-        "verifier": "self",
-    },
-    # Placeholder — replace after anchoring
-    "transparency": "pending",
+    "build_provenance": {"slsa_level": 0, "digest": "sha256:" + "b" * 64},
+    "appraisal": {"status": "none", "verifier": "self"},
 }
 
 signed = sign_record(record, key)
 ```
 
-!!! note
-    `transparency: "pending"` is valid for local development. Production records MUST carry a real receipt URI before being handed to a verifier that enforces §3.3 step 6.
+!!! note "The anchored unit is the signed object"
+    Anchoring binds the complete signed claim, signature included. Change either the body or the signature after anchoring and the proof stops verifying, which is the property you want.
 
 ---
 
-## Step 2 — Submit to the registry
+## Step 2 — Submit the record
 
-!!! info "No SDK client yet"
-    The `agentrust_trace` SDK does not yet include a registry client. Submit directly via HTTP using the SCITT Reference API ([draft-ietf-scitt-scrapi](https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/)). A Python client will be added to the SDK in a future release.
+Producers submit signed records to the registry's staging area, one JSON file per record. The anchor pipeline runs on a schedule, groups pending records by producer, builds one Merkle batch per group, and writes both the registry entry and one inclusion proof per record.
 
-Submit the signed record as a SCITT Signed Statement:
+You do not have to use the reference registry. Anything implementing [Anchor Format v1 §8](../../spec/registry-anchor-v1.md) works, and running your own is a reasonable choice for a deployment that cannot publish record bytes to a third party.
 
-```python
-import json
-import requests  # pip install requests
+---
 
-REGISTRY_URL = "https://registry.agentrust.io"
+## Step 3 — Retrieve your inclusion proof
 
-response = requests.post(
-    f"{REGISTRY_URL}/entries",
-    headers={"Content-Type": "application/json"},
-    data=json.dumps(signed),
-    timeout=30,
-)
-response.raise_for_status()
+The pipeline writes one proof per submitted record:
 
-entry = response.json()
-# entry contains the registry-assigned receipt URI
-receipt_uri = entry["receipt_uri"]
-print(f"Anchored: {receipt_uri}")
+```json
+{"leaf_index": 0, "audit_path": ["sha256:...", "sha256:..."]}
 ```
 
-The registry returns a JSON object with at minimum:
-
-| Field | Description |
-|---|---|
-| `receipt_uri` | Canonical URL of the SCITT receipt — use this as `transparency` |
-| `entry_id` | Registry-internal identifier for the log entry |
-| `registered_at` | ISO 8601 timestamp of registration |
+`leaf_index` is your record's position in the batch. `audit_path` is the sibling hash at each tree level, ordered leaf to root. A batch of one has an empty `audit_path`, which is valid and not an error.
 
 ---
 
-## Step 3 — Set `transparency` and re-sign
+## Step 4 — Verify the proof yourself
 
-Replace the placeholder and re-sign the record with the real receipt URI:
+This is the step that matters, and the one most likely to be skipped. A proof you have never checked is a receipt, not evidence.
+
+```bash
+pip install trace-verify
+
+trace-verify \
+  --claim your-record.json \
+  --proof your-record.proof.json \
+  --entry registry/2026/06/12.ndjson \
+  --batch-id 2026-06-12-001
+```
+
+Exit code 0 means the record is proven included in that batch. Exit code 1 means it is not, and there is no partial result between the two.
+
+The verifier is standard library only and small enough to read in one sitting. Read it, or reimplement it from [Anchor Format v1 §5.1](../../spec/registry-anchor-v1.md), which is written so you can. Verifying with a tool the registry operator wrote is better than nothing, and weaker than verifying with one you wrote.
+
+---
+
+## Step 5 — Set `transparency`
+
+Once anchored, set `transparency` to the entry that anchors your record and re-sign, so the signature covers the anchor reference.
 
 ```python
-record["transparency"] = receipt_uri
+record["transparency"] = "<registry entry URI>"
 signed_final = sign_record(record, key)
 ```
 
-The signature now covers the real `transparency` value. A verifier who later retrieves the receipt from `receipt_uri` can confirm the digest matches — without contacting the original operator.
+A verifier retrieving that entry can confirm inclusion without contacting you, which is the whole point.
 
 ---
 
-## Step 4 — Verify the receipt (optional, recommended)
+## What this proves, and what it does not
 
-To confirm the registry accepted the record correctly, retrieve and inspect the receipt:
+Inclusion proves the exact signed bytes were in the batch at the entry's timestamp, and that they have not changed since.
 
-```python
-receipt_resp = requests.get(receipt_uri, timeout=30)
-receipt_resp.raise_for_status()
-receipt = receipt_resp.json()
-
-# The receipt contains the log entry digest and a Merkle inclusion proof.
-# Check that it references your record's content.
-assert receipt["subject"] == signed_final["subject"]
-assert receipt["iat"] == signed_final["iat"]
-```
-
-A full cryptographic Merkle proof verification is not yet in the SDK. The registry exposes the raw proof fields for implementers who want to verify inclusion independently.
-
----
-
-## Verification step 6
-
-When a verifier calls `verify_record()`, it checks the signature. Step 6 of the TRACE verification procedure (spec §3.3) additionally requires the transparency receipt to resolve:
-
-> SCITT receipt resolves on the named transparency log.
-
-A verifier configured with `require_transparency: true` will retrieve `transparency` and check the digest against the log. Verifiers that skip this step accept a weaker guarantee — signature-only, not log-anchored.
+It does not validate the signature, and it does not say the record's contents are true. Signature verification against the producer key is a separate step (spec §3.3). A record can be genuinely anchored and still describe something inaccurate; anchoring establishes *when these bytes existed*, and nothing more.
 
 ---
 
@@ -166,7 +130,8 @@ A verifier configured with `require_transparency: true` will retrieve `transpare
 
 | Step | What happens |
 |---|---|
-| Build record with `"pending"` | Valid locally, not for production hand-off |
-| POST to registry | SCITT log records the digest at this timestamp |
-| Replace `transparency`, re-sign | Signature now covers the real receipt URI |
-| Verifier retrieves receipt URI | Tamper evidence independent of operator trust |
+| Sign the record | `transparency` stays unset until there is an anchor to name |
+| Submit to staging | The pipeline batches by producer and builds a Merkle tree |
+| Retrieve the proof | `leaf_index` plus `audit_path`, one per record |
+| **Verify it yourself** | Recompute the root; exit 0 or exit 1, nothing in between |
+| Set `transparency`, re-sign | Signature now covers the anchor reference |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -144,7 +144,7 @@ If `transparency` is set, the record is anchored in an append-only transparency 
 
 ```bash
 agentrust-trace verify-scitt session.trace.json \
-  --transparency-log https://registry.agentrust.io
+  --transparency-log https://registry.agentrust-io.com
 ```
 
 A valid SCITT receipt proves the record was included in the log and cannot be retroactively removed or modified.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,7 +189,9 @@ nav:
       - Integration with cMCP: docs/tutorials/integrating-with-cmcp.md
       - Anchor to the registry: docs/tutorials/anchoring-to-the-registry.md
       - Verify the tool transcript: docs/tutorials/verifying-the-audit-chain.md
-  - Specification: spec/trace-v0.2.md
+  - Specification:
+      - TRACE v0.2: spec/trace-v0.2.md
+      - Registry Anchor Format v1: spec/registry-anchor-v1.md
   - Integration:
       - AGT: docs/integration/agt.md
       - cMCP: docs/integration/cmcp.md

--- a/spec/registry-anchor-v1.md
+++ b/spec/registry-anchor-v1.md
@@ -1,0 +1,159 @@
+# TRACE Registry Anchor Format v1
+
+| Field | Value |
+|---|---|
+| Version | 1 |
+| Status | Normative companion to [TRACE v0.2](trace-v0.2.md) |
+| Applies to | The `transparency` claim (TRACE v0.2 §3.1) and Level 2 conformance |
+| License | CC BY 4.0 |
+
+This document specifies how TRACE Trust Records are anchored into an append-only registry, and how a third party verifies, **without trusting the registry operator**, that a given record was included in an anchor.
+
+It is published here rather than only in the registry implementation for a reason that matters more than tidiness: an inclusion proof nobody outside can check is not transparency. A conforming verifier can be written from this document alone. The reference tooling named in §7 is one implementation, not the definition.
+
+The construction follows [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962) (Certificate Transparency) Merkle trees; the inclusion-proof check is the [RFC 9162](https://www.rfc-editor.org/rfc/rfc9162) algorithm.
+
+---
+
+## 0. The canonicalization trap, before anything else
+
+**TRACE uses two different canonicalizations at two different layers, and they are not interchangeable.**
+
+| Layer | Canonicalization | Specified in |
+|---|---|---|
+| Signing a Trust Record | **RFC 8785 (JCS)** | TRACE v0.2 §3.2 |
+| Hashing a record into an anchor leaf | **Sorted-key JSON**, defined in §1 below | this document |
+
+An implementer who reasonably assumes JCS at the leaf will produce proofs that never verify, and the failure gives no useful diagnostic: the recomputed root simply differs from the published one, with nothing to indicate why.
+
+The two agree on records whose strings and keys are pure ASCII and whose numbers are integers, which is most records, which is exactly what makes this dangerous. They diverge on non-ASCII strings, where JCS emits the character and §1 emits a `\uXXXX` escape, and on non-integer numbers, where JCS applies ECMAScript number serialization. §1 excludes non-integer numbers from this profile for that reason.
+
+Do not "simplify" a verifier by reusing the signing canonicalizer at the leaf. If you do, write a test that anchors a record containing a non-ASCII character and verifies it, which is the test that catches this.
+
+---
+
+## 1. Canonical claim bytes
+
+The unit of anchoring is the **complete signed claim object, signature included**. Anchoring binds the signed artifact, not a pre-signature payload: if either the claim body or its signature changes, the anchor no longer matches.
+
+`canonical_claim_bytes` is the canonical JSON serialization of the claim object:
+
+- Object keys sorted lexicographically by Unicode code point, recursively.
+- Separators `","` and `":"`, no whitespace.
+- Non-ASCII characters escaped (`ensure_ascii`); output encoded as ASCII bytes.
+- No trailing newline.
+
+In Python this is exactly:
+
+```python
+json.dumps(claim, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii")
+```
+
+Claims MUST be JSON objects. TRACE Trust Records contain only strings, integers, booleans, nulls, arrays, and objects; claims containing non-integer numbers are outside this profile, because cross-language float serialization is not canonical.
+
+## 2. Leaf hash
+
+```
+leaf = SHA-256(0x00 || canonical_claim_bytes)
+```
+
+The `0x00` domain-separation prefix is the RFC 6962 leaf prefix. It prevents an interior node from being presented as a leaf (second-preimage attack).
+
+## 3. Merkle tree
+
+The tree over the ordered list of leaves is the RFC 6962 Merkle Tree Hash:
+
+- A tree of one leaf has root equal to that leaf hash.
+- Interior nodes: `node = SHA-256(0x01 || left || right)`, where `left` and `right` are the 32-byte child hashes and `0x01` is the interior prefix.
+- Construction proceeds level by level over the ordered leaves: adjacent pairs are hashed together; when a level has an odd number of nodes, the final node is **promoted unchanged** to the next level. It is NOT duplicated. This yields the same tree as the RFC 6962 recursive split at the largest power of two.
+- The empty batch (zero leaves) is invalid and MUST be rejected.
+
+The root is published hex-encoded, lowercase, prefixed with the algorithm:
+
+```
+sha256:<64 lowercase hex characters>
+```
+
+## 4. Registry entry
+
+An anchor is recorded as one JSON object with exactly these fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ts` | string | Anchoring time, ISO-8601 UTC with `Z` suffix |
+| `merkle_root` | string | `sha256:<hex>` root of the batch tree (§3) |
+| `leaf_count` | integer | Number of leaves in the batch, `>= 1` |
+| `producer` | string | Identifier of the party that produced and submitted the batch |
+| `batch_id` | string | Producer-scoped unique identifier for the batch |
+
+```json
+{"ts":"2026-06-12T18:30:00Z","merkle_root":"sha256:9c4f...","leaf_count":1,"producer":"cmcp-gateway/0.1.0","batch_id":"2026-06-12-001"}
+```
+
+**Entries are append-only.** Lines are only ever added; existing entries are never rewritten. A registry MUST make that property checkable by an outside party rather than merely assert it. The reference registry uses git history as the tamper-evidence layer: any rewrite of a published entry diverges the commit hashes that auditors and mirrors have already observed, which is why non-fast-forward pushes to its default branch are refused at the platform level as well as in CI.
+
+A registry conforming to this document MUST publish, for each anchor, the fields above, and MUST make the sequence of anchors retrievable by a party with no account or credential on the operator's infrastructure.
+
+## 5. Inclusion proof
+
+A producer gives each claim holder an inclusion proof:
+
+```json
+{"leaf_index": 0, "audit_path": ["sha256:<hex>", "sha256:<hex>"]}
+```
+
+- `leaf_index`: 0-based position of the claim's leaf in the batch.
+- `audit_path`: the RFC 6962 audit path, ordered leaf-to-root: at each tree level, the sibling hash needed to recompute the parent. A level where the node was promoted, and therefore had no sibling, contributes no path element. A single-leaf batch has an empty `audit_path`.
+
+### 5.1 Verification algorithm
+
+Inputs: the claim object, the proof (`leaf_index`, `audit_path`), and the registry entry (`merkle_root`, `leaf_count`). All `sha256:<hex>` strings decode to 32 raw bytes.
+
+```
+1. If leaf_index >= leaf_count, reject.
+2. r  = SHA-256(0x00 || canonical_claim_bytes)        # §1, §2
+   fn = leaf_index
+   sn = leaf_count - 1
+3. For each p in audit_path, in order:
+     a. If sn == 0, reject (path too long).
+     b. If fn is odd, or fn == sn:
+          r = SHA-256(0x01 || p || r)
+          If fn is even:                  # fn == sn, right-edge promotion
+              until fn is odd or fn == 0: fn = fn >> 1; sn = sn >> 1
+        else:
+          r = SHA-256(0x01 || r || p)
+     c. fn = fn >> 1; sn = sn >> 1
+4. Accept iff sn == 0 and r equals the entry's merkle_root.
+```
+
+Any failure, including a wrong root, leftover `sn`, a malformed hash, or an out-of-range index, means the claim is NOT proven included in that entry. A verifier MUST NOT report partial success.
+
+### 5.2 What verification proves, and what it does not
+
+A successful check proves the **exact signed claim bytes** were part of the batch whose root is committed in the registry at the entry's timestamp.
+
+It does not validate the claim's signature, and it does not validate the claim's semantics. Signature verification against the producer key is a separate TRACE step (v0.2 §3.3). A record can be genuinely anchored and still be a record of something untrue; anchoring proves when the bytes existed and that they have not changed since, which is the property the `transparency` claim is asserting and the only one it asserts.
+
+## 6. Relationship to the `transparency` claim
+
+TRACE v0.2 makes `transparency` optional below Level 2, because an unanchored Level 0 or Level 1 record has no receipt to name. Where it is present, it identifies the registry entry that anchors the record.
+
+At **Level 2 and above the anchor is what makes the record independently checkable**, so a verifier appraising a Level 2 record MUST be able to retrieve the entry and check inclusion without contacting the record's issuer. A `transparency` value that resolves only through the issuer's own infrastructure does not satisfy this.
+
+## 7. Reference implementations
+
+Named so that "here is the algorithm, and here is one implementation that is not the definition" is available as a pairing. Neither is normative.
+
+- **`trace-verify`** (PyPI): `pip install trace-verify`, then verify a claim against a proof and an entry. Standard library only.
+- A single-file standalone verifier and the anchoring tool ship in the registry repository, deliberately self-contained so they can be copied and audited in isolation rather than trusted.
+
+## 8. Conformance
+
+A registry conforms to Anchor Format v1 if it:
+
+1. Computes leaves and roots per §1 to §3.
+2. Publishes entries carrying the §4 fields, append-only, retrievable without operator credentials.
+3. Issues proofs of the §5 shape that verify under §5.1 against its published entries.
+4. Makes the append-only property externally checkable rather than asserted.
+
+An operator that satisfies 1 through 3 but not 4 is running a log, not a transparency log. The distinction is the whole point of the document.


### PR DESCRIPTION
Closes #111.

The format was already normative and already written so a conforming verifier could be built from it alone. It lived in `trace-registry`, which is private, so the one document an external verifier needs was the one they could not read. An inclusion proof nobody outside can check is not transparency.

This takes **option 1** from the issue, which @l33tdawg proposed: publish it here, in the public spec home, and leave the registry implementation where it is. That decouples publishing the format from the larger decision about repo visibility.

## `spec/registry-anchor-v1.md`

RFC 6962 trees, RFC 9162 inclusion check, the complete signed claim as the anchored unit, entry fields, proof shape, conformance.

**§0 leads with the trap** rather than burying it, per the issue. TRACE canonicalizes with RFC 8785 (JCS) for *signing* and sorted-key JSON for the *anchor leaf*. The two agree on ASCII-only records carrying integer numbers, which is most records, which is exactly what makes assuming JCS at the leaf dangerous: proofs never verify and the failure has no useful diagnostic. The section names the test that catches it.

**§8 requires the append-only property to be externally checkable, not asserted.** An operator issuing verifiable proofs while publishing nothing an outsider can audit is running a log, not a transparency log.

## Verified, not asserted

The point of the document is that someone can implement from it without reading our code, so I checked that rather than claiming it. An implementation written from the published text alone:

- verifies the registry's real anchored sample (`leaf_count 1`, empty audit path);
- verifies all five proofs of a five-leaf batch built by the registry's own `tools/anchor.py`, which exercises the odd-node **promotion** branch the single-leaf sample never touches (`leaf 4` gets a 1-element path, leaves 0 to 3 get 3);
- rejects a tampered claim against a valid proof.

## Two things found while writing it

**Four documents told readers to send signed records to a domain we do not own.** `docs/integration/agt.md`, `docs/integration/cmcp.md`, `docs/trust-levels.md` and `docs/verification.md` named `registry.agentrust.io`, which resolves to third-party parked addresses. Same defect the v0.2 profile cutover fixed in the identifier, missed in the prose. Moved to `registry.agentrust-io.com`, which is what the SDK's adapters already emit. `spec/trace-v0.1.md` keeps its original values: it is superseded and stands as a record of what was published.

**The anchoring tutorial documented an API that does not exist.** It told readers to POST a signed Trust Record to a SCITT HTTP endpoint at that parked domain and read a `receipt_uri` from the response. There is no such endpoint. Rewritten against the actual mechanism: submit to staging, retrieve the inclusion proof, verify it yourself against the published entry. It also still described `transparency` as a required string, which 0.5.1 changed. The page carries a dated note stating what it used to say, because anyone who built against it should know that nothing they sent was received.

## Not in this PR

Making `trace-registry` public. That is a separate decision with a licensing blocker in front of it, covered in the go-public runbook, and this PR is deliberately independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
