### PR TITLE
fix(security): enforce schema conformance during verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`verify_record()` now enforces the canonical v0.2 JSON Schema.** A cryptographically valid signature no longer causes an object with unknown fields, missing required claims, or invalid nested values to be accepted as a verified TRACE record. Schema failures are surfaced as `ValueError` with the failing field path.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/docs/tutorials/verifying-a-trust-record.md
+++ b/docs/tutorials/verifying-a-trust-record.md
@@ -6,7 +6,7 @@ Check the integrity and schema conformance of a TRACE Trust Record you received 
 
 - What `verify_record()` does internally, step by step
 - How to verify against a pinned trusted key instead of the embedded key
-- How to run schema validation separately from signature verification
+- How built-in schema validation rejects malformed signed records
 - How to collect all validation errors with `iter_errors()`
 - How to interpret `runtime.platform` to distinguish development from hardware-attested records
 - What to do when verification fails
@@ -23,12 +23,13 @@ pip install agentrust-trace
 
 When you call `verify_record(record, trusted_key)` the library:
 
-1. Reads `record["signature"]` and base64url-decodes it to raw bytes
-2. Resolves the trusted key you supplied, checking `kty == "OKP"` and `crv == "Ed25519"` before reconstructing an `Ed25519PublicKey` from the `x` field
-3. Enforces freshness: rejects records whose `iat` is older than `max_age_seconds` (default 24h), and, if you pass `expected_nonce`, compares it in constant time to `runtime.nonce`
-4. Rebuilds the canonical payload: all fields except `signature`, serialized with sorted keys and no whitespace
-5. Calls `Ed25519PublicKey.verify(sig_bytes, payload_bytes)` from the `cryptography` library
-6. Returns `None` on success, raises `cryptography.exceptions.InvalidSignature` on a bad signature and `ValueError` on every other rejection
+1. Requires the exact TRACE v0.2 profile and validates the complete record against its canonical JSON Schema
+2. Reads `record["signature"]` and base64url-decodes it to raw bytes
+3. Resolves the trusted key you supplied, checking `kty == "OKP"` and `crv == "Ed25519"` before reconstructing an `Ed25519PublicKey` from the `x` field
+4. Enforces freshness: rejects records whose `iat` is older than `max_age_seconds` (default 24h), and, if you pass `expected_nonce`, compares it in constant time to `runtime.nonce`
+5. Rebuilds the canonical payload with all fields except `signature`, using RFC 8785 (JCS)
+6. Calls `Ed25519PublicKey.verify(sig_bytes, payload_bytes)` from the `cryptography` library
+7. Returns `None` on success, raises `cryptography.exceptions.InvalidSignature` on a bad signature and `ValueError` on every other rejection
 
 A trusted key is required. A record cannot authenticate itself with the key it embeds, so `verify_record` will not fall back to `cnf.jwk` unless you explicitly opt in with `allow_embedded_key=True` (which emits a `UserWarning`, since it proves only internal consistency, not authenticity).
 
