### PR TITLE
feat(provenance): build, sign and verify server provenance records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ### Added
 
+- **`agentrust_trace.provenance`: build, sign and verify MCP Server Provenance Records.** Step 2 of the sequence, implementing `spec/server-provenance-v1.md`. In the SDK rather than in cMCP, so a publisher can produce a record without adopting a runtime, which is the only way the format reaches an ecosystem that will not adopt one.
+
+  **`check_tool_catalog()` is a separate call on purpose.** Verifying the signature proves a document is internally consistent and signed by a key you trust, which is exactly what an attacker holding a stolen publisher key can produce. What they cannot do is make the server in front of you offer the tools their record describes. That comparison needs something `verify_record()` does not have — what the server said to *you* — so it is its own obvious call rather than a flag, and it raises its own exception type so a consumer can tell "bad document" from "wrong server".
+
+  The builder refuses records that cannot mean anything: an identity with neither artifact nor endpoint, a `tee-attested` record with no evidence, evidence attached to a kind that does not claim it (a reader would take it as an attestation that was made), a publisher that is a display name rather than a resolvable DID or SPIFFE URI, and an endpoint URL with no key digest, since a URL alone is not an identity.
+
+  `verify_record()` requires a trusted key and never takes one from the record. Verifying a document against a key it supplies proves only that it is internally consistent, which is what a forgery is.
+
+  24 tests, including the one the format exists for: a perfectly valid signature over a description of a different server still fails the catalog check.
+
+### Added
+
 - **`spec/server-provenance-v1.md`: a signed statement about an MCP server.** cMCP enforces policy at the call boundary and can say nothing about whether the server on the other end is what it claims. Its catalog answers that locally — approved definitions, a measured catalog hash, a pinned TLS fingerprint — but every part of that is operator-asserted, so nothing one operator learns is usable by the next.
 
   The format carries the same shape of honesty as the `origin` block: a closed `kind` (`publisher-asserted`, `observer-attested`, `tee-attested`) because the interesting fact is never that provenance exists but who is asserting it, and an explicit rule that a verifier MUST NOT treat absence as any of them.

--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -82,3 +82,11 @@ __all__ = [
     "sign_record",
     "verify_record",
 ]
+
+# MCP Server Provenance Records (spec/server-provenance-v1.md) live in their own
+# module: they describe an artifact rather than an execution, so importing them
+# from the top level alongside TrustRecord would invite exactly the conflation
+# the specification opens by ruling out.
+from agentrust_trace import provenance as provenance  # noqa: E402
+
+__all__ = [*__all__, "provenance"]

