### PR TITLE
fix(security): reject future-dated Trust Records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Future-dated records no longer create an unbounded freshness window.** `verify_record()` now rejects an `iat` later than the verifier's clock plus `max_future_skew_seconds` (default 5 minutes), independently of the maximum-age check. The v0.2 freshness requirements and verification tutorial document both bounds.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -8,7 +8,7 @@ This document describes what TRACE does not do, and where layered defenses are n
 A TRACE claim at Level 0 (software-only signing) is signed by a key held in software. A privileged operator with root access can produce a valid-looking Level 0 record for a run that never happened, or that violated policy. Level 0 is suitable for development and audit-trail tooling only — not for third-party verification.
 
 **Replay of a valid past record**
-A TRACE claim proves a specific run happened; it does not prevent a verifier from being shown a valid record from an earlier run. Verifiers that rely on recency must check the `iat` and `exp` claims, require nonce binding to a challenge, or anchor records to a public transparency log and check for freshness.
+A TRACE claim proves a specific run happened; it does not prevent a verifier from being shown a valid record from an earlier run. Verifiers that rely on recency must bound `iat` in both directions (maximum age and allowed future clock skew), check `exp` when present, require nonce binding to a challenge, or anchor records to a public transparency log and check for freshness.
 
 **Policy correctness**
 The `policy.bundle_hash` field attests that a specific policy was in force at runtime. It does not attest that the policy achieves the intended security outcome. Policy review is a separate control.

--- a/docs/tutorials/verifying-a-trust-record.md
+++ b/docs/tutorials/verifying-a-trust-record.md
@@ -25,7 +25,7 @@ When you call `verify_record(record, trusted_key)` the library:
 
 1. Reads `record["signature"]` and base64url-decodes it to raw bytes
 2. Resolves the trusted key you supplied, checking `kty == "OKP"` and `crv == "Ed25519"` before reconstructing an `Ed25519PublicKey` from the `x` field
