### PR TITLE
test: rule registry the verifier consumes, and two independent vectors per rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov/
 # Virtualenvs
 .venv/
 venv/
+uv.lock

--- a/examples/action-receipts/README.md
+++ b/examples/action-receipts/README.md
@@ -96,6 +96,20 @@ three operations:
 | `14-receipt-issuer-key-unknown.json` | `receipt_unverified` with advisory | unknown | The issuer key is not in the verifier's pinned set. Unverifiable is not invalid (spec §3.3.1): no trust is conferred and no forgery is proven, surfaced as an `issuer_key_unknown` advisory. |
 | `15-receipt-from-future.json` | `receipt_invalid` | unknown | Issued after the verification time, so an upper bound on age never rejects it. |
 | `16-decision-not-in-enum.json` | `receipt_invalid` | unknown | An unrecognised decision verb, which must not read as accept or reject. |
+| `17-missing-receipt-explicit-null.json` | `receipt_missing_required` | unknown | The receipt supplied as an explicit `null`: 03's absence through a different door, misread by presence-checking implementations. |
+| `18-action-ref-tail-forged.json` | `receipt_invalid` | unknown | The declared `action_ref` matches the recomputed digest in every character but the last. |
+| `19-action-ref-mismatch-in-tail.json` | `receipt_invalid` | unknown | Receipt and action references differ only in the final character. |
+| `20-call-id-case-mismatch.json` | `receipt_invalid` | unknown | The linked call id is this call's id in a different case — a different call. |
+| `21-session-id-case-mismatch.json` | `receipt_invalid` | unknown | The session id in a different case — a different session. |
+| `22-evidence-hash-mismatch-in-tail.json` | `receipt_invalid` | unknown | The evidence hash is wrong only in its final character. |
+| `23-receipt-issuer-key-case-variant.json` | `receipt_unverified` with advisory | unknown | The right key pinned under a case-variant of the receipt's key id: not the key the receipt names. |
+| `24-receipt-signature-malformed.json` | `receipt_invalid` | unknown | Valid base64url decoding to 32 bytes — rejected by structure, where 04 needs cryptography. |
+| `25-stale-receipt-boundary.json` | `receipt_invalid` | unknown | Stale by exactly one second. |
+| `26-receipt-from-future-boundary.json` | `receipt_invalid` | unknown | Issued one second after the verification time. |
+| `27-receipt-chain-gap-in-tail.json` | `receipt_invalid` | unknown | The predecessor link is wrong only in its final character. |
+| `28-physical-completion-claim-case.json` | `receipt_invalid` | unknown | The claim `"None"`: the vocabulary word under case-normalisation, outside it as bytes. |
+| `29-same-party-self-report-rejected.json` | `receipt_valid_rejected` with warning | `rejected` | A gateway self-report on the rejected branch: issuer independence matters on both. |
+| `30-decision-case-variant.json` | `receipt_invalid` | unknown | The decision `"Accepted"`: in the vocabulary case-insensitively, outside it as bytes. |
 
 Fixtures `10`–`16` each pin down one rule that the verifier applies and that no fixture
 previously exercised. Every one was a check a conforming implementation could have
@@ -106,9 +120,19 @@ check at all; per spec §3.3.1 the outcome is `receipt_unverified`, not
 `receipt_invalid`, but a verifier that never consults its pinned set would report such
 a receipt as fully valid, which is what the vector distinguishes. Without
 `evidence_hash_mismatch` the signature covers a digest whose document may have been