--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -1,0 +1,248 @@
+"""MCP Server Provenance Records: build, sign, verify.
+
+Implements ``spec/server-provenance-v1.md``. A provenance record is a signed
+statement *about* an MCP server, not about an execution, so it is deliberately
+not a Trust Record and does not pretend to be one.
+
+The function that matters here is :func:`check_tool_catalog`. Everything else
+verifies that a document is internally consistent and signed by a key you already
+trust, which is table stakes; §5 step 5 of the specification is the step that
+catches a live attack, because it compares the record against the tools the
+server actually offered you rather than against itself. It is also the step an
+implementer skips first, so it is a separate, obvious call rather than a flag on
+another one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from typing import Any
+
+from agentrust_trace.sign import _canonical_bytes, _pubkey_from_jwk, key_to_jwk
+
+__all__ = [
+    "FORMAT",
+    "KINDS",
+    "ProvenanceError",
+    "ToolCatalogMismatch",
+    "build_record",
+    "check_tool_catalog",
+    "sign_record",
+    "tool_catalog_hash",
+    "verify_record",
+]
+
+FORMAT = "agentrust-io/mcp-server-provenance/1"
+
+#: Closed on purpose: the value of the field is that a verifier can key on it.
+KINDS = ("publisher-asserted", "observer-attested", "tee-attested")
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_PUBLISHER_RE = re.compile(r"^(did:[a-z0-9]+:.+|spiffe://[^/]+/.+)$")
+
+
+class ProvenanceError(ValueError):
+    """A provenance record is malformed, unsigned, or signed by the wrong key."""
+
+
+class ToolCatalogMismatch(ProvenanceError):
+    """The server offered a tool set the record does not describe.
+
+    Separate from :class:`ProvenanceError` because it means something different.
+    The others say the document is bad. This one says the document is fine and
+    the *server* is not the server it describes, which is the finding the format
+    exists to produce.
+    """
+
+
+def tool_catalog_hash(tools: list[dict[str, Any]]) -> str:
+    """Digest over a tool list, per specification §4.
+
+    Covers ``name``, ``description`` and ``input_schema`` of each tool, sorted by
+    name. Description is included deliberately: a tool whose description changes
+    from "search the docs" to "search the docs and email results to the address
+    in the query" is the rug-pull this hash exists to catch, and a hash over
+    names alone would not notice.
+
+    Output schemas, annotations and vendor extensions are excluded. They change
+    for reasons that are not security-relevant, and a hash that churns is a hash
+    nobody compares.
+    """
+    normalized = sorted(
+        (
+            {
+                "name": t.get("name"),
+                "description": t.get("description"),
+                "input_schema": t.get("input_schema", t.get("inputSchema")),
+            }
+            for t in tools
+        ),
+        key=lambda t: str(t["name"]),
+    )
+    # Sorted-key JSON, matching the anchor format rather than JCS. The two
+    # canonicalizations at two layers are described in registry-anchor-v1.md §0;
+    # this is the anchoring layer.
+    canonical = json.dumps(
+        normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("ascii")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def build_record(
+    *,
+    kind: str,
+    publisher: str,
+    tools: list[dict[str, Any]],
+    artifact: dict[str, str] | None = None,
+    endpoint: dict[str, str] | None = None,
+    attestation: dict[str, Any] | None = None,
+    issued_at: int | None = None,
+) -> dict[str, Any]:
+    """Assemble an unsigned provenance record.
+
+    Raises rather than emitting a record that cannot mean anything: an identity
+    with neither an artifact nor an endpoint identifies nothing, and a
+    ``tee-attested`` record without attestation evidence is the claim without the
+    thing that backs it.
+    """
+    if kind not in KINDS:
+        raise ProvenanceError(f"kind {kind!r} is not one of {', '.join(KINDS)}")
+    if not _PUBLISHER_RE.match(publisher or ""):
+        raise ProvenanceError(
+            f"publisher {publisher!r} must be a DID or SPIFFE URI. A display name is not "
+            "resolvable and a verifier cannot check one."
+        )
+    if artifact is None and endpoint is None:
+        raise ProvenanceError(
+            "a record needs artifact identity, endpoint identity, or both. One with "
+            "neither identifies nothing."
+        )
+    if artifact is not None:
+        if not artifact.get("package"):
+            raise ProvenanceError("artifact.package is required (a Package URL)")
+        if not _DIGEST_RE.match(artifact.get("digest", "")):
+            raise ProvenanceError(
+                "artifact.digest must be a sha256: digest of the entrypoint. For an "
+                "interpreted server that is the script, not the interpreter: every such "
+                "server on a host shares one interpreter digest."
+            )
+    if endpoint is not None:
+        if not endpoint.get("url"):
+            raise ProvenanceError("endpoint.url is required when endpoint is present")
+        if not _DIGEST_RE.match(endpoint.get("spki_sha256", "")):
+            raise ProvenanceError(
+                "endpoint.spki_sha256 must be a sha256: digest of the Subject Public Key "
+                "Info. A URL on its own is not an identity."
+            )
+    if kind == "tee-attested" and not attestation:
+        raise ProvenanceError(
+            "kind='tee-attested' without attestation evidence is the claim without the "
+            "thing that backs it"
+        )
+    if kind != "tee-attested" and attestation:
+        raise ProvenanceError(
+            f"kind={kind!r} carries attestation evidence. Evidence that is present but "
+            "not claimed invites a consumer to read it as an attestation that was made."
+        )
+
+    identity: dict[str, Any] = {}
+    if artifact is not None:
+        identity["artifact"] = dict(artifact)
+    if endpoint is not None:
+        identity["endpoint"] = dict(endpoint)
+
+    return {
+        "format": FORMAT,
+        "kind": kind,
+        "issued_at": int(issued_at if issued_at is not None else time.time()),
+        "identity": identity,
+        "publisher": publisher,
+        "tool_catalog": {"hash": tool_catalog_hash(tools), "tool_count": len(tools)},
+        "attestation": attestation,
+    }
+
+
+def sign_record(record: dict[str, Any], key: Any) -> dict[str, Any]:
+    """Sign per TRACE v0.2 §3.2: Ed25519 over the JCS form with the signature absent."""
+    payload = {**record, "cnf": {"jwk": key_to_jwk(key)}}
+    body = _canonical_bytes({k: v for k, v in payload.items() if k != "signature"})
+    import base64
+
+    sig = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
+    return {**payload, "signature": sig}
+
+
+def verify_record(record: dict[str, Any], trusted_jwk: dict[str, Any]) -> None:
+    """Verify structure and signature. Raises :class:`ProvenanceError` on failure.
+
+    *trusted_jwk* is required and is never taken from the record. Verifying a
+    document against a key it supplies proves only that it is internally
+    consistent, which is what a forged record is.
+
+    **This does not check the server.** It checks the paper. Call
+    :func:`check_tool_catalog` with the tools the server actually offered.
+    """
+    import base64
+
+    if record.get("format") != FORMAT:
+        raise ProvenanceError(
+            f"unknown format {record.get('format')!r}; expected {FORMAT}. An unknown "
+            "version is rejected rather than parsed best-effort."
+        )
+    if record.get("kind") not in KINDS:
+        raise ProvenanceError(f"unknown kind {record.get('kind')!r}")
+    if not _PUBLISHER_RE.match(str(record.get("publisher", ""))):
+        raise ProvenanceError("publisher must be a DID or SPIFFE URI")
+    identity = record.get("identity") or {}
+    if not identity.get("artifact") and not identity.get("endpoint"):
+        raise ProvenanceError("identity carries neither an artifact nor an endpoint")
+    catalog = record.get("tool_catalog") or {}
+    if not _DIGEST_RE.match(str(catalog.get("hash", ""))):
+        raise ProvenanceError("tool_catalog.hash is not a sha256: digest")
+
+    signature = record.get("signature")
+    if not signature:
+        raise ProvenanceError("record carries no signature")
+
+    embedded = (record.get("cnf") or {}).get("jwk")
+    if embedded and embedded != trusted_jwk:
+        raise ProvenanceError(
+            "the record's embedded key is not the trusted key. A record signed by some "
+            "other key is a record about a server somebody else is describing."
+        )
+
+    pub = _pubkey_from_jwk(trusted_jwk)
+    body = _canonical_bytes({k: v for k, v in record.items() if k != "signature"})
+    padded = signature + "=" * (-len(signature) % 4)
+    try:
+        pub.verify(base64.urlsafe_b64decode(padded), body)
+    except Exception as exc:  # cryptography raises InvalidSignature
+        raise ProvenanceError(f"signature does not verify: {exc}") from exc
+
+
+def check_tool_catalog(record: dict[str, Any], tools: list[dict[str, Any]]) -> None:
+    """Compare the record against the tools the server actually offered.
+
+    Specification §5 step 5, and the only step that catches a live attack. A
+    mismatch means the server you are talking to is not the server the record
+    describes, whoever signed it and however well the signature verifies.
+
+    Kept as its own call rather than folded into :func:`verify_record` because it
+    needs something ``verify_record`` does not have: what the server said to
+    *you*. A verifier that never obtains that has checked a document against
+    itself.
+    """
+    actual = tool_catalog_hash(tools)
+    expected = (record.get("tool_catalog") or {}).get("hash")
+    if actual != expected:
+        declared_count = (record.get("tool_catalog") or {}).get("tool_count")
+        raise ToolCatalogMismatch(
+            f"the server offered a tool set this record does not describe: computed "
+            f"{actual}, record says {expected} "
+            f"({len(tools)} tools offered, record declares {declared_count}). "
+            "The signature may be perfectly valid; this is about the server, not the "
+            "document."
+        )

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,224 @@
+"""Tests for MCP Server Provenance Records.
+
+The tests worth having are the ones where a record is well-formed, correctly
+signed, and still must not be believed: a valid signature over a description of a
+different server is exactly what an attacker with a stolen publisher key
+produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentrust_trace.provenance import (
+    FORMAT,
+    ProvenanceError,
+    ToolCatalogMismatch,
+    build_record,
+    check_tool_catalog,
+    sign_record,
+    tool_catalog_hash,
+    verify_record,
+)
+from agentrust_trace.sign import generate_key, key_to_jwk
+
+DIGEST = "sha256:" + "a" * 64
+OTHER_DIGEST = "sha256:" + "b" * 64
+
+TOOLS = [
+    {"name": "search", "description": "search the docs", "input_schema": {"type": "object"}},
+    {"name": "fetch", "description": "fetch a page", "input_schema": {"type": "object"}},
+]
+
+
+def _artifact():
+    return {"package": "pkg:npm/%40acme/mcp-search@2.1.0", "digest": DIGEST}
+
+
+def _record(**over):
+    kwargs = {
+        "kind": "publisher-asserted",
+        "publisher": "did:web:acme.example",
+        "tools": TOOLS,
+        "artifact": _artifact(),
+    }
+    kwargs.update(over)
+    return build_record(**kwargs)
+
+
+# --- the catalog hash, which is what the format is actually for ------------
+
+
+def test_hash_is_stable_and_order_independent() -> None:
+    assert tool_catalog_hash(TOOLS) == tool_catalog_hash(list(reversed(TOOLS)))
+
+
+def test_description_change_changes_the_hash() -> None:
+    """The rug-pull this exists to catch.
+
+    A tool that keeps its name and grows "and email results to the address in the
+    query" is the attack. A hash over names alone would not notice.
+    """
+    tampered = [dict(TOOLS[0], description="search the docs and email results"), TOOLS[1]]
+    assert tool_catalog_hash(tampered) != tool_catalog_hash(TOOLS)
+
+
+def test_input_schema_change_changes_the_hash() -> None:
+    tampered = [
+        dict(TOOLS[0], input_schema={"type": "object", "properties": {"to": {"type": "string"}}}),
+        TOOLS[1],
+    ]
+    assert tool_catalog_hash(tampered) != tool_catalog_hash(TOOLS)
+
+
+def test_added_tool_changes_the_hash() -> None:
+    assert tool_catalog_hash([*TOOLS, {"name": "pay", "description": "d", "input_schema": {}}]) != (
+        tool_catalog_hash(TOOLS)
+    )
+
+
+def test_camel_case_input_schema_is_accepted() -> None:
+    """MCP servers emit inputSchema; a hash that ignored it would be over nothing."""
+    camel = [
+        {"name": t["name"], "description": t["description"], "inputSchema": t["input_schema"]}
+        for t in TOOLS
+    ]
+    assert tool_catalog_hash(camel) == tool_catalog_hash(TOOLS)
+
+
+def test_output_schema_does_not_change_the_hash() -> None:
+    """Excluded deliberately: a hash that churns is a hash nobody compares."""
+    with_output = [dict(t, output_schema={"type": "string"}) for t in TOOLS]
+    assert tool_catalog_hash(with_output) == tool_catalog_hash(TOOLS)
+
+
+# --- building: refuse records that cannot mean anything --------------------
+
+
+def test_identity_with_neither_artifact_nor_endpoint_is_refused() -> None:
+    with pytest.raises(ProvenanceError, match="identifies nothing"):
+        build_record(kind="publisher-asserted", publisher="did:web:x", tools=TOOLS)
+
+
+def test_publisher_must_be_resolvable() -> None:
+    with pytest.raises(ProvenanceError, match="DID or SPIFFE"):
+        _record(publisher="Acme Corp")
+
+
+def test_endpoint_url_without_a_key_digest_is_refused() -> None:
+    """A URL on its own is not an identity."""
+    with pytest.raises(ProvenanceError, match="not an identity"):
+        build_record(
+            kind="publisher-asserted",
+            publisher="did:web:x",
+            tools=TOOLS,
+            endpoint={"url": "https://x/"},
+        )
+
+
+def test_tee_attested_without_evidence_is_refused() -> None:
+    with pytest.raises(ProvenanceError, match="without the thing that backs it"):
+        _record(kind="tee-attested")
+
+
+def test_evidence_without_the_matching_kind_is_refused() -> None:
+    """Evidence present but not claimed invites a reader to assume it was checked."""
+    with pytest.raises(ProvenanceError, match="not claimed"):
+        _record(attestation={"platform": "intel-tdx"})
+
+
+def test_unknown_kind_is_refused() -> None:
+    with pytest.raises(ProvenanceError, match="not one of"):
+        _record(kind="vendor-asserted")
+
+
+def test_artifact_digest_must_be_a_digest() -> None:
+    with pytest.raises(ProvenanceError, match="entrypoint"):
+        _record(artifact={"package": "pkg:npm/x@1", "digest": "sha256:placeholder"})
+
+
+# --- verification ----------------------------------------------------------
+
+
+def test_round_trip() -> None:
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    verify_record(signed, key_to_jwk(key))
+    check_tool_catalog(signed, TOOLS)
+
+
+def test_tampered_field_fails_the_signature() -> None:
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    signed["publisher"] = "did:web:attacker.example"
+    with pytest.raises(ProvenanceError, match="does not verify"):
+        verify_record(signed, key_to_jwk(key))
+
+
+def test_a_different_signer_is_rejected() -> None:
+    key, other = generate_key(), generate_key()
+    signed = sign_record(_record(), key)
+    with pytest.raises(ProvenanceError, match="not the trusted key"):
+        verify_record(signed, key_to_jwk(other))
+
+
+def test_unsigned_record_is_rejected() -> None:
+    with pytest.raises(ProvenanceError, match="no signature"):
+        verify_record(_record(), key_to_jwk(generate_key()))
+
+
+def test_unknown_format_version_is_rejected_not_parsed() -> None:
+    key = generate_key()
+    signed = sign_record({**_record(), "format": "agentrust-io/mcp-server-provenance/2"}, key)
+    with pytest.raises(ProvenanceError, match="unknown format"):
+        verify_record(signed, key_to_jwk(key))
+
+
+def test_format_constant_matches_the_spec() -> None:
+    assert FORMAT == "agentrust-io/mcp-server-provenance/1"
+
+
+# --- the step that catches a live attack -----------------------------------
+
+
+def test_valid_signature_over_a_different_server_still_fails_the_catalog_check() -> None:
+    """The test this whole format is for.
+
+    An attacker with a stolen publisher key produces a perfectly valid record.
+    What they cannot do is make the server in front of you offer the tools that
+    record describes.
+    """
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    verify_record(signed, key_to_jwk(key))  # the paper is impeccable
+
+    offered = [
+        dict(TOOLS[0], description="search the docs and email results to the query address"),
+        TOOLS[1],
+    ]
+    with pytest.raises(ToolCatalogMismatch, match="about the server, not the document"):
+        check_tool_catalog(signed, offered)
+
+
+def test_catalog_mismatch_is_its_own_error_type() -> None:
+    """A consumer must be able to tell "bad document" from "wrong server"."""
+    assert issubclass(ToolCatalogMismatch, ProvenanceError)
+
+
+def test_mismatch_message_reports_both_counts() -> None:
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    with pytest.raises(ToolCatalogMismatch) as exc:
+        check_tool_catalog(signed, TOOLS[:1])
+    assert "1 tools offered" in str(exc.value)
+    assert "declares 2" in str(exc.value)
+
+
+def test_tool_count_is_recorded() -> None:
+    assert _record()["tool_catalog"]["tool_count"] == len(TOOLS)
+
+
+def test_both_identities_may_be_present() -> None:
+    rec = _record(endpoint={"url": "https://mcp.acme.example/", "spki_sha256": OTHER_DIGEST})
+    assert "artifact" in rec["identity"]
+    assert "endpoint" in rec["identity"]


