### PR TITLE
fix(examples): correct 2025 timestamps and document the conformance level

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,21 @@
-# TRACE v0.1 example Trust Records
+# TRACE v0.2 example Trust Records
 
-Each file is a canonical TRACE v0.1 Trust Record that validates as-is against
-`schema/trace-claim.json` (no preprocessing, no comment stripping).
+Each file in this directory is a canonical TRACE v0.2 Trust Record that validates
+as-is against `schema/trace-claim.json` (no preprocessing, no comment stripping).
+
+These records are unsigned, so they are **Level 0** artifacts: they show the record
+shape and the claim set, not a cryptographically verifiable record. Check them with
+
+```bash
+pip install agentrust-trace-tests
+trace-tests verify --record examples/amd-sev-snp.json --level 0
+```
+
+At `--level 1` and above every one of them fails `TR-SIG-005` by design, because
+Level 1 requires a signature and `TR-SIG` fails closed. Signed records are produced
+by cmcp at runtime; see [docs/quickstart.md](../docs/quickstart.md) to sign your own.
+`TR-ENV-002` also enforces a 24-hour maximum record age, so pass `--max-age` when
+checking any archived record, including these.
 
 - `intel-tdx.json`: Intel TDX example.
 - `amd-sev-snp.json`: AMD SEV-SNP example.
@@ -15,8 +29,9 @@ Each file is a canonical TRACE v0.1 Trust Record that validates as-is against
   `schema/trace-claim.json`.
 - `canonicalization-boundary/`: three signed Trust Records that separate an
   RFC 8785-conformant canonicalizer from `json.dumps(sort_keys=True)`, which
-  §3.2.2 requires and names as insufficient. These *are* Trust Records and do
-  validate against the schema. See that directory's README.
+  §3.2.2 requires and names as insufficient. Each file is a test-vector envelope;
+  the Trust Record is under the `record` key and validates against the schema.
+  See that directory's README.
 
 The schema sets `additionalProperties: false`, so examples must not carry
 non-schema keys such as `_comment`. Keep descriptive notes in this file.

--- a/examples/amd-sev-snp.json
+++ b/examples/amd-sev-snp.json
@@ -1,6 +1,6 @@
 {
   "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
-  "iat": 1750676142,
+  "iat": 1782212142,
   "subject": "spiffe://trust.example.org/agent/payments-processor/prod",
   "model": {
     "provider": "anthropic",

--- a/examples/intel-tdx.json
+++ b/examples/intel-tdx.json
@@ -1,6 +1,6 @@
 {
   "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
-  "iat": 1750676200,
+  "iat": 1782212200,
   "subject": "spiffe://trust.example.org/agent/document-processor/staging",
   "model": {
     "provider": "meta",

--- a/examples/nvidia-h100.json
+++ b/examples/nvidia-h100.json
@@ -1,6 +1,6 @@
 {
   "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
-  "iat": 1750676300,
+  "iat": 1782212300,
   "subject": "spiffe://trust.example.org/agent/image-analysis/prod",
   "model": {
     "provider": "anthropic",

--- a/examples/sandbox-runtime.json
+++ b/examples/sandbox-runtime.json
@@ -1,6 +1,6 @@
 {
   "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
-  "iat": 1754400000,
+  "iat": 1785936000,
   "subject": "spiffe://runtime.example.org/sandbox/code-review-7f2a",
   "model": {
     "provider": "anthropic",

--- a/examples/tpm2.json
+++ b/examples/tpm2.json
@@ -1,6 +1,6 @@
 {
   "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
-  "iat": 1750676200,
+  "iat": 1782212200,
   "subject": "spiffe://trust.example.org/agent/document-processor/staging",
   "model": {
     "provider": "meta",


### PR DESCRIPTION
## Why

Pre-launch consistency pass ahead of the Aug 18 LF announcement, which tells partner engineers that reference implementations are available today and points them at this directory.

## What was wrong

- All five examples carried a **2025** `iat`. `1750676142` is `2025-06-23T10:55:42Z`, so records shipped for a June **2026** launch were dated a year early, and `TR-ENV-002` reported them as 413 days stale.
- Nothing documented that these records are unsigned. A first run at `--level 1` returns two failures (`TR-SIG-005` unsigned, `TR-ENV-002` stale) with no explanation, which is a poor first impression for exactly the audience the announcement sends here.
- The heading still said `TRACE v0.1`.
- The `canonicalization-boundary/` bullet read as though the files themselves are Trust Records. They are test-vector envelopes; the record is under the `record` key.

## Verification

All five examples validate against `schema/trace-claim.json` after the bump:

```
PASS  amd-sev-snp.json
PASS  intel-tdx.json
PASS  nvidia-h100.json
PASS  sandbox-runtime.json
PASS  tpm2.json
```

Local `pytest` shows 9 pre-existing failures in `tests/test_provenance.py` on **main as well as on this branch**, caused by the installed `agentrust-trace` 0.9.0 wheel shadowing the working tree (main is three commits past the 0.9.0 release). Not introduced here, and CI installs from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)