-3. Enforces freshness: rejects records whose `iat` is older than `max_age_seconds` (default 24h), and, if you pass `expected_nonce`, compares it in constant time to `runtime.nonce`
+3. Enforces freshness: rejects records whose `iat` is older than `max_age_seconds` (default 24h) or further in the future than `max_future_skew_seconds` (default 5m), and, if you pass `expected_nonce`, compares it in constant time to `runtime.nonce`
 4. Rebuilds the canonical payload: all fields except `signature`, serialized with sorted keys and no whitespace
 5. Calls `Ed25519PublicKey.verify(sig_bytes, payload_bytes)` from the `cryptography` library
 6. Returns `None` on success, raises `cryptography.exceptions.InvalidSignature` on a bad signature and `ValueError` on every other rejection

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -245,7 +245,7 @@ Implementations MUST use an RFC 8785-conformant library. Using `json.dumps(sort_
 
 Each profile MUST declare which binding form it uses. A record with no verifiable signature binding is not a Trust Record: verifiers MUST reject it. Schema validity alone confers no trust.
 
-**Freshness.** Records MUST carry `iat`. Verifiers MUST enforce a maximum record age: a record whose `iat` is older than the maximum age MUST be rejected. The default maximum age is 24 hours; a deployment profile MAY specify a different value. Verifiers SHOULD additionally support challenge-nonce binding for online verification: the verifier supplies a nonce, the issuer echoes it in `runtime.nonce`, and the verifier checks the echo. When a challenge nonce was issued, a record that omits or mismatches it MUST be rejected.
+**Freshness.** Records MUST carry `iat`. Verifiers MUST enforce a maximum record age: a record whose `iat` is older than the maximum age MUST be rejected. The default maximum age is 24 hours; a deployment profile MAY specify a different value. Verifiers MUST also reject a record whose `iat` is later than the verifier's current time plus an allowed clock-skew tolerance. The default tolerance is 5 minutes; a deployment profile MAY specify a different value. Without the upper bound, a far-future `iat` creates a record that remains fresh until that time plus the maximum age. Verifiers SHOULD additionally support challenge-nonce binding for online verification: the verifier supplies a nonce, the issuer echoes it in `runtime.nonce`, and the verifier checks the echo. When a challenge nonce was issued, a record that omits or mismatches it MUST be rejected.
 
 **Conformance alignment.** The TRACE conformance suite (trace-tests) already enforces both rules: records without a verifiable signature fail at conformance level 1 and above, and the default 24-hour max-age is enforced.
 
@@ -254,7 +254,7 @@ Each profile MUST declare which binding form it uses. A record with no verifiabl
 Any party — browser, CLI, in-cluster verifier, third-party auditor — verifies:
 
 1. The record's signature binding (section 3.2.2) verifies against the key in `cnf`, BEFORE any other field is trusted. A record with no verifiable binding MUST be rejected.
-2. The record is fresh: `iat` is within the maximum age (default 24 hours unless the deployment profile specifies otherwise). If the verifier issued a challenge nonce, `runtime.nonce` echoes it.
+2. The record is fresh: `iat` is neither older than the maximum age (default 24 hours) nor later than the current time plus the allowed clock skew (default 5 minutes), unless the deployment profile specifies different bounds. If the verifier issued a challenge nonce, `runtime.nonce` echoes it.
 3. Signature chain resolves to a known silicon root (NVIDIA, Intel, AMD, or equivalent).
 4. Runtime measurements match published Reference Integrity Manifests (RIMs).
 5. Policy hash matches the policy bundle the verifier expects.

--- a/src/agentrust_trace/sign.py
+++ b/src/agentrust_trace/sign.py
@@ -266,6 +266,7 @@ def verify_record(
     *,
     allow_embedded_key: bool = False,
     max_age_seconds: int | None = 86400,
+    max_future_skew_seconds: int = 300,
     expected_nonce: str | None = None,
     revocation: RevocationStore | None = None,
 ) -> None:
@@ -302,7 +303,9 @@ def verify_record(
 
     Freshness (fail closed):
         ``max_age_seconds`` (default 86400 = 24h) bounds how old ``record["iat"]``
-        may be relative to now; pass ``None`` to disable the age check. If
+        may be relative to now; pass ``None`` to disable the age check.
+        ``max_future_skew_seconds`` (default 300 = 5m) bounds tolerated clock skew;
+        a record dated further in the future is rejected. If
         ``expected_nonce`` is given, it is compared in constant time against
         ``record["runtime"]["nonce"]``. A stale record or nonce mismatch raises
         ``ValueError``.
@@ -398,11 +401,18 @@ def verify_record(
         _check_not_revoked(trusted_jwk, revocation)
 
     # Freshness: bound the age of the record against its issued-at timestamp.
+    if max_future_skew_seconds < 0:
+        raise ValueError("max_future_skew_seconds must be non-negative")
+    iat = record.get("iat")
+    if not isinstance(iat, int) or isinstance(iat, bool):
+        raise ValueError("record has no valid integer 'iat' for freshness check")
+    age = time.time() - iat
+    if age < -max_future_skew_seconds:
+        raise ValueError(
+            f"record is dated {int(-age)}s in the future, exceeds "
+            f"max_future_skew_seconds={max_future_skew_seconds}"
+        )
     if max_age_seconds is not None:
-        iat = record.get("iat")
-        if not isinstance(iat, int | float) or isinstance(iat, bool):
-            raise ValueError("record has no valid integer 'iat' for freshness check")
-        age = time.time() - iat
         if age > max_age_seconds:
             raise ValueError(
                 f"record is stale: iat is {int(age)}s old, exceeds max_age_seconds="

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -280,6 +280,54 @@ def test_verify_record_expired_allowed_when_max_age_none():
     verify_record(record, key_to_jwk(key), max_age_seconds=None)  # must not raise
 
 
+def test_verify_record_rejects_record_beyond_default_future_skew():
+    key = generate_key()
+    record = _minimal_record()
+    record["iat"] = int(time.time()) + 301
+    record = sign_record(record, key)
+
+    with pytest.raises(ValueError, match="future"):
+        verify_record(record, key_to_jwk(key))
+
+
+def test_verify_record_accepts_record_within_default_future_skew():
+    key = generate_key()
+    record = _minimal_record()
+    record["iat"] = int(time.time()) + 299
+    record = sign_record(record, key)
+
+    verify_record(record, key_to_jwk(key))
+
+
+def test_verify_record_future_skew_is_deployment_configurable():
+    key = generate_key()
+    record = _minimal_record()
+    record["iat"] = int(time.time()) + 601
+    record = sign_record(record, key)
+
+    with pytest.raises(ValueError, match="max_future_skew_seconds=600"):
+        verify_record(record, key_to_jwk(key), max_future_skew_seconds=600)
+    verify_record(record, key_to_jwk(key), max_future_skew_seconds=602)
+
+
+def test_disabling_max_age_does_not_disable_future_bound():
+    key = generate_key()
+    record = _minimal_record()
+    record["iat"] = int(time.time()) + 3600
+    record = sign_record(record, key)
+
+    with pytest.raises(ValueError, match="future"):
+        verify_record(record, key_to_jwk(key), max_age_seconds=None)
+
+
+def test_verify_record_rejects_negative_future_skew_configuration():
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        verify_record(record, key_to_jwk(key), max_future_skew_seconds=-1)
+
+
 def test_verify_record_rejects_non_okp_jwk():
     key = generate_key()
     record = sign_record(_fresh_record(), key)


### PR DESCRIPTION
## Why

`verify_record()` bounded how old a record could be but accepted arbitrarily future-dated `iat` values. A record dated a year ahead therefore remained fresh for a year plus the configured maximum age, creating an unintended replay window.

## What changed

- add `max_future_skew_seconds`, defaulting to five minutes
- reject `iat` values beyond the verifier clock plus that tolerance
- keep the future bound active even when maximum-age checking is disabled
- require integer timestamps and reject negative skew configuration
- update the normative v0.2 freshness language, verification tutorial, limitations, and changelog

## Verification

- focused signature tests: 49 passed
- full suite: 328 passed, 1 skipped
- `ruff check src tests`
- `mypy src/agentrust_trace`
- `git diff --check`

Five regression tests cover the default rejection boundary, tolerated skew, deployment overrides, independence from `max_age_seconds=None`, and invalid configuration.