### PR TITLE
fix(security): bind cnf.jwk to the trusted signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The confirmation key must now match the trusted signing key.** `verify_record()` compares the RFC 7638 thumbprints of `cnf.jwk` and the caller-supplied trusted key before accepting the signature. A trusted signer can no longer produce a record that verifies under one key while naming another key for downstream proof-of-possession checks.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/docs/tutorials/verifying-a-trust-record.md
+++ b/docs/tutorials/verifying-a-trust-record.md
@@ -56,7 +56,7 @@ except ValueError as e:
 
 ## Verify Against a Pinned Public Key
 
-The embedded `cnf.jwk` proves the record was not tampered with after signing. It does not prove the key is one you should trust. For stricter verification, supply your own trusted public key as the second argument.
+The embedded `cnf.jwk` names the key the record claims made its mandatory signature binding. It cannot establish trust by itself. Supply a trusted public key out of band; `verify_record()` requires the embedded and trusted keys to have the same RFC 7638 thumbprint, then verifies the signature with the trusted key.
 
 Pass either an `Ed25519PublicKey` object or a JWK dict you obtained out-of-band (for example, from the issuer's published key manifest):
 
@@ -84,7 +84,7 @@ pub_key = Ed25519PublicKey.from_public_bytes(x_bytes)
 verify_record(record, pub_key)
 ```
 
-When you supply a key, the library uses it instead of `cnf.jwk`. If the record was signed with a different key, `InvalidSignature` is raised.
+When you supply a key, the library first requires it to identify the same public key as `cnf.jwk`, ignoring optional JWK metadata such as `kid`, and then uses the trusted key for signature verification. A key mismatch raises `ValueError`; a matching key with an invalid signature raises `InvalidSignature`.
 
 ---
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -27,6 +27,12 @@ The pre-image is the RFC 8785 (JCS) canonical form of the record with only `sign
 
 The `cnf.jwk` field embeds the public key. For TEE-issued records, this key is TEE-bound — its private half never leaves the measured enclave.
 
+Resolve trust out of band and require the trusted key and `cnf.jwk` to have the
+same RFC 7638 thumbprint before verification. Checking the signature with a
+trusted key while allowing the signed record to name a different confirmation
+key breaks the binding required by §3.2.2 and can mislead downstream
+proof-of-possession checks.
+
 ```python
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 

--- a/src/agentrust_trace/sign.py
+++ b/src/agentrust_trace/sign.py
@@ -377,8 +377,10 @@ def verify_record(
 
     if isinstance(public_key_or_jwk, dict):
         pub = _pubkey_from_jwk(public_key_or_jwk)
+        trusted_jwk = public_key_or_jwk
     else:
         pub = public_key_or_jwk
+        trusted_jwk = _jwk_from_public_key(pub)
 
     # Revocation: signature validity is permanent, trust is not. A key compromised
     # after issuance still produces records that verify, so the only place the
@@ -390,12 +392,21 @@ def verify_record(
     # allow_embedded_key=True the two are the same object, and that path is already
     # documented as proving internal consistency only.
     if revocation is not None:
-        trusted_jwk = (
-            public_key_or_jwk
-            if isinstance(public_key_or_jwk, dict)
-            else _jwk_from_public_key(pub)
-        )
         _check_not_revoked(trusted_jwk, revocation)
+
+    # The signature binding is defined as a signature made by the key in cnf.
+    # Verifying with a caller-pinned key is necessary for authenticity, but it
+    # must not permit a trusted signer to authenticate a record that names a
+    # different confirmation key for downstream proof-of-possession checks.
+    cnf = record.get("cnf")
+    embedded_jwk = cnf.get("jwk") if isinstance(cnf, dict) else None
+    if not isinstance(embedded_jwk, dict):
+        raise ValueError("record has no valid cnf.jwk confirmation key")
+    _pubkey_from_jwk(embedded_jwk)
+    if not compare_digest(jwk_thumbprint(embedded_jwk), jwk_thumbprint(trusted_jwk)):
+        raise ValueError(
+            "record cnf.jwk does not identify the trusted key that verifies its signature"
+        )
 
     # Freshness: bound the age of the record against its issued-at timestamp.
     if max_age_seconds is not None:

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -285,13 +285,26 @@ def test_verify_record_compares_key_identity_not_optional_jwk_metadata():
 
 
 def test_verify_record_rejects_signed_record_without_confirmation_key():
+    """A record with no confirmation key does not verify, whoever signed it.
+
+    Since schema enforcement landed (#156) the rejection comes from the schema,
+    which makes `cnf` required, rather than from the cnf-to-trusted-key binding
+    below it: absent `cnf` is caught before the binding is reached. Both are
+    correct refusals, and the earlier one is the more fundamental. Asserted on
+    `cnf` rather than on the exact sentence so this does not re-break the next
+    time the order of two correct checks changes.
+
+    The binding itself is covered by test_verify_record_raises_for_tampered_cnf_jwk
+    and test_verify_record_rejects_valid_signature_that_names_another_cnf_key,
+    where `cnf` is present and names the wrong key.
+    """
     key = generate_key()
     record = _fresh_record()
     record.pop("cnf", None)
     body = _canonical_bytes(record)
     record["signature"] = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
 
-    with pytest.raises(ValueError, match=r"cnf\.jwk"):
+    with pytest.raises(ValueError, match=r"cnf"):
         verify_record(record, key_to_jwk(key))
 
 

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -229,8 +229,40 @@ def test_verify_record_raises_for_tampered_cnf_jwk():
     record = sign_record(_fresh_record(), key)
     trusted = key_to_jwk(key)
     record["cnf"]["jwk"] = key_to_jwk(other_key)
-    with pytest.raises(InvalidSignature):
+    with pytest.raises(ValueError, match=r"cnf\.jwk.*trusted key"):
         verify_record(record, trusted)
+
+
+def test_verify_record_rejects_valid_signature_that_names_another_cnf_key():
+    """A trusted signer must not authenticate another key as the confirmation key."""
+    signer = generate_key()
+    other = generate_key()
+    record = _fresh_record()
+    record["cnf"] = {"jwk": key_to_jwk(other)}
+    body = _canonical_bytes(record)
+    record["signature"] = base64.urlsafe_b64encode(signer.sign(body)).rstrip(b"=").decode()
+
+    with pytest.raises(ValueError, match=r"cnf\.jwk.*trusted key"):
+        verify_record(record, key_to_jwk(signer))
+
+
+def test_verify_record_compares_key_identity_not_optional_jwk_metadata():
+    key = generate_key()
+    record = sign_record(_fresh_record(), key)
+    trusted = {**key_to_jwk(key), "kid": "issuer-key-7", "use": "sig"}
+
+    verify_record(record, trusted)
+
+
+def test_verify_record_rejects_signed_record_without_confirmation_key():
+    key = generate_key()
+    record = _fresh_record()
+    record.pop("cnf", None)
+    body = _canonical_bytes(record)
+    record["signature"] = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
+
+    with pytest.raises(ValueError, match=r"cnf\.jwk"):
+        verify_record(record, key_to_jwk(key))
 
 
 def test_verify_record_raises_for_missing_signature():
@@ -259,7 +291,7 @@ def test_verify_record_rejects_wrong_trusted_key():
     key_b = generate_key()
     record = sign_record(_fresh_record(), key_a)
     # Signed by A, verified against B's public key — must not verify.
-    with pytest.raises(InvalidSignature):
+    with pytest.raises(ValueError, match=r"cnf\.jwk.*trusted key"):
         verify_record(record, key_to_jwk(key_b))
 
 


### PR DESCRIPTION
## Why

TRACE §3.2.2 defines the signature binding as a signature made by the key in `cnf`. The verifier required a trusted key and verified the signature with it, but did not require signed `cnf.jwk` to name that same key. A trusted signer could therefore authenticate a record that directed downstream proof-of-possession checks to an unrelated key.

## What changed

- derive RFC 7638 thumbprints for the trusted and embedded keys
- require both thumbprints to match before accepting the signature
- validate the embedded key as Ed25519
- compare key identity while ignoring optional JWK metadata such as `kid` and `use`
- preserve revocation checks against the trusted key before inspecting the embedded key
- clarify the two-key trust and binding process in both verification guides

## Verification

- focused signature tests: 47 passed
- full suite: 326 passed, 1 skipped
- `ruff check src tests`
- `mypy src/agentrust_trace`
- `git diff --check`

Regressions cover a valid trusted signature naming another confirmation key, missing `cnf.jwk`, optional trusted-key metadata, wrong trusted keys, tampering, public-key objects, and revocation ordering.