### PR TITLE
ci(security): fail closed before package publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Lint
-        run: ruff check src tests
+        run: ruff check src tests scripts
 
       - name: Type check
         run: mypy src/agentrust_trace

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.4
-        continue-on-error: true
         with:
           category: /language:python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,26 @@ jobs:
           pip install hatchling
           python -m hatchling build
 
+      - name: Verify wheel as installed artifact
+        run: |
+          python -m venv "$RUNNER_TEMP/wheel-venv"
+          "$RUNNER_TEMP/wheel-venv/bin/python" -m pip install dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/wheel-venv/bin/python" \
+            "$GITHUB_WORKSPACE/scripts/verify_release_artifact.py" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --expected-version "${GITHUB_REF_NAME#v}"
+
+      - name: Verify source distribution as installed artifact
+        run: |
+          python -m venv "$RUNNER_TEMP/sdist-venv"
+          "$RUNNER_TEMP/sdist-venv/bin/python" -m pip install "$GITHUB_WORKSPACE"/dist/*.tar.gz
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/sdist-venv/bin/python" \
+            "$GITHUB_WORKSPACE/scripts/verify_release_artifact.py" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --expected-version "${GITHUB_REF_NAME#v}"
+
       - uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Security
+
+- **Release gates now fail closed.** CodeQL analysis failures block instead of being ignored. Before trusted PyPI publication, clean virtual environments install and verify both the built wheel and source distribution outside the checkout, checking tag/version identity, packaged schema resources, signing and verification, and rejection of unknown security fields.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/scripts/verify_release_artifact.py
+++ b/scripts/verify_release_artifact.py
@@ -1,0 +1,74 @@
+"""Fail closed if a built TRACE distribution is incomplete or not self-consistent."""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import time
+from importlib import metadata
+from pathlib import Path
+
+import agentrust_trace
+from agentrust_trace import (
+    generate_key,
+    key_to_jwk,
+    sign_record,
+    validate_json,
+    verify_record,
+)
+from jsonschema import ValidationError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True, type=Path)
+    parser.add_argument("--expected-version", required=True)
+    args = parser.parse_args()
+
+    imported_from = Path(inspect.getfile(agentrust_trace)).resolve()
+    workspace = args.workspace.resolve()
+    if imported_from.is_relative_to(workspace):
+        raise SystemExit(
+            f"artifact check imported checkout source at {imported_from}, "
+            "not the installed artifact"
+        )
+
+    installed_version = metadata.version("agentrust-trace")
+    if installed_version != args.expected_version:
+        raise SystemExit(
+            f"installed artifact version {installed_version!r} != tag {args.expected_version!r}"
+        )
+    if agentrust_trace.__version__ != installed_version:
+        raise SystemExit(
+            f"runtime version {agentrust_trace.__version__!r} != metadata {installed_version!r}"
+        )
+
+    example_path = workspace / "examples" / "intel-tdx.json"
+    record = json.loads(example_path.read_text(encoding="utf-8"))
+    record["iat"] = int(time.time())
+    record.pop("signature", None)
+
+    # Exercises packaged schema resources plus the public signing and verification API.
+    validate_json(record)
+    key = generate_key()
+    signed = sign_record(record, key)
+    validate_json(signed)
+    verify_record(signed, key_to_jwk(key))
+
+    malformed = {**signed, "unexpected_security_semantics": "trusted"}
+    try:
+        validate_json(malformed)
+    except ValidationError:
+        pass
+    else:
+        raise SystemExit("packaged schema accepted an unknown top-level security field")
+
+    print(
+        f"verified agentrust-trace {installed_version} from {imported_from} "
+        "with packaged schema and signing round trip"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Two release gates could give false confidence: CodeQL analysis was explicitly allowed to fail, and the PyPI workflow published artifacts that had only been built—not installed or exercised. Source tests do not prove the wheel contains the expected schemas or that the sdist builds the same usable package.

## What changed

- remove `continue-on-error` from CodeQL analysis
- add a fail-closed artifact verifier
- install the exact wheel and sdist into separate clean virtual environments outside the checkout
- compare package metadata and runtime version with the release tag
- prove imports resolve to the installed artifact rather than checkout source
- load the packaged schema, validate an example, perform a signing/verification round trip, and reject an unknown security field
- include the verifier in CI lint scope

## Verification

Local reproduction of the release path:

- built `agentrust_trace-0.9.0-py3-none-any.whl`
- installed and verified the wheel in a clean temporary venv
- built/installed and verified `agentrust_trace-0.9.0.tar.gz` in a second clean venv
- source suite: 323 passed, 1 skipped
- `ruff check src tests scripts`
- `mypy src/agentrust_trace`
- `git diff --check`

The publish job still uses PyPI trusted publishing and now cannot reach it unless both artifact checks pass.