### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-08-09
+
 ### Added
 
 - **`agentrust_trace.provenance`: build, sign and verify MCP Server Provenance Records.** Step 2 of the sequence, implementing `spec/server-provenance-v1.md`. In the SDK rather than in cMCP, so a publisher can produce a record without adopting a runtime, which is the only way the format reaches an ecosystem that will not adopt one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentrust-trace"
-version = "0.7.0"
+version = "0.8.0"
 description = "TRACE v0.2 — hardware-attested governance records for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Ships `agentrust_trace.provenance` (#140) and `spec/server-provenance-v1.md` (#139).

Gateway consumption in cMCP is step 3 and cannot be written against an unreleased module: its tests skip entirely without the published package, which is a test suite that passes by not running.

Version bump and changelog heading only. 241 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)