### PR TITLE
docs(spec): JCS sorts by UTF-16 code unit, not Unicode code point

### DIFF
--- a/spec/registry-anchor-v1.md
+++ b/spec/registry-anchor-v1.md
@@ -26,7 +26,11 @@ The construction follows [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962) (Cer
 
 An implementer who reasonably assumes JCS at the leaf will produce proofs that never verify, and the failure gives no useful diagnostic: the recomputed root simply differs from the published one, with nothing to indicate why.
 
-The two agree on records whose strings and keys are pure ASCII and whose numbers are integers, which is most records, which is exactly what makes this dangerous. They diverge on non-ASCII strings, where JCS emits the character and §1 emits a `\uXXXX` escape, and on non-integer numbers, where JCS applies ECMAScript number serialization. §1 excludes non-integer numbers from this profile for that reason.
+The two agree on records whose strings and keys are pure ASCII and whose numbers are integers, which is most records, which is exactly what makes this dangerous. They diverge in three ways:
+
+- **Non-ASCII strings.** JCS emits the character; §1 emits a `\uXXXX` escape.
+- **Non-integer numbers.** JCS applies ECMAScript number serialization. §1 excludes non-integer numbers from this profile for that reason.
+- **Key order.** JCS sorts by UTF-16 code unit (RFC 8785 §3.2.3); §1 sorts by Unicode code point, which is what Python's `sort_keys=True` does. The two agree across the Basic Multilingual Plane and disagree once a key contains a supplementary-plane character, because surrogates occupy U+D800 to U+DFFF.
 
 Do not "simplify" a verifier by reusing the signing canonicalizer at the leaf. If you do, write a test that anchors a record containing a non-ASCII character and verifies it, which is the test that catches this.
 

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -235,7 +235,7 @@ A Trust Record normally describes an execution and is produced by the runtime th
 
 1. Construct the record object with all fields EXCEPT the `signature` field (for embedded-signature profiles) or the outer envelope (for enveloping-signature profiles). The `cnf` field, including `cnf.jwk`, is included in the canonical form.
 2. Apply RFC 8785 JSON Canonicalization Scheme (JCS) to produce a deterministic byte sequence:
-   - Object keys are sorted in Unicode code-point order (ascending).
+   - Object keys are sorted by UTF-16 code unit (ascending), per RFC 8785 §3.2.3. This is not the same as Unicode code-point order: the two agree across the Basic Multilingual Plane and diverge once a key contains a supplementary-plane character, because surrogates occupy U+D800 to U+DFFF and therefore sort below high BMP characters. Sorting Python `str` values with `sorted()` gives code-point order and is wrong here; an RFC 8785 library gets this right.
    - No whitespace between tokens.
    - Numbers are serialized in IEEE 754 double-precision format using the shortest decimal representation that round-trips.
    - Strings are serialized as UTF-8; only the characters mandated by RFC 8259 §7 are escaped (U+0022, U+005C, and U+0000–U+001F).


### PR DESCRIPTION
Closes #128. Reported by @lywinged, carried as a maintainer change per the spec contribution policy.

**§3.2.2** mandated RFC 8785 and then described its sort order wrongly in the same step. RFC 8785 §3.2.3 sorts object keys by UTF-16 code unit. The orders agree across the BMP and diverge once a key holds a supplementary-plane character, because surrogates occupy U+D800 to U+DFFF and sort below high BMP characters:

```python
>>> keys = ["zk\U0001f600", "zk�"]
>>> sorted(keys)                                       # code point
['zk�', 'zk\U0001f600']
>>> sorted(keys, key=lambda s: s.encode("utf-16-be"))  # UTF-16, what JCS does
['zk\U0001f600', 'zk�']
```

Nothing was broken and no record changes. `_canonical_bytes` already uses `rfc8785` and its docstring says UTF-16 code unit, so the code and the spec disagreed in the code's favour. The exposure is a reader implementing from the spec alone, who would reach for `sorted()` and produce a different pre-image.

**§0 of registry-anchor-v1.md** existed specifically to name the two-canonicalization trap, and listed two divergences: non-ASCII escaping and non-integer numbers. Key order is a third, because §1 sorts by code point via Python's `sort_keys=True` while the signing layer sorts by UTF-16 code unit. @lywinged spotted that gap in a follow-up comment.

That gap is not academic. Triaging agentrust-io/trace-registry#38 an hour ago, I widened a one-function bug to five call sites before reading which layer each one served, which is exactly the mistake §0 is written to prevent. It is now a complete list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