-replaced. They pin their own deterministic test key, since the private half of the key
-used by `01`–`09` is not published; `gen_rule_coverage_vectors.py` regenerates them
-byte-for-byte and only public JWKs appear in the files.
+replaced.
+
+Fixtures `17`–`30` are the second, independent vector for each rule. Two vectors are
+independent when a single implementation defect causes one to pass and the other to
+fail (#124), and each pair here is split by a declared, plausible shortcut: truncated
+digest comparison, case-normalised identifier matching, clock tolerance, structural
+signature validation, presence-checking instead of null-checking. The defect that
+separates each pair is declared and enforced in
+`tests/test_vector_completeness.py::DEFECTS`.
+
+Everything from `10` up pins its own deterministic test key, since the private half of
+the key used by `01`–`09` is not published; `gen_rule_coverage_vectors.py` regenerates
+the range byte-for-byte and only public JWKs appear in the files.
 
 `tests/test_action_receipt_fixtures.py` recomputes each digest, verifies each
 signature against the pinned key, checks session and call binding, enforces

--- a/examples/action-receipts/conformance/17-missing-receipt-explicit-null.json
+++ b/examples/action-receipts/conformance/17-missing-receipt-explicit-null.json
@@ -1,0 +1,36 @@
+{
+  "name": "missing-receipt-explicit-null",
+  "description": "A required receipt supplied as an explicit null rather than omitted. The same absence as 03 through a different door: a verifier that checks for the key rather than the value treats this as a present receipt.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "receipt": null,
+  "expected": {
+    "status": "receipt_missing_required",
+    "controller_outcome": "unknown",
+    "failures": [
+      "receipt_missing"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/18-action-ref-tail-forged.json
+++ b/examples/action-receipts/conformance/18-action-ref-tail-forged.json
@@ -1,0 +1,54 @@
+{
+  "name": "action-ref-tail-forged",
+  "description": "The declared action_ref equals the recomputed digest through the first sixteen hex characters and differs in the last. 10 is caught by any comparison at all; this one requires comparing the whole digest.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe030"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe030",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "tn13JtCrKxddyM-QpzPwTmg-l8KvpeiYT0PNehl2RagBwOj4mMfVhf_Tb-h9dVUKISZT0cblfdIVZbGdPKuECA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "action_ref_invalid"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/19-action-ref-mismatch-in-tail.json
+++ b/examples/action-receipts/conformance/19-action-ref-mismatch-in-tail.json
@@ -1,0 +1,54 @@
+{
+  "name": "action-ref-mismatch-in-tail",
+  "description": "The receipt's action_ref differs from the action's only in the final character. 05 differs from the first character; a truncated comparison passes this one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe030",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "tn13JtCrKxddyM-QpzPwTmg-l8KvpeiYT0PNehl2RagBwOj4mMfVhf_Tb-h9dVUKISZT0cblfdIVZbGdPKuECA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "action_ref_mismatch"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/20-call-id-case-mismatch.json
+++ b/examples/action-receipts/conformance/20-call-id-case-mismatch.json
@@ -1,0 +1,54 @@
+{
+  "name": "call-id-case-mismatch",
+  "description": "The receipt's linked_call_id is the context's call id upper-cased. 11 is a different call outright; this one is the same bytes through any case-normalising comparison.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986D7C-6B2F-7C68-9FF8-3E2F9D0DB337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "8HS7MISwck9aIfnJkcZx-kKXv2uorhKghkvWojkUlqQnwVb6c6-6RV8D4TKgmKjSvgJVmH9ATBxJx6q0urM8Bg"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "call_id_mismatch"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/21-session-id-case-mismatch.json
+++ b/examples/action-receipts/conformance/21-session-id-case-mismatch.json
@@ -1,0 +1,54 @@
+{
+  "name": "session-id-case-mismatch",
+  "description": "The receipt's session_id is the context's session id upper-cased. Session identifiers are opaque strings: two that differ by case are two sessions.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "TRACE-SESSION-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "pq7Adpx1V4mhGw_ZvVEjhdiEfLCueI-vHZt5hSr_ClBdl9fjN3w0VFlCvY13greLXMmtuK554MJMMUfu_pmrAQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "session_id_mismatch"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/22-evidence-hash-mismatch-in-tail.json
+++ b/examples/action-receipts/conformance/22-evidence-hash-mismatch-in-tail.json
@@ -1,0 +1,54 @@
+{
+  "name": "evidence-hash-mismatch-in-tail",
+  "description": "The receipt's evidence_hash agrees with the recomputed digest through every prefix and is wrong in the final character. 13 is wrong from the start; only a full-width comparison catches this one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d0",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "w3QCwTi7_Jo8Vswk5Pyks13k7vao5pScZLCsz1S0bRfjYe7XOWUzheqR_LwJyMmfK7D_rZcqTzApA6ILLmrhAw"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "evidence_hash_mismatch"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/23-receipt-issuer-key-case-variant.json
+++ b/examples/action-receipts/conformance/23-receipt-issuer-key-case-variant.json
@@ -1,0 +1,54 @@
+{
+  "name": "receipt-issuer-key-case-variant",
+  "description": "The trusted set pins the right public key under a case-variant of the receipt's issuer_key_id. An exact lookup does not hold this key; a case-normalising lookup does, and verifies. 14 names a key absent under any normalisation.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "DID:WEB:FACTORY.EXAMPLE:SAFETY-CONTROLLER#ED25519-COVERAGE-2026Q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "f1bVg8ZaBv6SaT5JGzs0J4XkzyVkvhS5wGNit-790NFeHAGLfw1kalsiqBxGC8HFNUVjHRcW2urOPl8A90sbDw"
+  },
+  "expected": {
+    "status": "receipt_unverified",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "issuer_key_unknown"
+    ]
+  }
+}

--- a/examples/action-receipts/conformance/24-receipt-signature-malformed.json
+++ b/examples/action-receipts/conformance/24-receipt-signature-malformed.json
@@ -1,0 +1,54 @@
+{
+  "name": "receipt-signature-malformed",
+  "description": "The signature is valid base64url decoding to 32 bytes \u2014 half an Ed25519 signature. 04 carries a well-formed signature by the wrong key; together they separate structural validation from cryptographic verification.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "signature_or_key_mismatch"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/25-stale-receipt-boundary.json
+++ b/examples/action-receipts/conformance/25-stale-receipt-boundary.json
@@ -1,0 +1,54 @@
+{
+  "name": "stale-receipt-boundary",
+  "description": "Stale by exactly one second: age 301 against a 300-second ceiling. 06 is stale by nineteen minutes; any tolerance an implementation grants swallows this one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:18:59Z",
+    "decision": "accepted",
+    "signature": "soTgLz2ZcBDTnkyiYij6LsS4cjtRA1WbvfIsF5Yd64eLvm15XMKXJAKz-3FIzza4LIKrVTrelSwI3zKsL71fAg"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "receipt_stale"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/26-receipt-from-future-boundary.json
+++ b/examples/action-receipts/conformance/26-receipt-from-future-boundary.json
@@ -1,0 +1,54 @@
+{
+  "name": "receipt-from-future-boundary",
+  "description": "Issued one second after the verification time. 15 is two minutes ahead; a clock-skew allowance passes this one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:24:01Z",
+    "decision": "accepted",
+    "signature": "OBHx15GIU76mkcmDB3Gb7AL-wg2sQ-XrCc26AQyMbXa5auE9Hx4HyA10kmCf0sRayoVyeLVG3PJvjCLSjFF1Cg"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "receipt_from_future"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/27-receipt-chain-gap-in-tail.json
+++ b/examples/action-receipts/conformance/27-receipt-chain-gap-in-tail.json
@@ -1,0 +1,54 @@
+{
+  "name": "receipt-chain-gap-in-tail",
+  "description": "The previous_receipt_hash matches the expected predecessor through every prefix and differs in the final character. 07 links somewhere else entirely.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c0",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "bF-rlW1L5jO5NB8jUdZXvUV7cF4wozJB1fyzglkGhrusTQ_3T7f_VNo9BOC4b19lWQQaSqk8f0Z3g1iXUmjFDw"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "receipt_chain_gap"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/28-physical-completion-claim-case.json
+++ b/examples/action-receipts/conformance/28-physical-completion-claim-case.json
@@ -1,0 +1,54 @@
+{
+  "name": "physical-completion-claim-case",
+  "description": "The claim is 'None' \u2014 the vocabulary word 'none' through any case-normalising comparison, and outside the vocabulary as bytes. 09 claims completion outright.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "None",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:ae13df8e0aa1f4ddd3d9e48fa269b7e813cd19255fdf22c215c5c6cfebe7d3ad",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "accepted",
+    "signature": "6heqQgGcYXjCluwnVCXBQ1ffQ9jE-Hh060taCPUve1FJ6hNAqPhG4hWcR86RT9LuPajat2qVAbszjFGIIR6WBQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "unsupported_physical_completion_claim"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/29-same-party-self-report-rejected.json
+++ b/examples/action-receipts/conformance/29-same-party-self-report-rejected.json
@@ -1,0 +1,54 @@
+{
+  "name": "same-party-self-report-rejected",
+  "description": "A gateway self-report on a rejected action. 08 self-reports an acceptance; independence of the issuer matters on both branches, and a warning emitted only for acceptances misses this one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "rejected",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "gateway_self_report",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:0496efa566eb12fab7f3a5adc51e496f327a838a2ff0aa34eaeb573e3bb037e3",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "rejected",
+    "signature": "u8L_IbhOYfTh-2CGKzFax1uCxJc1obwxFVdapDIkvPOpl1MvbF2zqJo6XQwJCBeuc49z68Llj_ytIdxFJlIxAg"
+  },
+  "expected": {
+    "status": "receipt_valid_rejected",
+    "controller_outcome": "rejected",
+    "failures": [],
+    "warnings": [
+      "issuer_not_independent"
+    ]
+  }
+}

--- a/examples/action-receipts/conformance/30-decision-case-variant.json
+++ b/examples/action-receipts/conformance/30-decision-case-variant.json
@@ -1,0 +1,54 @@
+{
+  "name": "decision-case-variant",
+  "description": "The decision is 'Accepted' \u2014 inside the vocabulary case-insensitively, outside it as bytes. 16 is a word the vocabulary never contained. An enum check that normalises case reads this as an acceptance.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "context": {
+    "call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-coverage-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "GUrISuzIssGcot1U1RFv02lETpxCYoQ0tz421ALSdqE"
+    }
+  },
+  "evidence": {
+    "terminal_state": "accepted",
+    "physical_completion_claim": "none",
+    "completeness_claim": "not_proven"
+  },
+  "receipt": {
+    "issuer": "did:web:factory.example:safety-controller",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-coverage-2026q3",
+    "issuer_independence": "separate_process",
+    "linked_call_id": "01986d7c-6b2f-7c68-9ff8-3e2f9d0db337",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "action_ref": "sha256:c2e97956de8b86d825780fcecea601a6eea02616855e6f0aa19d10bd351fe034",
+    "evidence_type": "application/vnd.agentrust.action-receipt+json",
+    "evidence_hash": "sha256:cf43260df01d89b5ce9ed0dce484ae1e3331fb477efda92cd0fd9365df9089d7",
+    "previous_receipt_hash": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1",
+    "issued_at": "2026-07-06T15:22:15Z",
+    "decision": "Accepted",
+    "signature": "92m895J8ch_NfD0M-mkDq0WNm-pud6bI9zKJ5PoNM63wgWXzeTdpeAwDC6Sg1u-QYr2Qx2z4oOgjL9SNXH5OBA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "decision_invalid"
+    ],
+    "warnings": []
+  }
+}

--- a/examples/action-receipts/conformance/gen_rule_coverage_vectors.py
+++ b/examples/action-receipts/conformance/gen_rule_coverage_vectors.py
@@ -1,11 +1,22 @@
-"""Close the seven receipt rules the conformance set never exercised.
+"""Rule-coverage vectors for the receipt verifier: 10-16, and the second set 17-30.
 
-Each of these checks exists in the verifier with no vector behind it, so an
-implementation could omit the check entirely and still pass. One fixture per rule,
-each triggering exactly that rule and nothing else.
+10-16 close the seven receipt rules the conformance set never exercised (merged
+upstream as PR #122): each triggers exactly one rule that previously had no vector
+behind it.
 
-The existing fixtures pin a key whose private half is not published, so these pin
-their own deterministic test key. Public JWKs only.
+17-30 give **every** receipt rule a second, independent vector (upstream #124: at
+least two independent vectors per rule, where two vectors are independent if a single
+implementation defect causes one to pass and the other to fail). Each second vector is
+adversarially placed against a specific implementation shortcut its partner cannot
+detect: digests that agree with the expected value through the first sixteen hex
+characters but not after, identifiers that differ only by case, freshness violations
+of exactly one second, a structurally well-formed signature of the wrong length, and
+a receipt that is explicitly ``null`` rather than absent. The defect each pair is
+split by is declared in ``tests/test_vector_completeness.py::DEFECTS`` and enforced
+there.
+
+The 01-09 fixtures pin a key whose private half is not published, so everything here
+pins its own deterministic test key. Public JWKs only.
 """
 
 from __future__ import annotations
@@ -21,7 +32,7 @@ import rfc8785
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-OUT = Path("examples/action-receipts/conformance")
+OUT = Path(__file__).resolve().parent
 PROFILE = "trace.action_receipt.conformance.v0"
 ISSUER = "did:web:factory.example:safety-controller"
 KEY_ID = f"{ISSUER}#ed25519-coverage-2026q3"
@@ -226,6 +237,229 @@ def main() -> None:
             "verb must not be read as either acceptance or rejection.",
             "decision_invalid",
             receipt_overrides={"decision": "deferred"},
+        ),
+    ))
+
+    # -----------------------------------------------------------------------
+    # 17-30: the second vector for every receipt rule (#124).
+    #
+    # Each is placed where its partner has no reach. The partner vectors above and
+    # in 01-09 violate their rule loudly — a wholly different digest, a different
+    # identifier, minutes of staleness. These violate the same rules at the margin
+    # an implementation shortcut would forgive: matching prefixes, case variants,
+    # one-second boundaries, well-formed-but-wrong structures.
+    # -----------------------------------------------------------------------
+
+    def tail_flip(digest: str) -> str:
+        """The same digest through every prefix, wrong in the final character."""
+        return digest[:-1] + ("0" if digest[-1] != "0" else "1")
+
+    correct_ref = sha256_jcs({name: ACTION[name] for name in ACTION_REF_FIELDS})
+
+    # receipt_missing, second vector: the receipt key is present and null. An
+    # implementation that tests key presence rather than null-ness reads this as a
+    # receipt and falls through to dereference it.
+    fixtures.append((
+        "17-missing-receipt-explicit-null.json",
+        {
+            "name": "missing-receipt-explicit-null",
+            "description": "A required receipt supplied as an explicit null rather "
+            "than omitted. The same absence as 03 through a different door: a "
+            "verifier that checks for the key rather than the value treats this as "
+            "a present receipt.",
+            "profile": PROFILE,
+            "context": {
+                "call_id": CALL_ID,
+                "session_id": SESSION,
+                "require_receipt": True,
+                "verification_time": "2026-07-06T15:24:00Z",
+                "max_receipt_age_seconds": 300,
+                "expected_previous_receipt_hash": PREV_HASH,
+            },
+            "action": {**ACTION, "action_ref": correct_ref},
+            "trusted_issuer_keys": {KEY_ID: jwk()},
+            "receipt": None,
+            "expected": {
+                "status": "receipt_missing_required",
+                "controller_outcome": "unknown",
+                "failures": ["receipt_missing"],
+                "warnings": [],
+            },
+        },
+    ))
+
+    forged_tail = tail_flip(correct_ref)
+    f = build(
+        "action-ref-tail-forged",
+        "The declared action_ref equals the recomputed digest through the first "
+        "sixteen hex characters and differs in the last. 10 is caught by any "
+        "comparison at all; this one requires comparing the whole digest.",
+        "action_ref_invalid",
+        receipt_overrides={"action_ref": forged_tail},
+    )
+    f["action"]["action_ref"] = forged_tail  # keep them equal: only the digest rule fires
+    fixtures.append(("18-action-ref-tail-forged.json", f))
+
+    fixtures.append((
+        "19-action-ref-mismatch-in-tail.json",
+        build(
+            "action-ref-mismatch-in-tail",
+            "The receipt's action_ref differs from the action's only in the final "
+            "character. 05 differs from the first character; a truncated comparison "
+            "passes this one.",
+            "action_ref_mismatch",
+            receipt_overrides={"action_ref": tail_flip(correct_ref)},
+        ),
+    ))
+
+    fixtures.append((
+        "20-call-id-case-mismatch.json",
+        build(
+            "call-id-case-mismatch",
+            "The receipt's linked_call_id is the context's call id upper-cased. 11 is "
+            "a different call outright; this one is the same bytes through any "
+            "case-normalising comparison.",
+            "call_id_mismatch",
+            receipt_overrides={"linked_call_id": CALL_ID.upper()},
+        ),
+    ))
+
+    fixtures.append((
+        "21-session-id-case-mismatch.json",
+        build(
+            "session-id-case-mismatch",
+            "The receipt's session_id is the context's session id upper-cased. Session "
+            "identifiers are opaque strings: two that differ by case are two sessions.",
+            "session_id_mismatch",
+            receipt_overrides={"session_id": SESSION.upper()},
+        ),
+    ))
+
+    fixtures.append((
+        "22-evidence-hash-mismatch-in-tail.json",
+        build(
+            "evidence-hash-mismatch-in-tail",
+            "The receipt's evidence_hash agrees with the recomputed digest through "
+            "every prefix and is wrong in the final character. 13 is wrong from the "
+            "start; only a full-width comparison catches this one.",
+            "evidence_hash_mismatch",
+            receipt_overrides={"evidence_hash": tail_flip(sha256_jcs(EVIDENCE))},
+        ),
+    ))
+
+    # issuer_key_unknown, second vector: the pinned set holds this very key under a
+    # case-variant of the receipt's key id. Key identifiers are opaque: a lookup that
+    # normalises case resolves this and treats the receipt as verifiable.
+    f = build(
+        "receipt-issuer-key-case-variant",
+        "The trusted set pins the right public key under a case-variant of the "
+        "receipt's issuer_key_id. An exact lookup does not hold this key; a "
+        "case-normalising lookup does, and verifies. 14 names a key absent under "
+        "any normalisation.",
+        "issuer_key_unknown",
+        trusted={KEY_ID.upper(): jwk()},
+    )
+    f["expected"] = {
+        "status": "receipt_unverified",
+        "controller_outcome": "unknown",
+        "failures": [],
+        "warnings": ["issuer_key_unknown"],
+    }
+    fixtures.append(("23-receipt-issuer-key-case-variant.json", f))
+
+    # signature_or_key_mismatch, second vector: a signature that decodes cleanly to
+    # the wrong number of bytes. 04 is a well-formed 64-byte signature by the wrong
+    # key, which only cryptographic verification rejects; this one is rejected by
+    # structure alone. An implementation that stops at structure passes 04.
+    f = build(
+        "receipt-signature-malformed",
+        "The signature is valid base64url decoding to 32 bytes — half an Ed25519 "
+        "signature. 04 carries a well-formed signature by the wrong key; together "
+        "they separate structural validation from cryptographic verification.",
+        "signature_or_key_mismatch",
+    )
+    f["receipt"]["signature"] = b64u(bytes(32))  # after signing: structurally short
+    fixtures.append(("24-receipt-signature-malformed.json", f))
+
+    fixtures.append((
+        "25-stale-receipt-boundary.json",
+        build(
+            "stale-receipt-boundary",
+            "Stale by exactly one second: age 301 against a 300-second ceiling. 06 is "
+            "stale by nineteen minutes; any tolerance an implementation grants "
+            "swallows this one.",
+            "receipt_stale",
+            receipt_overrides={"issued_at": "2026-07-06T15:18:59Z"},
+        ),
+    ))
+
+    fixtures.append((
+        "26-receipt-from-future-boundary.json",
+        build(
+            "receipt-from-future-boundary",
+            "Issued one second after the verification time. 15 is two minutes ahead; "
+            "a clock-skew allowance passes this one.",
+            "receipt_from_future",
+            receipt_overrides={"issued_at": "2026-07-06T15:24:01Z"},
+        ),
+    ))
+
+    fixtures.append((
+        "27-receipt-chain-gap-in-tail.json",
+        build(
+            "receipt-chain-gap-in-tail",
+            "The previous_receipt_hash matches the expected predecessor through every "
+            "prefix and differs in the final character. 07 links somewhere else "
+            "entirely.",
+            "receipt_chain_gap",
+            receipt_overrides={"previous_receipt_hash": tail_flip(PREV_HASH)},
+        ),
+    ))
+
+    fixtures.append((
+        "28-physical-completion-claim-case.json",
+        build(
+            "physical-completion-claim-case",
+            "The claim is 'None' — the vocabulary word 'none' through any "
+            "case-normalising comparison, and outside the vocabulary as bytes. 09 "
+            "claims completion outright.",
+            "unsupported_physical_completion_claim",
+            evidence={**EVIDENCE, "physical_completion_claim": "None"},
+        ),
+    ))
+
+    # issuer_not_independent, second vector: the same self-report on the rejected
+    # path. A warning wired only into the acceptance branch — a natural shortcut,
+    # since acceptance is where self-reporting profits — goes silent here.
+    f = build(
+        "same-party-self-report-rejected",
+        "A gateway self-report on a rejected action. 08 self-reports an acceptance; "
+        "independence of the issuer matters on both branches, and a warning emitted "
+        "only for acceptances misses this one.",
+        "issuer_not_independent",
+        evidence={**EVIDENCE, "terminal_state": "rejected"},
+        receipt_overrides={
+            "issuer_independence": "gateway_self_report",
+            "decision": "rejected",
+        },
+    )
+    f["expected"] = {
+        "status": "receipt_valid_rejected",
+        "controller_outcome": "rejected",
+        "failures": [],
+        "warnings": ["issuer_not_independent"],
+    }
+    fixtures.append(("29-same-party-self-report-rejected.json", f))
+
+    fixtures.append((
+        "30-decision-case-variant.json",
+        build(
+            "decision-case-variant",
+            "The decision is 'Accepted' — inside the vocabulary case-insensitively, "
+            "outside it as bytes. 16 is a word the vocabulary never contained. An "
+            "enum check that normalises case reads this as an acceptance.",
+            "decision_invalid",
+            receipt_overrides={"decision": "Accepted"},
         ),
     ))
 

--- a/tests/test_action_receipt_fixtures.py
+++ b/tests/test_action_receipt_fixtures.py
@@ -1,4 +1,20 @@
-"""Conformance checks for the informative action-receipt fixture set."""
+"""Conformance checks for the informative action-receipt fixture set.
+
+The verifier consumes an explicit registry of named rules (``RULES``) rather than
+emitting failure codes inline. The registry is the inventory: every obligation this
+verifier enforces is one ``Rule`` entry, and the completeness suite in
+`test_vector_completeness.py` mutates registry entries by name — removing or weakening
+one hook at a time — to prove each rule is load-bearing for at least two independent
+fixtures.
+
+That shape is the review outcome of #124: recovering the rule inventory from this
+module's source (by AST-walking for string literals appended to failure lists) stays
+blind to ``append`` vs ``extend``, constants, f-strings and refactors — a source-derived
+inventory can silently under-count. A registry the verifier itself consumes turns "add
+a rule without adding it to the inventory" from heuristically detectable into
+structurally difficult: a check that is not registered is a check that never runs, and
+an unregistered emission path is a guard failure, not a silent hole.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +22,8 @@ import base64
 import binascii
 import hashlib
 import json
-from dataclasses import dataclass
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -19,6 +36,18 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 FIXTURE_DIR = Path(__file__).parent.parent / "examples" / "action-receipts" / "conformance"
 ACTION_REF_FIELDS = ("agent_id", "action_type", "action_scope", "action_timestamp")
 
+STATUSES = frozenset(
+    {
+        "receipt_valid_accepted",
+        "receipt_valid_rejected",
+        "receipt_invalid",
+        "receipt_unverified",
+        "receipt_missing_required",
+    }
+)
+"""Every outcome the verifier can return. Enforced at construction: a status outside
+this set is a bug in the verifier, not a new outcome."""
+
 
 @dataclass(frozen=True)
 class ReceiptResult:
@@ -26,6 +55,14 @@ class ReceiptResult:
     controller_outcome: str
     failures: list[str]
     warnings: list[str]
+
+    def __post_init__(self) -> None:
+        assert self.status in STATUSES, f"undeclared verifier outcome {self.status!r}"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
 
 def _load_fixture(path: Path) -> dict[str, Any]:
@@ -48,82 +85,172 @@ def _parse_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def _verify_signature(receipt: dict[str, Any], trusted_jwk: dict[str, str]) -> None:
+def _receipt_age_seconds(fixture: dict[str, Any]) -> float:
+    delta = _parse_timestamp(fixture["context"]["verification_time"]) - _parse_timestamp(
+        fixture["receipt"]["issued_at"]
+    )
+    return delta.total_seconds()
+
+
+def _trusted_jwk(fixture: dict[str, Any], signed: dict[str, Any]) -> dict[str, str] | None:
+    return fixture["trusted_issuer_keys"].get(signed["issuer_key_id"])
+
+
+def _signature_invalid(signed: dict[str, Any], trusted_jwk: dict[str, str]) -> bool:
     if trusted_jwk.get("kty") != "OKP" or trusted_jwk.get("crv") != "Ed25519":
-        raise ValueError("fixture key must be an Ed25519 OKP JWK")
-    public_key = Ed25519PublicKey.from_public_bytes(_decode_base64url(trusted_jwk["x"]))
-    signing_input = {key: value for key, value in receipt.items() if key != "signature"}
-    public_key.verify(_decode_base64url(receipt["signature"]), rfc8785.dumps(signing_input))
+        return True
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(_decode_base64url(trusted_jwk["x"]))
+        signing_input = {key: value for key, value in signed.items() if key != "signature"}
+        public_key.verify(_decode_base64url(signed["signature"]), rfc8785.dumps(signing_input))
+    except (InvalidSignature, ValueError):
+        return True
+    return False
 
 
-def _verify_fixture(fixture: dict[str, Any]) -> ReceiptResult:
-    context = fixture["context"]
-    action = fixture["action"]
+# ---------------------------------------------------------------------------
+# The rule registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One named obligation. ``check`` returns True when the defect it guards against
+    is observed in the fixture — i.e. True means the code is emitted."""
+
+    code: str
+    severity: str  # "failure" | "warning"
+    path: str  # "receipt" | "missing"
+    check: Callable[[dict[str, Any]], bool] = field(compare=False)
+
+
+def _action_ref_invalid(f: dict[str, Any]) -> bool:
+    preimage = {name: f["action"][name] for name in ACTION_REF_FIELDS}
+    return bool(f["action"]["action_ref"] != _sha256_jcs(preimage))
+
+
+def _action_ref_mismatch(f: dict[str, Any]) -> bool:
+    return bool(f["receipt"]["action_ref"] != f["action"]["action_ref"])
+
+
+def _call_id_mismatch(f: dict[str, Any]) -> bool:
+    return bool(f["receipt"]["linked_call_id"] != f["context"]["call_id"])
+
+
+def _session_id_mismatch(f: dict[str, Any]) -> bool:
+    return bool(f["receipt"]["session_id"] != f["context"]["session_id"])
+
+
+def _evidence_hash_mismatch(f: dict[str, Any]) -> bool:
+    return bool(f["receipt"]["evidence_hash"] != _sha256_jcs(f["evidence"]))
+
+
+def _issuer_key_unknown(f: dict[str, Any]) -> bool:
+    # Spec section 3.3.1: a receipt whose issuer key is unknown to the verifier is
+    # unverified, not invalid. An unpinned key is an inability to check, not
+    # evidence of forgery, so this is an advisory rather than a failure; the
+    # structural checks still run, and any of them failing is positive evidence
+    # that does make the receipt invalid.
+    return _trusted_jwk(f, f["receipt"]) is None
+
+
+def _receipt_signature_invalid(f: dict[str, Any]) -> bool:
+    jwk = _trusted_jwk(f, f["receipt"])
+    return jwk is not None and _signature_invalid(f["receipt"], jwk)
+
+
+def _receipt_stale(f: dict[str, Any]) -> bool:
+    return _receipt_age_seconds(f) > f["context"]["max_receipt_age_seconds"]
+
+
+def _receipt_from_future(f: dict[str, Any]) -> bool:
+    return _receipt_age_seconds(f) < 0
+
+
+def _receipt_chain_gap(f: dict[str, Any]) -> bool:
+    return bool(
+        f["receipt"]["previous_receipt_hash"] != f["context"]["expected_previous_receipt_hash"]
+    )
+
+
+def _unsupported_physical_completion(f: dict[str, Any]) -> bool:
+    return bool(f["evidence"]["physical_completion_claim"] != "none")
+
+
+def _issuer_not_independent(f: dict[str, Any]) -> bool:
+    return bool(f["receipt"]["issuer_independence"] == "gateway_self_report")
+
+
+def _decision_invalid(f: dict[str, Any]) -> bool:
+    return f["receipt"]["decision"] not in {"accepted", "rejected"}
+
+
+def _receipt_missing(f: dict[str, Any]) -> bool:
+    return f.get("receipt") is None
+
+
+RULES: tuple[Rule, ...] = (
+    # -- a required receipt that was never produced ------------------------------
+    Rule("receipt_missing", "failure", "missing", _receipt_missing),
+    # -- receipts ----------------------------------------------------------------
+    Rule("action_ref_invalid", "failure", "receipt", _action_ref_invalid),
+    Rule("action_ref_mismatch", "failure", "receipt", _action_ref_mismatch),
+    Rule("call_id_mismatch", "failure", "receipt", _call_id_mismatch),
+    Rule("session_id_mismatch", "failure", "receipt", _session_id_mismatch),
+    Rule("evidence_hash_mismatch", "failure", "receipt", _evidence_hash_mismatch),
+    Rule("issuer_key_unknown", "warning", "receipt", _issuer_key_unknown),
+    Rule("signature_or_key_mismatch", "failure", "receipt", _receipt_signature_invalid),
+    Rule("receipt_stale", "failure", "receipt", _receipt_stale),
+    Rule("receipt_from_future", "failure", "receipt", _receipt_from_future),
+    Rule("receipt_chain_gap", "failure", "receipt", _receipt_chain_gap),
+    Rule(
+        "unsupported_physical_completion_claim",
+        "failure",
+        "receipt",
+        _unsupported_physical_completion,
+    ),
+    Rule("issuer_not_independent", "warning", "receipt", _issuer_not_independent),
+    Rule("decision_invalid", "failure", "receipt", _decision_invalid),
+)
+
+
+def _evaluate(
+    fixture: dict[str, Any], rules: Sequence[Rule], path: str
+) -> tuple[list[str], list[str]]:
+    """The single point where rule codes are emitted.
+
+    Everything the verifier reports flows through this loop, which is what makes the
+    registry authoritative: the completeness suite asserts by AST that no other code
+    in this module appends to a failure or warning list.
+    """
+    failures: list[str] = []
+    warnings: list[str] = []
+    for rule in rules:
+        if rule.path == path and rule.check(fixture):
+            (failures if rule.severity == "failure" else warnings).append(rule.code)
+    return failures, warnings
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: paths and outcomes
+# ---------------------------------------------------------------------------
+
+
+def _verify_fixture(fixture: dict[str, Any], rules: Sequence[Rule] = RULES) -> ReceiptResult:
     receipt = fixture.get("receipt")
 
     if receipt is None:
-        if context["require_receipt"]:
-            return ReceiptResult(
-                status="receipt_missing_required",
-                controller_outcome="unknown",
-                failures=["receipt_missing"],
-                warnings=[],
-            )
-        raise AssertionError("the conformance set has no optional missing-receipt case")
+        if not fixture["context"]["require_receipt"]:
+            raise AssertionError("the conformance set has no optional missing-receipt case")
+        failures, warnings = _evaluate(fixture, rules, "missing")
+        return ReceiptResult(
+            status="receipt_missing_required",
+            controller_outcome="unknown",
+            failures=failures,
+            warnings=warnings,
+        )
 
-    failures: list[str] = []
-    warnings: list[str] = []
-
-    action_preimage = {field: action[field] for field in ACTION_REF_FIELDS}
-    expected_action_ref = _sha256_jcs(action_preimage)
-    if action["action_ref"] != expected_action_ref:
-        failures.append("action_ref_invalid")
-    if receipt["action_ref"] != action["action_ref"]:
-        failures.append("action_ref_mismatch")
-
-    if receipt["linked_call_id"] != context["call_id"]:
-        failures.append("call_id_mismatch")
-    if receipt["session_id"] != context["session_id"]:
-        failures.append("session_id_mismatch")
-
-    evidence = fixture["evidence"]
-    if receipt["evidence_hash"] != _sha256_jcs(evidence):
-        failures.append("evidence_hash_mismatch")
-
-    trusted_jwk = fixture["trusted_issuer_keys"].get(receipt["issuer_key_id"])
-    if trusted_jwk is None:
-        # Spec section 3.3.1: a receipt whose issuer key is unknown to the verifier is
-        # unverified, not invalid. An unpinned key is an inability to check, not
-        # evidence of forgery, so this is an advisory rather than a failure; the
-        # structural checks below still run, and any of them failing is positive
-        # evidence that does make the receipt invalid.
-        warnings.append("issuer_key_unknown")
-    else:
-        try:
-            _verify_signature(receipt, trusted_jwk)
-        except (InvalidSignature, ValueError):
-            failures.append("signature_or_key_mismatch")
-
-    receipt_age = _parse_timestamp(context["verification_time"]) - _parse_timestamp(
-        receipt["issued_at"]
-    )
-    if receipt_age.total_seconds() > context["max_receipt_age_seconds"]:
-        failures.append("receipt_stale")
-    if receipt_age.total_seconds() < 0:
-        failures.append("receipt_from_future")
-
-    if receipt["previous_receipt_hash"] != context["expected_previous_receipt_hash"]:
-        failures.append("receipt_chain_gap")
-
-    if evidence["physical_completion_claim"] != "none":
-        failures.append("unsupported_physical_completion_claim")
-
-    if receipt["issuer_independence"] == "gateway_self_report":
-        warnings.append("issuer_not_independent")
-
-    decision = receipt["decision"]
-    if decision not in {"accepted", "rejected"}:
-        failures.append("decision_invalid")
+    failures, warnings = _evaluate(fixture, rules, "receipt")
 
     if failures:
         return ReceiptResult(
@@ -133,7 +260,7 @@ def _verify_fixture(fixture: dict[str, Any]) -> ReceiptResult:
             warnings=warnings,
         )
 
-    if trusted_jwk is None:
+    if "issuer_key_unknown" in warnings:
         # Nothing failed, but nothing was signed by a key the verifier could check
         # either. The receipt confers no trust and proves no wrongdoing, and the
         # controller outcome stays unknown because the evidence is only as good as
@@ -145,14 +272,22 @@ def _verify_fixture(fixture: dict[str, Any]) -> ReceiptResult:
             warnings=warnings,
         )
 
-    status = "receipt_valid_accepted" if decision == "accepted" else "receipt_valid_rejected"
+    status = (
+        "receipt_valid_accepted"
+        if receipt["decision"] == "accepted"
+        else "receipt_valid_rejected"
+    )
     return ReceiptResult(
         status=status,
-        controller_outcome=evidence["terminal_state"],
+        controller_outcome=fixture["evidence"]["terminal_state"],
         failures=[],
         warnings=warnings,
     )
 
+
+# ---------------------------------------------------------------------------
+# The conformance run
+# ---------------------------------------------------------------------------
 
 FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
 
@@ -177,6 +312,24 @@ def test_fixture_set_is_complete() -> None:
         "14-receipt-issuer-key-unknown.json",
         "15-receipt-from-future.json",
         "16-decision-not-in-enum.json",
+        # 17-30 are the second vector for every rule (#124: two independent vectors
+        # each), placed against implementation shortcuts the first set cannot detect —
+        # prefix-true digests, case-variant identifiers, one-second boundaries,
+        # structural-but-wrong signatures, an explicit-null receipt.
+        "17-missing-receipt-explicit-null.json",
+        "18-action-ref-tail-forged.json",
+        "19-action-ref-mismatch-in-tail.json",
+        "20-call-id-case-mismatch.json",
+        "21-session-id-case-mismatch.json",
+        "22-evidence-hash-mismatch-in-tail.json",
+        "23-receipt-issuer-key-case-variant.json",
+        "24-receipt-signature-malformed.json",
+        "25-stale-receipt-boundary.json",
+        "26-receipt-from-future-boundary.json",
+        "27-receipt-chain-gap-in-tail.json",
+        "28-physical-completion-claim-case.json",
+        "29-same-party-self-report-rejected.json",
+        "30-decision-case-variant.json",
     ]
 
 

--- a/tests/test_vector_completeness.py
+++ b/tests/test_vector_completeness.py
@@ -1,0 +1,469 @@
+"""Completeness checks over the action-receipt conformance vectors.
+
+`test_action_receipt_fixtures.py` asks whether the vectors are *correct*. This module
+asks whether they are *complete*: does every obligation the verifier implements have
+vectors that notice when the obligation is gone — and notice it from more than one
+direction?
+
+The rule inventory is ``RULES``, the registry the verifier itself consumes. A
+hand-maintained rule list drifts when someone forgets to extend it; an inventory
+recovered from the verifier's source by AST search has the mirror failure — a rule
+written as ``extend([...])``, ``+=``, an f-string or a named constant is invisible to
+the walk, and the suite reports complete coverage over an inventory that is quietly
+missing entries (#124). The registry inverts that: a check that is not registered
+never runs, so it cannot silently exist outside the inventory, and
+``test_no_emission_outside_the_registry`` is the residual guard for code that would
+try to emit around it.
+
+Mutation therefore targets **named rule hooks**: a rule is deleted by rebuilding the
+registry without its entry, or weakened by substituting its check — never by
+pattern-matching source text — so the mutation cannot drift away from the code under
+test.
+
+The questions, in increasing strength:
+
+1. Does any fixture expect a code the registry cannot produce? (dead expectations)
+2. Is every registered rule exercised by some fixture? (unexercised rules)
+3. Does deleting each rule change at least **two** fixtures' outcomes? (#124:
+   single-vector coverage has no margin — one fixture weakened or renamed away
+   silently removes a rule's coverage)
+4. Are two of those fixtures **independent** — is there a single plausible
+   implementation defect that one catches and the other misses? Two copies of the
+   same vector satisfy question 3 and fail this one.
+5. Has any rule's margin dropped below what it was? (silent thinning)
+
+Independence is #124's definition made executable. For every rule, ``DEFECTS``
+declares at least one *weakened* variant of its check, each modelling a real
+implementation shortcut: comparing digest prefixes, case-insensitive identifier
+matching, structural signature validation without cryptography, clock-skew
+tolerances. A rule's vectors are independent when some declared defect deviates at
+least one of them from its expected outcome while leaving another undisturbed. The
+declaration is fail-closed: a registered rule with no defect entry fails the suite,
+so the question "what bug would your second vector catch that your first would not?"
+has to be answered when the rule is added, not after a regression demonstrates it.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.test_action_receipt_fixtures import (
+    ACTION_REF_FIELDS,
+    RULES,
+    STATUSES,
+    Rule,
+    _decode_base64url,
+    _receipt_age_seconds,
+    _sha256_jcs,
+    _trusted_jwk,
+    _verify_fixture,
+)
+
+TESTS_DIR = Path(__file__).parent
+VERIFIER_MODULE = TESTS_DIR / "test_action_receipt_fixtures.py"
+FIXTURE_DIR = TESTS_DIR.parent / "examples" / "action-receipts" / "conformance"
+MARGINS_FILE = TESTS_DIR / "vector_margins.json"
+FIXTURES = sorted(FIXTURE_DIR.glob("*.json"))
+
+RULE_CODES = tuple(rule.code for rule in RULES)
+
+
+# ---------------------------------------------------------------------------
+# Declared defects: one weakened check per rule, minimum
+# ---------------------------------------------------------------------------
+
+Check = Callable[[dict[str, Any]], bool]
+
+
+def _hash_prefix(value: str) -> str:
+    return value[:23]  # "sha256:" + 16 hex characters
+
+
+def _ci_lookup(fixture: dict[str, Any], signed: dict[str, Any]) -> dict[str, str] | None:
+    """A key lookup that normalises case — the classic 'be liberal' shortcut."""
+    wanted = signed["issuer_key_id"].lower()
+    for key_id, jwk in fixture["trusted_issuer_keys"].items():
+        if key_id.lower() == wanted:
+            return jwk
+    return None
+
+
+def _sig_malformed(signed: dict[str, Any]) -> bool:
+    """Structural validation only: decodes and length-checks, never verifies."""
+    try:
+        return len(_decode_base64url(signed["signature"])) != 64
+    except ValueError:
+        return True
+
+
+def _recomputed_action_ref(fixture: dict[str, Any]) -> str:
+    return _sha256_jcs({name: fixture["action"][name] for name in ACTION_REF_FIELDS})
+
+
+DEFECTS: dict[str, dict[str, Check]] = {
+    # An implementation that tests key presence rather than null-ness treats an
+    # explicit `"receipt": null` as a receipt.
+    "receipt_missing": {
+        "treats_explicit_null_as_present": lambda f: "receipt" not in f,
+    },
+    # Digest comparisons shortened to a prefix — log-friendly truncation that leaks
+    # into the comparison.
+    "action_ref_invalid": {
+        "compares_truncated_digest": lambda f: _hash_prefix(_recomputed_action_ref(f))
+        != _hash_prefix(f["action"]["action_ref"]),
+    },
+    "action_ref_mismatch": {
+        "compares_truncated_digest": lambda f: _hash_prefix(f["receipt"]["action_ref"])
+        != _hash_prefix(f["action"]["action_ref"]),
+    },
+    "evidence_hash_mismatch": {
+        "compares_truncated_digest": lambda f: _hash_prefix(f["receipt"]["evidence_hash"])
+        != _hash_prefix(_sha256_jcs(f["evidence"])),
+    },
+    "receipt_chain_gap": {
+        "compares_truncated_digest": lambda f: _hash_prefix(
+            f["receipt"]["previous_receipt_hash"]
+        )
+        != _hash_prefix(f["context"]["expected_previous_receipt_hash"]),
+    },
+    # Identifier comparisons that normalise case, as URL- and DID-handling code
+    # habitually does.
+    "call_id_mismatch": {
+        "compares_case_insensitively": lambda f: f["receipt"]["linked_call_id"].lower()
+        != f["context"]["call_id"].lower(),
+    },
+    "session_id_mismatch": {
+        "compares_case_insensitively": lambda f: f["receipt"]["session_id"].lower()
+        != f["context"]["session_id"].lower(),
+    },
+    "issuer_key_unknown": {
+        "looks_up_keys_case_insensitively": lambda f: _ci_lookup(f, f["receipt"]) is None,
+    },
+    "decision_invalid": {
+        "matches_enum_case_insensitively": lambda f: f["receipt"]["decision"].lower()
+        not in {"accepted", "rejected"},
+    },
+    "unsupported_physical_completion_claim": {
+        "compares_case_insensitively": lambda f: f["evidence"][
+            "physical_completion_claim"
+        ].lower()
+        != "none",
+    },
+    # A signature check that stops at well-formedness.
+    "signature_or_key_mismatch": {
+        "checks_structure_only": lambda f: _trusted_jwk(f, f["receipt"]) is not None
+        and _sig_malformed(f["receipt"]),
+    },
+    # Freshness windows padded with tolerance an operator once asked for.
+    "receipt_stale": {
+        "grants_sixty_seconds_grace": lambda f: _receipt_age_seconds(f)
+        > f["context"]["max_receipt_age_seconds"] + 60,
+    },
+    "receipt_from_future": {
+        "tolerates_sixty_seconds_skew": lambda f: _receipt_age_seconds(f) < -60,
+    },
+    # A warning wired to the happy path only.
+    "issuer_not_independent": {
+        "warns_only_on_accepted": lambda f: f["receipt"]["issuer_independence"]
+        == "gateway_self_report"
+        and f["receipt"]["decision"] == "accepted",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Running the verifier under mutation
+# ---------------------------------------------------------------------------
+
+Outcome = tuple[str, str, tuple[str, ...], tuple[str, ...]]
+
+
+def _expected(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))["expected"]
+
+
+def _outcomes(rules: tuple[Rule, ...]) -> list[Outcome]:
+    """Full outcome per fixture: status, failures and warnings.
+
+    Status alone is too coarse. Under a status-only comparison a warning can never be
+    load-bearing by construction, which reads as "warnings are untestable" when it is
+    only an artifact of what is being compared.
+    """
+    results: list[Outcome] = []
+    for path in FIXTURES:
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            r = _verify_fixture(fixture, rules)
+            results.append((path.name, r.status, tuple(r.failures), tuple(r.warnings)))
+        except Exception as exc:  # a mutation that breaks the verifier still counts
+            results.append((path.name, f"raised:{type(exc).__name__}", (), ()))
+    return results
+
+
+def _baseline() -> list[Outcome]:
+    return [
+        (path.name, e["status"], tuple(e.get("failures", [])), tuple(e.get("warnings", [])))
+        for path, e in ((p, _expected(p)) for p in FIXTURES)
+    ]
+
+
+BASELINE = _baseline()
+
+
+def _without(code: str) -> tuple[Rule, ...]:
+    return tuple(rule for rule in RULES if rule.code != code)
+
+
+def _weakened(code: str, check: Check) -> tuple[Rule, ...]:
+    return tuple(
+        replace(rule, check=check) if rule.code == code else rule for rule in RULES
+    )
+
+
+def _deviating(rules: tuple[Rule, ...]) -> set[str]:
+    """Fixture names whose outcome under `rules` departs from their expected block."""
+    return {
+        was[0]
+        for was, now in zip(BASELINE, _outcomes(rules), strict=True)
+        if was != now
+    }
+
+
+def _margin(code: str) -> set[str]:
+    """The fixtures that notice this rule's deletion."""
+    return _deviating(_without(code))
+
+
+# ---------------------------------------------------------------------------
+# 0. Guards on the instrument itself
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_well_formed() -> None:
+    """Vacuity and hygiene: the inventory below is only as good as the registry."""
+    assert FIXTURES, "no fixtures found"
+    assert len(RULES) >= 13, "the registry lost most of its entries"
+    assert len(set(RULE_CODES)) == len(RULE_CODES), "duplicate rule codes in the registry"
+    assert all(rule.severity in {"failure", "warning"} for rule in RULES)
+    assert all(rule.path in {"receipt", "missing"} for rule in RULES)
+
+
+def test_no_emission_outside_the_registry() -> None:
+    """Nothing in the verifier may emit a code around the registry.
+
+    The registry is the inventory *because* `_evaluate` is the only place a code is
+    emitted. This walks the verifier's source and fails on: an append to a failure or
+    warning collection anywhere else, or a literal code smuggled into a result's
+    `failures=`/`warnings=` argument.
+    """
+    tree = ast.parse(VERIFIER_MODULE.read_text(encoding="utf-8"))
+
+    enclosing: dict[ast.AST, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for child in ast.walk(node):
+                enclosing.setdefault(child, node.name)
+
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"append", "extend", "insert"}
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in {"failures", "warnings"}
+            and enclosing.get(node) != "_evaluate"
+        ):
+            findings.append(
+                f"line {node.lineno}: {node.func.value.id}.{node.func.attr}(...) outside "
+                "_evaluate"
+            )
+        if isinstance(node, ast.keyword) and node.arg in {"failures", "warnings"}:
+            if isinstance(node.value, ast.List):
+                for element in node.value.elts:
+                    if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                        findings.append(
+                            f"line {element.lineno}: literal {element.value!r} in a "
+                            f"{node.arg}= argument bypasses the registry"
+                        )
+
+    assert not findings, (
+        "the verifier emits outside the registry, so the inventory is incomplete:\n  "
+        + "\n  ".join(findings)
+    )
+
+
+def test_registry_codes_are_literals() -> None:
+    """Every `Rule(...)` names its code as a string literal.
+
+    Not needed at runtime — the imported registry is the ground truth either way —
+    but a computed code would make the registry unreadable in review, and reviewability
+    is half of what the registry is for.
+    """
+    tree = ast.parse(VERIFIER_MODULE.read_text(encoding="utf-8"))
+    computed = [
+        f"line {node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Rule"
+        and node.args
+        and not (
+            isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str)
+        )
+    ]
+    assert not computed, f"Rule() calls with computed codes: {computed}"
+
+
+# ---------------------------------------------------------------------------
+# 1-2. Cheap diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _codes_expected_by_fixtures() -> set[str]:
+    codes: set[str] = set()
+    for path in FIXTURES:
+        expected = _expected(path)
+        codes.update(expected.get("failures", []))
+        codes.update(expected.get("warnings", []))
+    return codes
+
+
+def test_no_fixture_expects_a_code_the_registry_cannot_emit() -> None:
+    """A fixture naming a code nothing produces holds an assertion that cannot fail."""
+    orphans = _codes_expected_by_fixtures() - set(RULE_CODES)
+    assert not orphans, (
+        f"fixtures expect codes no registered rule produces: {sorted(orphans)}. "
+        "Either the rule was removed and the fixture kept, or the code is misspelled — "
+        "in both cases the fixture is no longer testing anything."
+    )
+
+
+def test_every_registered_rule_is_exercised_by_some_fixture() -> None:
+    unexercised = sorted(set(RULE_CODES) - _codes_expected_by_fixtures())
+    assert not unexercised, (
+        f"{len(unexercised)} obligation(s) have no conformance vector: {unexercised}. "
+        "Each is a check a conforming implementation could omit entirely and still pass."
+    )
+
+
+def test_every_declared_outcome_is_reached_by_some_fixture() -> None:
+    reached = {_expected(path)["status"] for path in FIXTURES}
+    assert not sorted(STATUSES - reached), (
+        f"outcomes the verifier can return that no fixture produces: "
+        f"{sorted(STATUSES - reached)}"
+    )
+    assert not sorted(reached - STATUSES), (
+        f"fixtures expect outcomes the verifier cannot return: {sorted(reached - STATUSES)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3-4. Margin and independence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", RULE_CODES)
+def test_each_rule_is_load_bearing_for_two_fixtures(code: str) -> None:
+    """Deleting an obligation must change at least two fixtures' outcomes.
+
+    One is existence; two is margin. With a single load-bearing vector, any change
+    that weakens or retires that vector silently removes the rule's coverage — the
+    failure mode #124 exists to close. A rule here has margin two only if both
+    vectors independently notice its deletion, so a vector that merely *names* the
+    rule while another rule fires on its input does not count.
+    """
+    margin = _margin(code)
+    assert len(margin) >= 2, (
+        f"removing rule {code!r} changed {len(margin)} fixture outcome(s) "
+        f"({sorted(margin)}). Two independent vectors are required per rule; with "
+        "fewer, coverage rests on a single fixture and disappears with it."
+    )
+
+
+def test_every_rule_declares_a_defect() -> None:
+    """Fail closed: registering a rule requires declaring what its second vector adds.
+
+    A rule with no weakened variant cannot demonstrate that its vectors are
+    independent rather than copies, so the declaration is part of adding the rule —
+    the mirror of the registry requirement on the verifier side.
+    """
+    missing = sorted(set(RULE_CODES) - set(DEFECTS))
+    assert not missing, f"registered rules with no declared defect variant: {missing}"
+    stale = sorted(set(DEFECTS) - set(RULE_CODES))
+    assert not stale, f"defects declared for rules that no longer exist: {stale}"
+
+
+@pytest.mark.parametrize("code", RULE_CODES)
+def test_vectors_for_each_rule_are_independent(code: str) -> None:
+    """#124's criterion, executed: some single defect separates the rule's vectors.
+
+    For at least one declared weakening of the rule, one load-bearing vector must
+    catch the defective implementation (its outcome deviates from expected) while
+    another passes it. If every declared defect moves all of a rule's vectors
+    together, the vectors are redundant copies: every implementation shortcut they
+    can detect, they detect identically, and the second vector adds count without
+    margin.
+    """
+    bearing = _margin(code)
+    if len(bearing) < 2:
+        pytest.fail(f"rule {code!r} lacks two load-bearing vectors; margin test covers this")
+
+    separations = {}
+    for name, weakened_check in DEFECTS[code].items():
+        caught = _deviating(_weakened(code, weakened_check)) & bearing
+        if 0 < len(caught) < len(bearing):
+            separations[name] = sorted(caught)
+
+    assert separations, (
+        f"no declared defect separates the vectors for {code!r}: every weakening "
+        f"either fools all of {sorted(bearing)} or none of them. The vectors are "
+        "mutually redundant — author one that catches a defect the others miss, or "
+        "declare a defect that tells them apart."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_margins_have_not_thinned() -> None:
+    """A ratchet above the floor: coverage may not silently get thinner.
+
+    The floor is two. Anything above it that exists today — a rule three or four
+    fixtures notice — may not quietly decay back toward the floor: lowering a
+    recorded margin is a decision someone has to make on purpose, in the same commit,
+    with a reason. Raising one is an ordinary PR.
+    """
+    current = {code: len(_margin(code)) for code in RULE_CODES}
+
+    if not MARGINS_FILE.exists():
+        MARGINS_FILE.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        pytest.skip(f"recorded initial margins to {MARGINS_FILE.name}; re-run to enforce")
+
+    recorded: dict[str, int] = json.loads(MARGINS_FILE.read_text(encoding="utf-8"))
+    thinned = {
+        key: (recorded[key], current[key])
+        for key in recorded
+        if key in current and current[key] < recorded[key]
+    }
+    assert not thinned, (
+        "coverage thinned for: "
+        + ", ".join(f"{k} {was}->{now}" for k, (was, now) in sorted(thinned.items()))
+        + f". If the reduction is intended, update {MARGINS_FILE.name} in the same commit "
+        "and say why."
+    )
+
+    vanished = sorted(set(recorded) - set(current))
+    assert not vanished, (
+        f"rules that had recorded margins no longer exist: {vanished}. If they were "
+        f"removed on purpose, drop them from {MARGINS_FILE.name} in the same commit."
+    )

--- a/tests/vector_margins.json
+++ b/tests/vector_margins.json
@@ -1,0 +1,16 @@
+{
+  "action_ref_invalid": 2,
+  "action_ref_mismatch": 2,
+  "call_id_mismatch": 2,
+  "decision_invalid": 2,
+  "evidence_hash_mismatch": 2,
+  "issuer_key_unknown": 2,
+  "issuer_not_independent": 2,
+  "receipt_chain_gap": 2,
+  "receipt_from_future": 2,
+  "receipt_missing": 2,
+  "receipt_stale": 2,
+  "session_id_mismatch": 2,
+  "signature_or_key_mismatch": 2,
+  "unsupported_physical_completion_claim": 2
+}


### PR DESCRIPTION
Closes #124. **Authored by @lywinged**, from their branch `lywinged/trace-spec:feat/124-registry-and-second-vectors`. I rebased it onto current main (it was 33 commits behind) and dropped `uv.lock`; the commit is theirs and the authorship is intact. Opened as a maintainer because the branch had no PR.

**What it does.** Every action-receipt obligation was exercised by exactly one fixture, so deleting, renaming or weakening any single vector silently retired a rule and nothing failed. This gives each of the 14 obligations a second, independent vector and makes the margin enforceable.

The design follows @carloshvp's review on the issue. The AST walk for string literals is retired as the inventory source, because `append`, `extend`, constants and helper returns are silent blind spots. In its place the verifier consumes an explicit tuple of named `Rule` entries and emits every code from a single loop, so an unregistered check is a check that never runs. The AST survives inverted: it now asserts that nothing else in the module appends to a failure or warning list, so an emission path bypassing the registry fails the suite.

Independence is executable rather than asserted. The issue's definition is "one implementation defect makes one vector pass and the other fail", which only means something if the defects are named, so each rule declares at least one weakened variant of its check: digest-prefix comparison, case-normalised identifiers, clock tolerance, signature structure validated without cryptography. Two vectors count as independent only when a declared defect moves one and leaves the other alone, and a rule with no declared defect fails the suite.

`tests/vector_margins.json` is the ratchet: 14 rules, all at margin 2, so anything above the floor cannot decay back to it unnoticed.

**Verified on current main after the rebase:** 313 passed, 1 skipped, ruff clean on `tests/` and `examples/`.

**One limit @lywinged states themselves**, worth keeping visible: independence is relative to the declared defect set, so a shortcut nobody thought to declare is still invisible. It is a floor on discrimination, not a proof of it. They also noted they would rather the vectors were not all authored by one hand, and that a second independently written set would be more valuable as a cross-run than either set alone. That remains open and is not a reason to hold this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
