### PR TITLE
docs(security): align disclosure policy with TRACE v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Documentation
+
+- **The security policy now describes the software that is actually released.** It puts the Python signing and verification APIs, schemas, adapters, packaging, and release automation in scope; lists TRACE v0.2 and `agentrust-trace` 0.x as supported; and marks the superseded v0.1 profile unsupported.
+
 ## [0.9.0] — 2026-08-09
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Scope
 
-This repository contains a specification and machine-readable schema. Security issues fall into two categories:
+This repository contains the TRACE specification, machine-readable schemas, conformance fixtures, and the `agentrust-trace` Python reference library. Security issues fall into two categories:
 
 **Specification vulnerabilities** — flaws in the TRACE spec that would allow an attacker to forge a valid Trust Record, bypass verification, break the cryptographic chain, or make verifiable claims that are structurally false. These are the most serious and are treated as critical.
 
-**Implementation vulnerabilities** — flaws in reference examples or schema that could mislead implementors into producing insecure Trust Records. Report these here.
+**Implementation vulnerabilities** — flaws in the Python signing or verification APIs, schemas, adapters, reference examples, packaging, or release automation that could accept, produce, or distribute insecure Trust Records. Report these here.
 
 Vulnerabilities in the reference implementation (cMCP) should be reported at [agentrust-io/cmcp](https://github.com/agentrust-io/cmcp) using its security policy.
 
@@ -27,7 +27,7 @@ Include:
 | Severity | Initial response | Fix target |
 |---|---|---|
 | Critical (forgeable Trust Record, broken verification chain) | 24 hours | 7 days |
-| High (misleading schema, incorrect normative text) | 48 hours | 14 days |
+| High (verification bypass, misleading schema, incorrect normative text) | 48 hours | 14 days |
 | Medium / Low (editorial, non-normative) | 5 business days | Next spec patch |
 
 ## Disclosure
@@ -38,5 +38,5 @@ We follow coordinated disclosure. We will work with reporters to agree on a disc
 
 | Version | Supported |
 |---|---|
-| v0.1 (current) | Yes |
-| Earlier drafts | No |
+| TRACE v0.2 / `agentrust-trace` 0.x | Yes |
+| TRACE v0.1 and earlier drafts | No |

--- a/tests/test_security_policy.py
+++ b/tests/test_security_policy.py
@@ -1,0 +1,25 @@
+"""Release-facing security policy invariants."""
+
+from pathlib import Path
+
+
+POLICY = (Path(__file__).parent.parent / "SECURITY.md").read_text(encoding="utf-8")
+
+
+def test_current_trace_profile_is_supported() -> None:
+    assert "TRACE v0.2 / `agentrust-trace` 0.x | Yes" in POLICY
+
+
+def test_superseded_profile_is_not_supported() -> None:
+    assert "TRACE v0.1 and earlier drafts | No" in POLICY
+    assert "v0.1 (current)" not in POLICY
+
+
+def test_private_reporting_channel_is_published() -> None:
+    assert "trace-spec/security/advisories/new" in POLICY
+    assert "Do not open a public GitHub issue" in POLICY
+
+
+def test_reference_library_is_explicitly_in_scope() -> None:
+    assert "Python reference library" in POLICY
+    assert "signing or verification APIs" in POLICY


### PR DESCRIPTION
## Why

`SECURITY.md` still described this as only a specification/schema repository and listed v0.1 as the current supported version. The public release includes a Python reference library and v0.2-only verification behavior, so reporters need an accurate scope and support statement.

## What changed

- put signing and verification APIs, schemas, adapters, examples, packaging, and release automation explicitly in scope
- classify verification bypasses as high-severity implementation findings
- list TRACE v0.2 and `agentrust-trace` 0.x as supported
- mark TRACE v0.1 and earlier drafts unsupported
- retain GitHub private security advisories as the reporting channel
- add four policy invariants to prevent the release-facing statements from drifting silently

## Verification

- focused policy tests: 4 passed
- full suite: 327 passed, 1 skipped
- `ruff check src tests`
- `mypy src/agentrust_trace`
- `git diff --check`