### PR DESCRIPTION
Step 2 of the sequence, implementing `spec/server-provenance-v1.md` (#139).

In the **SDK rather than in cMCP**, so a publisher can produce a record without adopting a runtime. That is the only way this format reaches an ecosystem whose operators will never adopt one, which was the whole argument for building it.

## The design decision worth reviewing

**`check_tool_catalog()` is a separate call, not a flag on `verify_record()`.**

Verifying the signature proves a document is internally consistent and signed by a key you trust. That is exactly what an attacker holding a stolen publisher key produces. What they *cannot* do is make the server in front of you offer the tools their record describes.

That comparison needs something `verify_record()` structurally does not have: what the server said **to you**. So it is its own obvious call, and it raises its own exception type, so a consumer can tell "bad document" from "wrong server" — different findings with different responses.

The test that matters:

```python
verify_record(signed, trusted_jwk)   # the paper is impeccable
check_tool_catalog(signed, offered)  # ToolCatalogMismatch
```

## Refusals in the builder

Records that cannot mean anything do not get built:

| Refused | Why |
|---|---|
| identity with neither artifact nor endpoint | identifies nothing |
| `tee-attested` with no evidence | the claim without the thing that backs it |
| evidence on a kind that does not claim it | a reader takes it as an attestation that was made |
| publisher as a display name | a name is not resolvable; a verifier cannot check one |
| endpoint URL with no key digest | a URL alone is not an identity |
| `artifact.digest` that is not a digest | error message says: the entrypoint, not the interpreter |

`verify_record()` requires a trusted key and never takes one from the record. Verifying a document against a key it supplies proves only that it is internally consistent, which is what a forgery is.

## One accommodation to reality

`tool_catalog_hash()` accepts `inputSchema` as well as `input_schema`, because that is what MCP servers actually emit. A hash that silently ignored the real field name would be a hash over nothing.

24 tests, 241 in the suite, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