@@ -50,7 +51,7 @@ except ValueError as e:
     print(f"verification failed: {e}")
 ```
 
-`ValueError` is raised when no trusted key is supplied, the record is missing a `signature` field, a key or signature cannot be decoded, the JWK type is not Ed25519, or the record is stale. Treat all of these as verification failure.
+`ValueError` is raised when schema conformance fails, no trusted key is supplied, the record is missing a `signature` field, a key or signature cannot be decoded, the JWK type is not Ed25519, or the record is stale. Treat all of these as verification failure.
 
 ---
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -6,6 +6,11 @@ TRACE Trust Records are independently verifiable offline — no call to the issu
 
 This is the normative protocol from [§3.3 of the spec](../spec/trace-v0.2.md).
 
+Before interpreting any claim, validate the complete object against the canonical
+v0.2 JSON Schema. A valid signature authenticates every byte but does not make an
+unknown field, missing required claim, or invalid enum meaningful. The Python
+`verify_record()` API performs this schema check automatically and fails closed.
+
 ### Step 1 — Parse the envelope
 
 A TRACE Trust Record is a signed JSON object. The `signature` field contains a base64url-encoded Ed25519 (or ES256/ES384) signature over the canonical JSON of the record with only `signature` removed. The `cnf.jwk` public key remains in the signed pre-image, binding that key to the rest of the record.

--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -14,7 +14,6 @@
     "data_class",
     "build_provenance",
     "appraisal",
-    "transparency",
     "cnf"
   ],
   "properties": {

--- a/src/agentrust_trace/schema/trace-v0.2.json
+++ b/src/agentrust_trace/schema/trace-v0.2.json
@@ -14,7 +14,6 @@
     "data_class",
     "build_provenance",
     "appraisal",
-    "transparency",
     "cnf"
   ],
   "properties": {

--- a/src/agentrust_trace/sign.py
+++ b/src/agentrust_trace/sign.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Container
 from typing import Any, TypeAlias
 
 import rfc8785
+from jsonschema import ValidationError
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
@@ -352,6 +353,21 @@ def verify_record(
         raise ValueError("record has no 'signature' field")
 
     sig_bytes = _b64url_decode(sig_b64, field="signature")
+
+    # Signature validity is not schema validity. Enforce the canonical profile
+    # shape here so callers cannot accidentally treat a signed object carrying
+    # unknown fields, missing required claims, or invalid nested values as a
+    # verified TRACE Trust Record. Signature presence and encoding are checked
+    # first so the public API preserves its specific envelope errors.
+    from agentrust_trace.validate import validate_json
+
+    try:
+        validate_json(record)
+    except ValidationError as exc:
+        location = ".".join(str(part) for part in exc.absolute_path) or "<record>"
+        raise ValueError(
+            f"record does not conform to the TRACE v0.2 schema at {location}: {exc.message}"
+        ) from exc
 
     # Resolve the trusted public key. A trusted key is required: a record cannot
     # authenticate itself with the key it embeds.

--- a/src/agentrust_trace/validate.py
+++ b/src/agentrust_trace/validate.py
@@ -24,7 +24,7 @@ SCHEMA: dict[str, Any] = _schema()
 
 
 def validate_json(record: dict[str, Any]) -> None:
-    """Validate *record* against the canonical TRACE v0.1 JSON Schema.
+    """Validate *record* against the canonical TRACE v0.2 JSON Schema.
 
     Raises :class:`jsonschema.ValidationError` on the first violation found.
     Use :func:`iter_errors` for all violations.

--- a/tests/test_sandbox_adapter.py
+++ b/tests/test_sandbox_adapter.py
@@ -329,23 +329,11 @@ def test_an_anchored_record_passes_the_published_json_schema() -> None:
     validate_json(sign_record(record, generate_key()))
 
 
-def test_unanchored_record_is_model_valid_but_the_json_schema_still_requires_transparency() -> None:
-    """Documents a live divergence between the model and schema/trace-claim.json.
-
-    0.5.1 made ``transparency`` optional on the model, because a Level 0 or Level 1
-    record is not anchored and has no receipt to name. The published JSON Schema still
-    lists ``transparency`` in ``required``. Until that is reconciled, an unanchored
-    record validates against the model and not against the schema.
-
-    This test exists so the divergence is visible and fails loudly the day it is fixed,
-    rather than being rediscovered by a downstream implementer.
-    """
-    import jsonschema
-
+def test_unanchored_record_is_model_and_schema_valid() -> None:
+    """Level 0/1 records are unanchored, so transparency is optional everywhere."""
     record = _make_adapter().build_trust_record(_make_session())
     TrustRecord.model_validate(record)
-    with pytest.raises(jsonschema.ValidationError, match="transparency"):
-        validate_json(record)
+    validate_json(record)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -149,6 +149,36 @@ def test_verify_record_passes_for_valid_signature():
     verify_record(record, key_to_jwk(key))  # must not raise
 
 
+def test_verify_record_rejects_signed_unknown_top_level_field():
+    key = generate_key()
+    record = _fresh_record()
+    record["unexpected_security_semantics"] = "trusted"
+    signed = sign_record(record, key)
+
+    with pytest.raises(ValueError, match="does not conform.*unexpected_security_semantics"):
+        verify_record(signed, key_to_jwk(key))
+
+
+def test_verify_record_rejects_signed_missing_required_claim():
+    key = generate_key()
+    record = _fresh_record()
+    del record["appraisal"]
+    signed = sign_record(record, key)
+
+    with pytest.raises(ValueError, match="does not conform.*appraisal"):
+        verify_record(signed, key_to_jwk(key))
+
+
+def test_verify_record_rejects_signed_invalid_nested_value():
+    key = generate_key()
+    record = _fresh_record()
+    record["policy"]["enforcement_mode"] = "bypass"
+    signed = sign_record(record, key)
+
+    with pytest.raises(ValueError, match=r"policy\.enforcement_mode"):
+        verify_record(signed, key_to_jwk(key))
+
+
 def _fresh_record_with_profile(profile) -> dict:
     record = _fresh_record()
     if profile is None:
@@ -529,6 +559,6 @@ def test_round_trip_with_non_ascii_payload():
     """End-to-end: signing and verifying a record carrying non-ASCII data."""
     key = generate_key()
     record = _fresh_record()
-    record["model"]["note"] = "modèle français \U0001f916"
+    record["model"]["provider"] = "modèle français \U0001f916"
     signed = sign_record(record, key)
     verify_record(signed, key_to_jwk(key))  # must not raise


### PR DESCRIPTION
## Why

A valid signature authenticates bytes; it does not make unknown fields, missing required claims, or invalid enum values part of TRACE. `verify_record()` previously checked selected fields and the signature without enforcing the canonical v0.2 schema, creating separate notions of schema-valid and signature-valid records.

## What changed

- validate the complete signed object against the packaged canonical v0.2 schema during `verify_record()`
- preserve the existing specific errors for missing and malformed signatures
- surface schema failures as `ValueError` with the failing field path
- document built-in schema validation in the verification guide and tutorial
- correct the stale v0.1 docstring in `validate_json()`
- reconcile an existing schema/model contradiction by making `transparency` optional for unanchored Level 0/1 records, as the model, conformance levels, and documentation already require

## Verification

- focused sign/schema/adapter tests: 112 passed
- full suite: 326 passed, 1 skipped
- `ruff check src tests`
- `mypy src/agentrust_trace`
- `git diff --check`

New regressions cover correctly signed records with an unknown top-level field, a missing required claim, and an invalid nested enforcement mode.