### PR TITLE
docs: remove the dead CoSAI-hosting story and align launch terminology

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,7 +1,7 @@
 # Technical Charter — TRACE
 
-**Proposed hosting**: CoSAI (Coalition for Secure AI) for the technical workstream; Linux Foundation entity hosting the Model Context Protocol for specification, IP, trademark, and conformance mark.  
-**Status**: Pre-acceptance draft — effective upon host organization acceptance.
+**Hosting**: The Linux Foundation, as its own series: "TRACE Specification, a Series of LF Projects, LLC". This supersedes the earlier proposal to split the technical workstream to CoSAI and the specification, IP, and trademark to the Linux Foundation entity hosting the Model Context Protocol. CoSAI participates as a technical-liaison partner for WS4 interoperability, not as a host.  
+**Status**: Draft — formation with LF Projects, LLC is in progress; effective when the Technical Charter takes effect.
 
 > **Note for external contributors:** This charter is a working draft and has not yet been accepted by a host organization. Governance terms, IP policy, and conformance mark ownership described here are proposed, not final. Do not implement production systems based on governance commitments in this document until v1.0 ratification.  
 **Version**: 0.1 (aligned with spec v0.1)
@@ -10,7 +10,7 @@
 
 ## 1. Mission
 
-The TRACE project develops and maintains an open, portable, hardware-enforced governance record for AI agents and other confidential workloads. The mission is to make execution governance evidence verifiable by any party — without trusting the operator, without callbacks to the issuer, and without vendor lock-in to any cloud, silicon vendor, or AI provider.
+The TRACE project develops and maintains an open, portable, hardware-attested governance record for AI agents and other confidential workloads. The mission is to make execution governance evidence verifiable by any party — without trusting the operator, without callbacks to the issuer, and without vendor lock-in to any cloud, silicon vendor, or AI provider.
 
 ## 2. Scope
 
@@ -78,7 +78,7 @@ TRACE participates in IETF RATS, SCITT, and EAR working groups as a consuming pr
 | Milestone | Target |
 |---|---|
 | v0.1 draft — CC Summit announcement | June 2026 |
-| CoSAI committee formation | Q3 2026 |
+| LF Projects series formation | Q3 2026 |
 | MCP profile and A2A profile (v0.2) | Q3 2026 |
 | Host organization submission | Q3 2026 |
 | v1.0 ratification under TSC governance | 2027 |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 
 | Name | Affiliation | GitHub | Contact |
 |---|---|---|---|
-| Imran Siddique | OPAQUE Systems | @imraan | maintainers@agentrust.io |
+| Imran Siddique | OPAQUE Systems | @imran-siddique | maintainers@agentrust.io |
 
 The Project Lead has final decision authority on specification changes, AAIF/CoSAI submission scope, conformance requirements, and Maintainer appointments.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/icon.svg" width="96" height="96" alt="TRACE"/>
 </p>
 
-# TRACE: Trust Runtime Attestation and Compliance Evidence
+# TRACE: Trust, Runtime Attestation, and Compliance Evidence
 
 <p align="center">
   <a href="https://trace.agentrust-io.com">
@@ -71,7 +71,7 @@ Being formed at the Linux Foundation as its own series, "TRACE Specification, a 
 
 ### What is TRACE?
 
-TRACE (Trust Runtime Attestation and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools.
+TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools.
 
 ### What does a TRACE Trust Record prove?
 
@@ -103,7 +103,7 @@ The current specification is TRACE v0.2, published with a conformance test suite
       "name": "What is TRACE?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "TRACE (Trust Runtime Attestation and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools."
+        "text": "TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools."
       }
     },
     {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-description: TRACE (Trust Runtime Attestation and Compliance Evidence) is an open specification for signed, hardware-attested AI agent governance records that any third party can verify without trusting the operator.
+description: TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for signed, hardware-attested AI agent governance records that any third party can verify without trusting the operator.
 ---
 
 # TRACE
 
-**Trust Runtime Attestation and Compliance Evidence** — an open specification for hardware-attested AI agent governance records.
+**Trust, Runtime Attestation, and Compliance Evidence** — an open specification for hardware-attested AI agent governance records.
 
 TRACE defines the format, anchoring protocol, and verification rules for cryptographically provable evidence that an AI agent ran under a specific policy, in a verified hardware environment, on classified data, invoking identified tools — bound into a single signed artifact rooted in silicon attestation.
 

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -29,7 +29,7 @@ Records already issued under v0.1 remain verifiable against the v0.1 specificati
 
 ## Abstract
 
-TRACE (Trust, Runtime Attestation, and Compliance Evidence) defines an open, portable, hardware-enforced governance record for AI agents and other confidential workloads. It binds *what executed* (model, code, runtime), *under what policy*, *on what data class*, *invoking which tools*, into a single signed artifact rooted in silicon attestation. The record travels with the workload across hosts, clouds, and providers and is verifiable offline by any party.
+TRACE (Trust, Runtime Attestation, and Compliance Evidence) defines an open, portable, hardware-attested governance record for AI agents and other confidential workloads. It binds *what executed* (model, code, runtime), *under what policy*, *on what data class*, *invoking which tools*, into a single signed artifact rooted in silicon attestation. The record travels with the workload across hosts, clouds, and providers and is verifiable offline by any party.
 
 TRACE composes existing standards rather than replacing them. It profiles RATS/EAT (RFC 9711) for the wire envelope, SLSA for build-time provenance, SCITT for transparency anchoring, SPIFFE for workload identity, EAR for evidence appraisal, and MCP / A2A for the agent execution surface. Where gaps exist — notably the AI-agent execution profile — TRACE proposes the minimum new schema to close them.
 


### PR DESCRIPTION
## Why

Pre-launch consistency pass ahead of the Aug 18 LF announcement. #127 (now merged) fixed `GOVERNANCE.md`, `LICENSE`, and `CONTRIBUTING.md`; this covers the gaps it left, so a reporter or partner reading the repo sees the same story the release tells.

## What was wrong

**1. `CHARTER.md` still opened with the superseded hosting plan.** It said hosting was CoSAI for the technical workstream plus the LF entity hosting MCP for spec, IP and trademark. `spec/trace-v0.2.md` §6.1 already supersedes that ("made TRACE a guest of two hosts, neither of which owned the conformance mark outright"), and #127 fixed `GOVERNANCE.md`, but the charter had not caught up. The §8 timeline row still read "CoSAI committee formation".

**2. "hardware-enforced" contradicts the charter's own scope.** §2 puts *runtime policy enforcement engines* explicitly out of scope, so calling the record hardware-enforced overclaims, and it is the term partner reviewers are most likely to challenge. The repo already prefers *hardware-attested* by a wide margin (11 uses in `docs/`, 3 in `README.md`, versus 2). Changed the charter mission and the spec abstract to match. Editorial only, no normative change.

**3. `MAINTAINERS.md` listed a GitHub handle that 404s.** `@imraan` returns 404; `@imran-siddique` is the account behind every commit in the repo.

**4. The acronym had two published forms.** Both `spec/trace-v0.1.md` and `spec/trace-v0.2.md` titles use "Trust, Runtime Attestation, and Compliance Evidence"; `README.md` and `docs/index.md` used the comma-free form. Aligned the latter to the spec, which is also the form the LF and TII drafts use.

## Note

`CHARTER.md` was deliberately left alone in #127 because LF supplies the Technical Charter template. These are minimal line edits to remove a contradiction that is visible during launch week, and they do not conflict with a later template swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)