### PR TITLE
fix(provenance): identify a JWK by its key material, not its dict shape

### DIFF
--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -21,7 +21,12 @@ import re
 import time
 from typing import Any
 
-from agentrust_trace.sign import _canonical_bytes, _pubkey_from_jwk, key_to_jwk
+from agentrust_trace.sign import (
+    _canonical_bytes,
+    _pubkey_from_jwk,
+    jwk_thumbprint,
+    key_to_jwk,
+)
 
 __all__ = [
     "FORMAT",
@@ -252,11 +257,23 @@ def verify_record(record: dict[str, Any], trusted_jwk: dict[str, Any]) -> None:
         raise ProvenanceError("record carries no signature")
 
     embedded = (record.get("cnf") or {}).get("jwk")
-    if embedded and embedded != trusted_jwk:
-        raise ProvenanceError(
-            "the record's embedded key is not the trusted key. A record signed by some "
-            "other key is a record about a server somebody else is describing."
-        )
+    if embedded:
+        # Compared by RFC 7638 thumbprint, not by dict equality. A JWK is identified by
+        # its key material; `kid`, `use` and `alg` are optional members that carry none
+        # of it, and a key resolved from a JWKS endpoint normally has `kid` while
+        # `key_to_jwk` emits the bare minimum. Dict equality made that difference fatal
+        # and rejected records signed by exactly the right key.
+        from hmac import compare_digest
+
+        try:
+            matched = compare_digest(jwk_thumbprint(embedded), jwk_thumbprint(trusted_jwk))
+        except ValueError as exc:
+            raise ProvenanceError(f"the record's embedded key is unusable: {exc}") from exc
+        if not matched:
+            raise ProvenanceError(
+                "the record's embedded key is not the trusted key. A record signed by "
+                "some other key is a record about a server somebody else is describing."
+            )
 
     pub = _pubkey_from_jwk(trusted_jwk)
     body = _canonical_bytes({k: v for k, v in record.items() if k != "signature"})

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -8,6 +8,8 @@ produces.
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from agentrust_trace.provenance import (
@@ -20,7 +22,7 @@ from agentrust_trace.provenance import (
     tool_catalog_hash,
     verify_record,
 )
-from agentrust_trace.sign import generate_key, key_to_jwk
+from agentrust_trace.sign import _canonical_bytes, generate_key, key_to_jwk
 
 DIGEST = "sha256:" + "a" * 64
 OTHER_DIGEST = "sha256:" + "b" * 64
@@ -358,3 +360,53 @@ def test_a_trailing_newline_does_not_satisfy_a_pattern(field: str, value: str) -
 
     with pytest.raises(ProvenanceError):
         verify_record(sign_record(record, key), key_to_jwk(key))
+
+# --- key identity ---------------------------------------------------------
+
+
+def test_a_trusted_key_carrying_kid_still_verifies() -> None:
+    """The deployment case: a key resolved from a JWKS endpoint has `kid`.
+
+    `key_to_jwk` emits the bare `{crv, kty, x}`, while a JWKS serves the same key
+    with `kid` (and often `use`) because that is how it distinguishes keys across
+    rotation. Compared as dicts those differ, and every record signed by exactly
+    the right key was refused.
+    """
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    from_jwks = {**key_to_jwk(key), "kid": "2026q3", "use": "sig"}
+    verify_record(signed, from_jwks)
+
+
+def test_an_embedded_key_carrying_kid_still_verifies() -> None:
+    """The same difference on the record's own `cnf.jwk`.
+
+    Signed by hand because `sign_record` builds `cnf` itself from `key_to_jwk`, so
+    this implementation cannot emit a `cnf.jwk` carrying `kid` even though the
+    format permits one. A record from another implementation can, and it has to
+    verify here.
+    """
+    key = generate_key()
+    payload = {**_forged(), "cnf": {"jwk": {**key_to_jwk(key), "kid": "2026q3"}}}
+    body = _canonical_bytes({k: v for k, v in payload.items() if k != "signature"})
+    signature = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
+    verify_record({**payload, "signature": signature}, key_to_jwk(key))
+
+
+def test_a_genuinely_different_embedded_key_is_still_refused() -> None:
+    """Widening the comparison must not widen it to a different key."""
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    signed["cnf"]["jwk"] = key_to_jwk(generate_key())
+    with pytest.raises(ProvenanceError, match="not the trusted key"):
+        verify_record(signed, key_to_jwk(key))
+
+
+def test_an_unusable_embedded_key_is_refused_rather_than_crashing() -> None:
+    """A `cnf.jwk` with no usable `kty` has no thumbprint; that is a refusal."""
+    key = generate_key()
+    signed = sign_record(_record(), key)
+    signed["cnf"]["jwk"] = {"kty": "RSA-not-supported", "n": "..."}
+    with pytest.raises(ProvenanceError, match="unusable"):
+        verify_record(signed, key_to_jwk(key))
+


### PR DESCRIPTION
## What this changes

`provenance.verify_record` compared the record's `cnf.jwk` against the trusted key
with dict equality:

```python
if embedded and embedded != trusted_jwk:
    raise ProvenanceError("the record's embedded key is not the trusted key. ...")
```

A JWK is identified by its key material. `kid`, `use` and `alg` are optional members
that carry none of it. `key_to_jwk` emits the bare `{crv, kty, x}`, while a key
resolved from a JWKS endpoint normally carries `kid`, because that is how JWKS
distinguishes keys across rotation. The two are the same public key and not the same
dict, so a consumer holding its trusted key from a JWKS rejected every record:

```python
from agentrust_trace import provenance as P
from agentrust_trace.sign import generate_key, key_to_jwk, _pubkey_from_jwk

key = generate_key(); jwk = key_to_jwk(key)
tools = [{"name": "search", "description": "d", "input_schema": {"type": "object"}}]
record = P.build_record(
    kind="publisher-asserted", publisher="did:web:acme.example", tools=tools,
    endpoint={"url": "https://mcp.acme.example", "spki_sha256": "sha256:" + "a" * 64},
)
signed = P.sign_record(record, key)

from_jwks = {**jwk, "kid": "2026q3", "use": "sig"}          # the same key, from a JWKS
_pubkey_from_jwk(jwk).public_bytes_raw() == _pubkey_from_jwk(from_jwks).public_bytes_raw()
# True

P.verify_record(signed, from_jwks)
# ProvenanceError: the record's embedded key is not the trusted key. A record signed
# by some other key is a record about a server somebody else is describing.
```

The signature verified. Only the comparison failed — and the message accuses the
publisher of substituting a key when it used exactly the right one, which leaves an
implementer with nowhere to look: valid signature, correct key, and an error saying
the key is wrong.

Now compared by RFC 7638 thumbprint. `sign.jwk_thumbprint` already implements it, and
its docstring already states the property this needs:

> stable across JWKs that differ in optional members such as `kid`, `alg`, or `use`

The check itself is unchanged in intent — a record whose embedded key is a *different*
key is still refused, and #146's posture depends on that. Only the comparison widens.
A `cnf.jwk` with no usable `kty` is now a refusal rather than an uncaught `ValueError`.

**Also**, `_PUBLISHER_RE` and `_DIGEST_RE` anchored with `$`, which in Python matches
before one final newline, so `publisher = "did:web:acme.example\n"` and a
`tool_catalog.hash` with a trailing newline both passed `verify_record`. Both now
anchor with `\Z`.

Both were raised on #146 and were not part of that fix; #142 is closed, so neither was
being tracked anywhere.

## Tests

Six, and each is load-bearing rather than merely present — reverting the thumbprint
comparison to dict equality fails three of them, reverting the anchors fails the other
two:

- a trusted key carrying `kid`/`use` still verifies (the deployment case)
- an embedded `cnf.jwk` carrying `kid` still verifies
- a genuinely different embedded key is still refused (the widening does not overshoot)
- an unusable `cnf.jwk` is refused rather than crashing
- `publisher` may not carry a trailing newline
- `tool_catalog.hash` may not carry a trailing newline

The embedded-key case is signed by hand, because `sign_record` builds `cnf` itself from
`key_to_jwk` and this implementation therefore cannot emit a `cnf.jwk` carrying `kid`.
Another implementation can, and the format permits it, so the verifier has to accept it.

329 tests pass; ruff and mypy clean.

## Type of change

- [ ] Editorial (typo, link fix, clarification — no normative effect)
- [x] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

Strictly a library fix; no spec text changes. Ticking non-breaking as the closest fit —
records and keys that verified before still verify, and some that were wrongly refused
now verify.

## Spec section

None. `spec/server-provenance-v1.md` is unchanged; §3 already lists `cnf.jwk` as "public
key the signature verifies under", which is the reading this restores.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change) — not applicable, no normative change
- [ ] Breaking changes marked — not applicable
- [ ] Backward compatibility statement — not applicable
