### PR TITLE
test: prevent installed wheels from shadowing checkout source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local test runs now always exercise the checkout.** Pytest prepends `src` to its import path, and a regression test asserts that `agentrust_trace` resolves to the repository source. A stale installed wheel can no longer shadow current security fixes and produce misleading failures or passes.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,22 @@
 
 TRACE is an open specification. Contributions are welcome in four areas: the specification text, the JSON Schema, the examples, and the conformance test suite (in [agentrust-io/trace-tests](https://github.com/agentrust-io/trace-tests)).
 
+## Running the reference-library checks
+
+Install the development dependencies and run the suite from the repository root:
+
+```bash
+pip install -e ".[dev]"
+pytest
+ruff check src tests
+mypy src/agentrust_trace
+```
+
+Pytest is configured to import `src/agentrust_trace` from the checkout. A stale
+wheel installed elsewhere in the environment must not shadow the code under
+test; a regression test fails with the resolved import path if that guarantee is
+lost.
+
 ## DCO sign-off
 
 All commits must include a Developer Certificate of Origin sign-off:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ packages = ["src/agentrust_trace"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 addopts = "-v --tb=short"
 
 [tool.ruff]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,6 +13,7 @@ tagging a version that is not semver.
 
 from __future__ import annotations
 
+import inspect
 import pathlib
 import re
 import tomllib
@@ -25,6 +26,14 @@ import agentrust_trace
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _PYPROJECT = _ROOT / "pyproject.toml"
 _INIT = _ROOT / "src" / "agentrust_trace" / "__init__.py"
+
+
+def test_test_suite_imports_checkout_source() -> None:
+    """A stale installed wheel must never shadow the source being tested."""
+    imported = pathlib.Path(inspect.getfile(agentrust_trace)).resolve()
+    assert imported == _INIT.resolve(), (
+        f"tests imported agentrust_trace from {imported}, not the checkout at {_INIT.resolve()}"
+    )
 
 
 def _declared_version() -> str:


### PR DESCRIPTION
## Why

A normal local `pytest` run imported the previously installed 0.9.0 wheel instead of the checkout. Nine security regression tests then failed against old code, while other environments could just as easily produce misleading passes. Tests must prove which artifact they exercise.

## What changed

- configure pytest with `pythonpath = ["src"]`
- add a regression asserting `agentrust_trace` resolves to this checkout's `src/agentrust_trace/__init__.py`
- document the supported local lint, type-check, and test commands for contributors
- record the harness correction in the changelog

## Verification

Run without setting `PYTHONPATH`, while the stale 0.9.0 wheel remained installed:

- focused harness tests: 4 passed, 1 intentional metadata-environment skip
- full suite: 324 passed, 1 skipped
- `ruff check src tests`
- `mypy src/agentrust_trace`
- `git diff --check`

The regression would fail with the exact shadowing path if pytest stopped preferring the checkout.