### PR TITLE
fix(provenance): anchor with \Z, so a trailing newline is not part of an identifier

### DIFF
--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -40,8 +40,10 @@ FORMAT = "agentrust-io/mcp-server-provenance/1"
 #: Closed on purpose: the value of the field is that a verifier can key on it.
 KINDS = ("publisher-asserted", "observer-attested", "tee-attested")
 
-_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-_PUBLISHER_RE = re.compile(r"^(did:[a-z0-9]+:.+|spiffe://[^/]+/.+)$")
+# `\Z`, not `$`: in Python `$` also matches immediately before a single trailing newline,
+# so `^...$` accepts "did:web:acme.example\n" and every digest with a newline glued to it.
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}\Z")
+_PUBLISHER_RE = re.compile(r"^(did:[a-z0-9]+:.+|spiffe://[^/]+/.+)\Z")
 
 
 class ProvenanceError(ValueError):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -316,3 +316,45 @@ def test_a_well_formed_record_still_verifies() -> None:
     key = generate_key()
     signed = sign_record(_record(), key)
     verify_record(signed, key_to_jwk(key))
+
+
+# --- anchoring: a trailing newline is not part of an identifier ------------
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("publisher", "did:web:acme.example\n"),
+        ("artifact.digest", DIGEST + "\n"),
+        ("endpoint.spki_sha256", DIGEST + "\n"),
+        ("tool_catalog.hash", DIGEST + "\n"),
+    ],
+)
+def test_a_trailing_newline_does_not_satisfy_a_pattern(field: str, value: str) -> None:
+    """`$` in Python matches before a single trailing newline; these need `\\Z`.
+
+    Four fields are anchored with the same two patterns. Before this, every one of them
+    accepted its own value with a newline glued to the end, and `verify_record` returned
+    cleanly on all four. Only `tool_catalog.hash` had anything downstream to catch it,
+    and only because `check_tool_catalog` recomputes and compares.
+    """
+    key = generate_key()
+    record = {
+        "format": FORMAT,
+        "kind": "publisher-asserted",
+        "identity": {"artifact": _artifact()},
+        "publisher": "did:web:acme.example",
+        "tool_catalog": {"hash": tool_catalog_hash(TOOLS), "tool_count": len(TOOLS)},
+        "issued_at": 1760000000,
+    }
+    if field == "publisher":
+        record["publisher"] = value
+    elif field == "artifact.digest":
+        record["identity"]["artifact"]["digest"] = value
+    elif field == "endpoint.spki_sha256":
+        record["identity"] = {"endpoint": {"url": "https://acme.example/mcp", "spki_sha256": value}}
+    else:
+        record["tool_catalog"]["hash"] = value
+
+    with pytest.raises(ProvenanceError):
+        verify_record(sign_record(record, key), key_to_jwk(key))


### PR DESCRIPTION
Follows the anchoring point from my review comment on #146, which nobody has picked up. Two lines of pattern and one parametrized test.

**What it is.** In Python `$` matches at the end of the string *and* immediately before a single trailing newline. Both patterns in this module are anchored `^...$`, so every field they guard accepts its own value with a newline glued to the end, and `verify_record` returns cleanly.

Two patterns, four fields:

```
publisher             "did:web:acme.example\n"   accepted
artifact.digest       "sha256:...\n"             accepted
endpoint.spki_sha256  "sha256:...\n"             accepted
tool_catalog.hash     "sha256:...\n"             accepted by verify_record
```

Only the last has anything downstream to catch it, and only because `check_tool_catalog` recomputes the digest and compares. The other three are accepted and nothing later disagrees.

`\Z` is the end of the string and nothing else. One comment sits on the pair, because the two anchors look interchangeable and are not.

**Correcting my own report.** On #146 I said this affected two fields and that "the hash case fails safe". Both halves were too narrow. It is four fields, because the two patterns are reused, and *fails safe* is true of `tool_catalog.hash` and false of `artifact.digest`, which is the same digest pattern with no recomputation behind it. I had checked one field and described the pattern.

**Verified.** Four parametrized cases, one per field. They fail on all four before the change and pass after; I ran it both ways rather than assuming. 327 passed, 1 skipped. `ruff` and `mypy` clean.

Not in this PR: the regexes are permissive in other ways. `did:[a-z0-9]+:.+` accepts a DID with a space in it, and `.+` accepts a great deal. That is a separate question from anchoring and I have not touched it.
