### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-09
+
 ### Added
 
 - **`spec/content-marking-v1.md` and `agentrust_trace.content_marking`: bind a marked asset to the execution that produced it.** EU AI Act Article 50(2) and 50(4) have been in force since 2 August 2026 and are the only AI Act obligations that bite this year. One C2PA assertion, `com.agentrust-io.trace`, carries a hashed reference to the Trust Record for the execution that produced the asset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentrust-trace"
-version = "0.8.0"
+version = "0.9.0"
 description = "TRACE v0.2 — hardware-attested governance records for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Ships `enforcement_mode: "declared"` (#143) and the content-marking binding (#144).

Cut now because the framework adapters cannot default to `declared` against an unreleased enum — they would have to keep refusing the field, which is exactly the overstatement the new value exists to remove.

Version bump and changelog heading only. 263 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)