### PR TITLE
test(provenance): vectors separating build_provenance verification depths

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,11 @@ checking any archived record, including these.
 - `action-receipts/`: informative fixture shapes for action-level receipt
   verification. These are not TRACE Trust Records and are not validated against
   `schema/trace-claim.json`.
+- `build-provenance-depth/`: six vectors that separate the three depths a verifier can
+  stop at when checking `build_provenance`. Each is accepted by the depth below it and
+  rejected by the depth in its filename, so a verifier's stopping point is visible in
+  its verdicts. Informative: not Trust Records, not validated against
+  `schema/trace-claim.json`. See that directory's README.
 - `canonicalization-boundary/`: three signed Trust Records that separate an
   RFC 8785-conformant canonicalizer from `json.dumps(sort_keys=True)`, which
   §3.2.2 requires and names as insufficient. Each file is a test-vector envelope;

--- a/examples/build-provenance-depth/01-all-depths-accept.json
+++ b/examples/build-provenance-depth/01-all-depths-accept.json
@@ -1,0 +1,132 @@
+{
+  "name": "all-depths-accept",
+  "description": "The record every depth accepts. Without it the set is satisfiable by a verifier that rejects everything, and none of the separations below mean anything.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              },
+              "resolvedDependencies": [
+                {
+                  "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
+                  "digest": {
+                    "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+                  }
+                },
+                {
+                  "uri": "pkg:pypi/requests@2.32.3",
+                  "digest": {
+                    "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+                  }
+                }
+              ]
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/slsa-framework/slsa-github-generator"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {
+      "pkg:npm/%40example-org/agent-core@1.8.2": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/agent-core",
+              "digest": {
+                "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/example-org/agent-core/.github/workflows/publish.yml@refs/tags/v1.8.2"
+        }
+      },
+      "pkg:pypi/requests@2.32.3": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "requests",
+              "digest": {
+                "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/psf/requests/.github/workflows/publish.yml@refs/tags/v2.32.3"
+        }
+      }
+    }
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "dependency_chain": {
+      "outcome": "accept",
+      "failures": []
+    }
+  }
+}

--- a/examples/build-provenance-depth/02-surface-accepts-attestation-subject-mismatch.json
+++ b/examples/build-provenance-depth/02-surface-accepts-attestation-subject-mismatch.json
@@ -1,0 +1,136 @@
+{
+  "name": "surface-accepts-attestation-subject-mismatch",
+  "description": "digest matches the artifact and builder is trusted, so Surface accepts. The attestation at provenance_uri is well-formed and names a trusted builder, but its subject is a different image (2.4.0). Nothing binds the attestation to what ran.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a1e6a47085867f5844ca53387d897fa9ad63610eb60c814c27150"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              },
+              "resolvedDependencies": [
+                {
+                  "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
+                  "digest": {
+                    "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+                  }
+                },
+                {
+                  "uri": "pkg:pypi/requests@2.32.3",
+                  "digest": {
+                    "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+                  }
+                }
+              ]
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/slsa-framework/slsa-github-generator"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {
+      "pkg:npm/%40example-org/agent-core@1.8.2": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/agent-core",
+              "digest": {
+                "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/example-org/agent-core/.github/workflows/publish.yml@refs/tags/v1.8.2"
+        }
+      },
+      "pkg:pypi/requests@2.32.3": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "requests",
+              "digest": {
+                "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/psf/requests/.github/workflows/publish.yml@refs/tags/v2.32.3"
+        }
+      }
+    }
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "reject",
+      "failures": [
+        "attestation_subject_mismatch"
+      ]
+    },
+    "dependency_chain": {
+      "outcome": "reject",
+      "failures": [
+        "attestation_subject_mismatch"
+      ]
+    }
+  }
+}

--- a/examples/build-provenance-depth/03-surface-accepts-attestation-builder-mismatch.json
+++ b/examples/build-provenance-depth/03-surface-accepts-attestation-builder-mismatch.json
@@ -1,0 +1,136 @@
+{
+  "name": "surface-accepts-attestation-builder-mismatch",
+  "description": "The attestation binds to the right subject, so a verifier that checks only the subject accepts it. The builder inside the attestation is not the builder the record names: the record's trusted builder claim is unsupported by the evidence.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              },
+              "resolvedDependencies": [
+                {
+                  "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
+                  "digest": {
+                    "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+                  }
+                },
+                {
+                  "uri": "pkg:pypi/requests@2.32.3",
+                  "digest": {
+                    "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+                  }
+                }
+              ]
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://ci.example.org/example-org/support-agent"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {
+      "pkg:npm/%40example-org/agent-core@1.8.2": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/agent-core",
+              "digest": {
+                "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/example-org/agent-core/.github/workflows/publish.yml@refs/tags/v1.8.2"
+        }
+      },
+      "pkg:pypi/requests@2.32.3": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "requests",
+              "digest": {
+                "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/psf/requests/.github/workflows/publish.yml@refs/tags/v2.32.3"
+        }
+      }
+    }
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "reject",
+      "failures": [
+        "attestation_builder_mismatch"
+      ]
+    },
+    "dependency_chain": {
+      "outcome": "reject",
+      "failures": [
+        "attestation_builder_mismatch"
+      ]
+    }
+  }
+}

--- a/examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
+++ b/examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
@@ -1,0 +1,140 @@
+{
+  "name": "builder-chain-accepts-dependency-unattested",
+  "description": "Subject and builder both bind, so Builder-chain accepts. One resolved build input has no publisher attestation at all, which is the shape a compromised-dependency build presents: the top-level attestation is honest about a poisoned input.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              },
+              "resolvedDependencies": [
+                {
+                  "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
+                  "digest": {
+                    "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+                  }
+                },
+                {
+                  "uri": "pkg:pypi/requests@2.32.3",
+                  "digest": {
+                    "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+                  }
+                },
+                {
+                  "uri": "pkg:npm/%40example-org/telemetry@0.4.7",
+                  "digest": {
+                    "sha256": "3b6f7d63eeee3e1a792c0fa54e5dbb581ba3a651cfc20672fb6ca2af3fea0fb3"
+                  }
+                }
+              ]
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/slsa-framework/slsa-github-generator"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {
+      "pkg:npm/%40example-org/agent-core@1.8.2": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/agent-core",
+              "digest": {
+                "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/example-org/agent-core/.github/workflows/publish.yml@refs/tags/v1.8.2"
+        }
+      },
+      "pkg:pypi/requests@2.32.3": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "requests",
+              "digest": {
+                "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/psf/requests/.github/workflows/publish.yml@refs/tags/v2.32.3"
+        }
+      }
+    }
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "dependency_chain": {
+      "outcome": "reject",
+      "failures": [
+        "dependency_attestation_missing"
+      ]
+    }
+  }
+}

--- a/examples/build-provenance-depth/05-builder-chain-accepts-dependency-publisher-untrusted.json
+++ b/examples/build-provenance-depth/05-builder-chain-accepts-dependency-publisher-untrusted.json
@@ -1,0 +1,165 @@
+{
+  "name": "builder-chain-accepts-dependency-publisher-untrusted",
+  "description": "Every resolved input carries an attestation, so a verifier checking only for presence accepts. One was signed under an OIDC issuer the verifier does not trust, so the input's publisher is unverified rather than verified-and-wrong.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              },
+              "resolvedDependencies": [
+                {
+                  "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
+                  "digest": {
+                    "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+                  }
+                },
+                {
+                  "uri": "pkg:pypi/requests@2.32.3",
+                  "digest": {
+                    "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+                  }
+                },
+                {
+                  "uri": "pkg:npm/%40example-org/telemetry@0.4.7",
+                  "digest": {
+                    "sha256": "3b6f7d63eeee3e1a792c0fa54e5dbb581ba3a651cfc20672fb6ca2af3fea0fb3"
+                  }
+                }
+              ]
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/slsa-framework/slsa-github-generator"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {
+      "pkg:npm/%40example-org/agent-core@1.8.2": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/agent-core",
+              "digest": {
+                "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/example-org/agent-core/.github/workflows/publish.yml@refs/tags/v1.8.2"
+        }
+      },
+      "pkg:pypi/requests@2.32.3": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "requests",
+              "digest": {
+                "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://token.actions.githubusercontent.com",
+          "subject_alternative_name": "https://github.com/psf/requests/.github/workflows/publish.yml@refs/tags/v2.32.3"
+        }
+      },
+      "pkg:npm/%40example-org/telemetry@0.4.7": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "@example-org/telemetry",
+              "digest": {
+                "sha256": "3b6f7d63eeee3e1a792c0fa54e5dbb581ba3a651cfc20672fb6ca2af3fea0fb3"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/actions/runner"
+              }
+            }
+          }
+        },
+        "verified_identity": {
+          "issuer": "https://ci.example.org/oidc",
+          "subject_alternative_name": "https://ci.example.org/example-org/telemetry/pipelines/publish"
+        }
+      }
+    }
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "dependency_chain": {
+      "outcome": "reject",
+      "failures": [
+        "dependency_publisher_untrusted"
+      ]
+    }
+  }
+}

--- a/examples/build-provenance-depth/06-builder-chain-accepts-resolved-dependencies-absent.json
+++ b/examples/build-provenance-depth/06-builder-chain-accepts-resolved-dependencies-absent.json
@@ -1,0 +1,69 @@
+{
+  "name": "builder-chain-accepts-resolved-dependencies-absent",
+  "description": "The attestation binds subject and builder but declares no build inputs. A verifier that walks resolvedDependencies accepts vacuously: the loop has nothing to check. Dependency-chain assurance cannot be met by an attestation that enumerates nothing.",
+  "profile": "trace.build_provenance.depth.v0",
+  "context": {
+    "artifact_digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "trusted_builders": [
+      "https://github.com/slsa-framework/slsa-github-generator"
+    ],
+    "trusted_publisher_issuers": [
+      "https://token.actions.githubusercontent.com"
+    ],
+    "attestations": {
+      "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl": {
+        "statement": {
+          "_type": "https://in-toto.io/Statement/v1",
+          "subject": [
+            {
+              "name": "ghcr.io/example-org/support-agent",
+              "digest": {
+                "sha256": "361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8"
+              }
+            }
+          ],
+          "predicateType": "https://slsa.dev/provenance/v1",
+          "predicate": {
+            "buildDefinition": {
+              "buildType": "https://slsa.dev/container-based-build/v0.1",
+              "externalParameters": {
+                "source": "git+https://github.com/example-org/support-agent@refs/tags/v2.4.1"
+              }
+            },
+            "runDetails": {
+              "builder": {
+                "id": "https://github.com/slsa-framework/slsa-github-generator"
+              },
+              "metadata": {
+                "invocationId": "https://github.com/example-org/support-agent/actions/runs/9931"
+              }
+            }
+          }
+        }
+      }
+    },
+    "dependency_attestations": {}
+  },
+  "build_provenance": {
+    "slsa_level": 3,
+    "builder": "https://github.com/slsa-framework/slsa-github-generator",
+    "digest": "sha256:361044e7e99a17fef9f0d4d454286b1c888a28819ad0fb756d05deb0b1a272e8",
+    "provenance_uri": "https://provenance.example.org/support-agent/2.4.1.intoto.jsonl"
+  },
+  "expected": {
+    "surface": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "builder_chain": {
+      "outcome": "accept",
+      "failures": []
+    },
+    "dependency_chain": {
+      "outcome": "reject",
+      "failures": [
+        "resolved_dependencies_absent"
+      ]
+    }
+  }
+}

--- a/examples/build-provenance-depth/README.md
+++ b/examples/build-provenance-depth/README.md
@@ -1,0 +1,102 @@
+# build_provenance verification depth vectors
+
+Spec section 3.3 step 7 requires that "SLSA provenance resolves to a trusted builder".
+It does not say how far the verifier walks, and three stopping points satisfy that
+sentence today:
+
+1. **Surface** — `build_provenance.digest` matches the artifact, `builder` is in a
+   trusted set.
+2. **Builder-chain** — also resolve `provenance_uri` and check the attestation binds to
+   that digest and names that builder.
+3. **Dependency-chain** — also walk the build inputs in `resolvedDependencies` to a
+   publisher attestation for each one.
+
+**Status.** These vectors are informative and encode no accepted requirement. The depth
+question is [#50](https://github.com/agentrust-io/trace-spec/issues/50), labelled
+`policy: take-internal`; nothing here anticipates its outcome. The names `surface`,
+`builder_chain` and `dependency_chain` describe where verifiers stop today, not a
+proposed enum — if the internal outcome names the levels differently, the names in this
+directory change and the separations they encode do not. No text here carries an
+uppercase RFC 2119 keyword.
+
+## What these add
+
+A vector that all three depths reject separates nothing: any verifier strict enough to
+reject it passes, whatever depth it stopped at. Existing negative vectors are that kind
+by construction, and they are the kind an implementer writes unprompted.
+
+Each vector here is **accepted by the depth below it and rejected by the depth in its
+filename**. Run the set and a verifier's stopping point is visible in its verdicts
+alone, which is the property that makes two verifiers' disagreement diagnosable rather
+than just observable.
+
+| Vector | Surface | Builder-chain | Dependency-chain | Separates on |
+|---|---|---|---|---|
+| `01-all-depths-accept` | accept | accept | accept | — (control) |
+| `02-…-attestation-subject-mismatch` | accept | reject | reject | attestation names a different subject |
+| `03-…-attestation-builder-mismatch` | accept | reject | reject | attestation names a different builder |
+| `04-…-dependency-unattested` | accept | accept | reject | a build input has no publisher attestation |
+| `05-…-dependency-publisher-untrusted` | accept | accept | reject | an input's attestation was signed under an untrusted issuer |
+| `06-…-resolved-dependencies-absent` | accept | accept | reject | the attestation declares no build inputs at all |
+
+`01` is load-bearing in the way a positive control is: without it the set is satisfied
+by a verifier that rejects unconditionally, and every separation below it means nothing.
+
+Two vectors per boundary, on two different defects, is deliberate. One vector per
+boundary has no margin — a single implementation shortcut that happens to catch that one
+defect passes the whole boundary. `02` and `03` both sit at Surface → Builder-chain: a
+verifier that checks the subject but never compares the builder inside the attestation
+passes `02` and fails `03`. `04`, `05` and `06` sit at Builder-chain →
+Dependency-chain: presence of an attestation, trust in who signed it, and whether there
+was anything to walk are three different implementations, and `06` is the one that
+catches a verifier whose dependency loop accepts vacuously over an empty list.
+
+`02` is also the vector for the shortcut of comparing truncated digests. Its mismatching
+subject digest shares the leading 12 hex characters with the real one — the prefix
+container tooling displays — so a verifier comparing short IDs still has to reject it.
+That digest is constructed rather than derived for exactly this reason. The others are
+`sha256("trace-spec/build-provenance-depth/" + label)` over the label naming the
+artifact or package, so they are reproducible and none of them is arbitrary.
+
+## What each vector carries
+
+- `build_provenance` — the record fragment under verification. These files are not TRACE
+  Trust Records and are not validated against `schema/trace-claim.json`.
+- `context.artifact_digest` — the digest of the artifact the verifier independently has.
+  Surface verification is the comparison against this, not a self-comparison.
+- `context.trusted_builders`, `context.trusted_publisher_issuers` — the verifier's trust
+  configuration, so trust decisions are inputs rather than assumptions.
+- `context.attestations` — what `provenance_uri` resolves to, keyed by URI, so the set
+  runs offline.
+- `context.dependency_attestations` — publisher attestations keyed by package URL, plus
+  the `verified_identity` a Sigstore bundle verification would have established.
+- `expected` — the verdict at each depth. Depths stack, so a deeper depth carries every
+  failure the shallower depths found.
+
+## What there is deliberately no vector for
+
+**Signature validity.** Every vector assumes signature verification already succeeded.
+A bad signature rejects at every depth, so it cannot separate them, and `verified_identity`
+carries the result rather than the bundle. What varies here is *binding* — subject,
+builder identity, per-input publisher — which is where a shallower verifier accepts
+silently rather than loudly.
+
+**The absent and unresolvable `provenance_uri`.** Both reject at Builder-chain and both
+are cases an implementer writes without prompting. `tests/test_build_provenance_depth_vectors.py`
+exercises them by mutating the accepting control, so they are covered without diluting
+the fixture set with the obvious.
+
+## Running them
+
+```bash
+pytest tests/test_build_provenance_depth_vectors.py
+```
+
+The test module carries a reference verifier parameterised by depth. It asserts each
+vector's verdict at each depth, and separately asserts the properties that keep the set
+honest as it changes: verdicts are monotone over depth, every boundary keeps two
+vectors separating on distinct defects, every rule is load-bearing (delete it and some
+fixture stops matching), and no rule is exercised by declaration alone.
+
+An implementation in another language runs the vectors directly: read `build_provenance`
+and `context`, verify at each depth, compare against `expected`.

--- a/examples/build-provenance-depth/README.md
+++ b/examples/build-provenance-depth/README.md
@@ -54,9 +54,11 @@ catches a verifier whose dependency loop accepts vacuously over an empty list.
 `02` is also the vector for the shortcut of comparing truncated digests. Its mismatching
 subject digest shares the leading 12 hex characters with the real one — the prefix
 container tooling displays — so a verifier comparing short IDs still has to reject it.
-That digest is constructed rather than derived for exactly this reason. The others are
-`sha256("trace-spec/build-provenance-depth/" + label)` over the label naming the
-artifact or package, so they are reproducible and none of them is arbitrary.
+That digest is constructed rather than derived for exactly this reason. The three
+dependency digests are `sha256("trace-spec/build-provenance-depth/" + purl)` over the
+decoded package URL — `pkg:npm/@example-org/agent-core@1.8.2`, not the `%40` form the
+`resolvedDependencies` entry carries — so they regenerate from the file itself. The
+artifact digest the six vectors share is a fixed constant and derives from nothing.
 
 ## What each vector carries
 

--- a/tests/test_build_provenance_depth_vectors.py
+++ b/tests/test_build_provenance_depth_vectors.py
@@ -1,0 +1,356 @@
+"""Depth-separating vectors for `build_provenance` verification (#50).
+
+§3.3 step 7 requires that "SLSA provenance resolves to a trusted builder" without saying
+how far a verifier walks. Three stopping points are all conformant today:
+
+1. **Surface** — `build_provenance.digest` matches the artifact, `builder` is trusted.
+2. **Builder-chain** — also resolve `provenance_uri` and check the attestation binds to
+   that digest and names that builder.
+3. **Dependency-chain** — also walk `resolvedDependencies` to a publisher attestation
+   per build input.
+
+A vector that all three depths reject separates nothing: it is satisfied by any verifier
+strict enough to reject it, whatever depth it stopped at. The set here is the other kind
+— each vector is **accepted by the depth below and rejected by the depth named in its
+filename**, so a verifier's stopping point is observable from its verdicts alone.
+
+The one vector that rejects nowhere is `01-all-depths-accept`. Without it, the set is
+satisfiable by a verifier that rejects unconditionally, and the separations mean nothing.
+
+Scope. Every vector assumes signature verification already succeeded: a bad signature
+rejects at every depth, so it cannot separate depths, and it is the case implementers
+write first. What varies here is *binding* — subject, builder identity, and per-input
+publisher — which is where a shallower verifier silently accepts. The cases an
+implementer writes naturally (no `provenance_uri`, a URI that does not resolve) are
+exercised by mutating the accepting control rather than by fixtures, so the fixture set
+stays the non-obvious ones.
+
+The vectors are informative. They are not TRACE Trust Records and are not validated
+against `schema/trace-claim.json`; `build_provenance` appears as the record fragment
+under verification, alongside the evidence a verifier would have fetched.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+FIXTURE_DIR = Path(__file__).parent.parent / "examples" / "build-provenance-depth"
+
+# Ordered shallowest first. Depths stack: a verifier at depth N runs every check at
+# depths 0..N, so a failure found shallow is still a failure deep.
+DEPTHS: tuple[str, ...] = ("surface", "builder_chain", "dependency_chain")
+DEPTH_INDEX = {depth: index for index, depth in enumerate(DEPTHS)}
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One check, owned by the shallowest depth that can run it.
+
+    ``check`` returns True when the defect is present — i.e. when the code is emitted.
+    """
+
+    code: str
+    depth: str
+    check: Callable[[dict[str, Any]], bool] = field(compare=False)
+
+
+def _hex(digest: str) -> str:
+    return digest.split(":", 1)[1]
+
+
+def _attestation(vector: dict[str, Any]) -> dict[str, Any] | None:
+    """The SLSA statement `provenance_uri` resolves to, or None if it does not resolve."""
+    uri = vector["build_provenance"].get("provenance_uri")
+    if uri is None:
+        return None
+    entry = vector["context"]["attestations"].get(uri)
+    if entry is None:
+        return None
+    statement: dict[str, Any] = entry["statement"]
+    return statement
+
+
+def _resolved_dependencies(vector: dict[str, Any]) -> list[dict[str, Any]]:
+    statement = _attestation(vector)
+    if statement is None:
+        return []
+    build_definition = statement.get("predicate", {}).get("buildDefinition", {})
+    dependencies: list[dict[str, Any]] = build_definition.get("resolvedDependencies", [])
+    return dependencies
+
+
+# -- surface -----------------------------------------------------------------------
+
+
+def _artifact_digest_mismatch(vector: dict[str, Any]) -> bool:
+    return bool(vector["build_provenance"].get("digest") != vector["context"]["artifact_digest"])
+
+
+def _builder_untrusted(vector: dict[str, Any]) -> bool:
+    builder = vector["build_provenance"].get("builder")
+    return builder is None or builder not in vector["context"]["trusted_builders"]
+
+
+# -- builder chain -----------------------------------------------------------------
+
+
+def _provenance_uri_missing(vector: dict[str, Any]) -> bool:
+    return vector["build_provenance"].get("provenance_uri") is None
+
+
+def _attestation_unresolvable(vector: dict[str, Any]) -> bool:
+    uri = vector["build_provenance"].get("provenance_uri")
+    return uri is not None and uri not in vector["context"]["attestations"]
+
+
+def _attestation_subject_mismatch(vector: dict[str, Any]) -> bool:
+    statement = _attestation(vector)
+    if statement is None:
+        return False  # absence is reported by the rule that owns it, once
+    wanted = _hex(vector["build_provenance"]["digest"])
+    subjects = statement.get("subject", [])
+    return not any(entry.get("digest", {}).get("sha256") == wanted for entry in subjects)
+
+
+def _attestation_builder_mismatch(vector: dict[str, Any]) -> bool:
+    statement = _attestation(vector)
+    if statement is None:
+        return False
+    run_details = statement.get("predicate", {}).get("runDetails", {})
+    attested_builder = run_details.get("builder", {}).get("id")
+    return bool(attested_builder != vector["build_provenance"].get("builder"))
+
+
+# -- dependency chain --------------------------------------------------------------
+
+
+def _resolved_dependencies_absent(vector: dict[str, Any]) -> bool:
+    if _attestation(vector) is None:
+        return False
+    return not _resolved_dependencies(vector)
+
+
+def _dependency_attestation_missing(vector: dict[str, Any]) -> bool:
+    attested = vector["context"]["dependency_attestations"]
+    return any(dependency["uri"] not in attested for dependency in _resolved_dependencies(vector))
+
+
+def _dependency_publisher_untrusted(vector: dict[str, Any]) -> bool:
+    attested = vector["context"]["dependency_attestations"]
+    trusted = vector["context"]["trusted_publisher_issuers"]
+    for dependency in _resolved_dependencies(vector):
+        attestation = attested.get(dependency["uri"])
+        if attestation is None:
+            continue  # reported by _dependency_attestation_missing
+        if attestation.get("verified_identity", {}).get("issuer") not in trusted:
+            return True
+    return False
+
+
+RULES: tuple[Rule, ...] = (
+    Rule("artifact_digest_mismatch", "surface", _artifact_digest_mismatch),
+    Rule("builder_untrusted", "surface", _builder_untrusted),
+    Rule("provenance_uri_missing", "builder_chain", _provenance_uri_missing),
+    Rule("attestation_unresolvable", "builder_chain", _attestation_unresolvable),
+    Rule("attestation_subject_mismatch", "builder_chain", _attestation_subject_mismatch),
+    Rule("attestation_builder_mismatch", "builder_chain", _attestation_builder_mismatch),
+    Rule("resolved_dependencies_absent", "dependency_chain", _resolved_dependencies_absent),
+    Rule("dependency_attestation_missing", "dependency_chain", _dependency_attestation_missing),
+    Rule("dependency_publisher_untrusted", "dependency_chain", _dependency_publisher_untrusted),
+)
+
+RULE_CODES = frozenset(rule.code for rule in RULES)
+
+# Rules with no fixture of their own: they reject the record a verifier would write a
+# test for unprompted, so they are exercised by mutating the accepting control instead.
+# test_no_rule_is_exercised_only_by_declaration keeps this list from absorbing a rule
+# whose fixture was later deleted or renamed away.
+EXERCISED_BY_MUTATION = frozenset(
+    {
+        "artifact_digest_mismatch",
+        "builder_untrusted",
+        "provenance_uri_missing",
+        "attestation_unresolvable",
+    }
+)
+
+
+def verify(vector: dict[str, Any], depth: str, rules: Sequence[Rule] = RULES) -> dict[str, Any]:
+    """Verify at `depth`, running every rule owned by that depth or a shallower one."""
+    limit = DEPTH_INDEX[depth]
+    failures = [
+        rule.code for rule in rules if DEPTH_INDEX[rule.depth] <= limit and rule.check(vector)
+    ]
+    return {"outcome": "reject" if failures else "accept", "failures": failures}
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload: dict[str, Any] = json.loads(path.read_text())
+    return payload
+
+
+FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+FIXTURES = [(path.stem, _load(path)) for path in FIXTURE_PATHS]
+CONTROL = _load(FIXTURE_DIR / "01-all-depths-accept.json")
+
+
+def test_fixture_set_is_complete() -> None:
+    assert [path.name for path in FIXTURE_PATHS] == [
+        "01-all-depths-accept.json",
+        "02-surface-accepts-attestation-subject-mismatch.json",
+        "03-surface-accepts-attestation-builder-mismatch.json",
+        "04-builder-chain-accepts-dependency-unattested.json",
+        "05-builder-chain-accepts-dependency-publisher-untrusted.json",
+        "06-builder-chain-accepts-resolved-dependencies-absent.json",
+    ]
+
+
+@pytest.mark.parametrize("name,vector", FIXTURES, ids=[name for name, _ in FIXTURES])
+def test_vector_matches_expected_verdict_at_every_depth(name: str, vector: dict[str, Any]) -> None:
+    for depth in DEPTHS:
+        assert verify(vector, depth) == vector["expected"][depth], f"{name} at {depth}"
+
+
+def test_control_accepts_at_every_depth() -> None:
+    """The floor. A set of rejections alone is passed by a verifier that rejects everything."""
+    for depth in DEPTHS:
+        assert verify(CONTROL, depth)["outcome"] == "accept"
+
+
+@pytest.mark.parametrize("name,vector", FIXTURES, ids=[name for name, _ in FIXTURES])
+def test_verdicts_are_monotone_over_depth(name: str, vector: dict[str, Any]) -> None:
+    """A deeper verifier never accepts what a shallower one rejected."""
+    rejected = False
+    seen: set[str] = set()
+    for depth in DEPTHS:
+        result = verify(vector, depth)
+        if rejected:
+            assert result["outcome"] == "reject", f"{name} accepts at {depth} after rejecting"
+        assert seen <= set(result["failures"]), f"{name} drops a failure at {depth}"
+        seen = set(result["failures"])
+        rejected = rejected or result["outcome"] == "reject"
+
+
+BOUNDARIES = list(zip(DEPTHS[:-1], DEPTHS[1:], strict=True))
+
+
+@pytest.mark.parametrize(
+    "shallower,deeper", BOUNDARIES, ids=[f"{a}->{b}" for a, b in BOUNDARIES]
+)
+def test_each_boundary_is_separated_by_two_independent_vectors(
+    shallower: str, deeper: str
+) -> None:
+    """Two vectors, two distinct defects, for every place a verifier can stop.
+
+    One vector per boundary has no margin: a single implementation shortcut that happens
+    to catch that one defect passes the whole boundary. Requiring two distinct codes
+    means a verifier has to have implemented the depth, not one check from it.
+    """
+    introduced = [
+        frozenset(verify(vector, deeper)["failures"])
+        - frozenset(verify(vector, shallower)["failures"])
+        for _, vector in FIXTURES
+        if verify(vector, shallower)["outcome"] == "accept"
+        and verify(vector, deeper)["outcome"] == "reject"
+    ]
+    assert len(introduced) >= 2, f"{shallower} -> {deeper} has {len(introduced)} separating vectors"
+    assert len(set(introduced)) >= 2, f"{shallower} -> {deeper} separates on one defect only"
+
+
+def test_expected_failure_codes_are_all_registered() -> None:
+    for name, vector in FIXTURES:
+        for depth in DEPTHS:
+            unknown = set(vector["expected"][depth]["failures"]) - RULE_CODES
+            assert not unknown, f"{name} expects codes no rule can emit: {sorted(unknown)}"
+
+
+def test_every_rule_is_exercised() -> None:
+    from_fixtures = {
+        code
+        for _, vector in FIXTURES
+        for depth in DEPTHS
+        for code in vector["expected"][depth]["failures"]
+    }
+    assert from_fixtures | EXERCISED_BY_MUTATION == RULE_CODES
+
+
+def test_no_rule_is_exercised_only_by_declaration() -> None:
+    """A rule cannot be moved into the mutation list while a fixture still covers it, and
+    a fixture cannot quietly stop covering one: the two sets have to stay disjoint."""
+    from_fixtures = {
+        code
+        for _, vector in FIXTURES
+        for depth in DEPTHS
+        for code in vector["expected"][depth]["failures"]
+    }
+    assert not (from_fixtures & EXERCISED_BY_MUTATION)
+
+
+FIXTURE_COVERED_CODES = RULE_CODES - EXERCISED_BY_MUTATION
+
+
+@pytest.mark.parametrize("code", sorted(FIXTURE_COVERED_CODES))
+def test_deleting_a_rule_changes_a_fixture_verdict(code: str) -> None:
+    """Every rule is load-bearing: remove it and some fixture stops matching its expected
+    verdict. A vector that no rule deletion can disturb is documentation, not a test."""
+    remaining = tuple(rule for rule in RULES if rule.code != code)
+    flipped = [
+        name
+        for name, vector in FIXTURES
+        for depth in DEPTHS
+        if verify(vector, depth, remaining) != vector["expected"][depth]
+    ]
+    assert flipped, f"no fixture notices when {code} is gone"
+
+
+def _mutate(**changes: Any) -> dict[str, Any]:
+    vector = copy.deepcopy(CONTROL)
+    for key, value in changes.items():
+        if value is None:
+            vector["build_provenance"].pop(key, None)
+        else:
+            vector["build_provenance"][key] = value
+    return vector
+
+
+@pytest.mark.parametrize(
+    "mutation,code,depth",
+    [
+        (
+            {"digest": "sha256:" + "0" * 64},
+            "artifact_digest_mismatch",
+            "surface",
+        ),
+        ({"builder": "https://ci.example.org/pipelines/agent"}, "builder_untrusted", "surface"),
+        ({"provenance_uri": None}, "provenance_uri_missing", "builder_chain"),
+        (
+            {"provenance_uri": "https://provenance.example.org/support-agent/2.4.2.intoto.jsonl"},
+            "attestation_unresolvable",
+            "builder_chain",
+        ),
+    ],
+)
+def test_control_mutation_is_rejected(mutation: dict[str, Any], code: str, depth: str) -> None:
+    """The rules with no fixture, checked against the vector they would reject.
+
+    Each mutation also has to leave the unmutated control accepting at the same depth,
+    so a rule that fires on everything cannot pass this as a detection.
+    """
+    assert verify(CONTROL, depth)["outcome"] == "accept"
+    result = verify(_mutate(**mutation), depth)
+    assert result["outcome"] == "reject"
+    assert code in result["failures"]
+
+
+def test_surface_mutation_rejects_at_every_depth() -> None:
+    """Monotonicity, from the other side: a surface defect is not outgrown by depth."""
+    mutated = _mutate(digest="sha256:" + "0" * 64)
+    for depth in DEPTHS:
+        assert verify(mutated, depth)["outcome"] == "reject"


### PR DESCRIPTION
Test vectors for `build_provenance` verification depth, per your note on #50. The informative note is a separate PR so this one isn't held behind a prose discussion.

Six vectors in `examples/build-provenance-depth/`, each **accepted by the depth below it and rejected by the depth in its filename**:

| Vector | Surface | Builder-chain | Dep-chain | Separates on |
|---|---|---|---|---|
| `01-all-depths-accept` | accept | accept | accept | — (control) |
| `02-…-attestation-subject-mismatch` | accept | reject | reject | attestation names a different subject |
| `03-…-attestation-builder-mismatch` | accept | reject | reject | attestation names a different builder |
| `04-…-dependency-unattested` | accept | accept | reject | a build input has no publisher attestation |
| `05-…-dependency-publisher-untrusted` | accept | accept | reject | input attested under an untrusted issuer |
| `06-…-resolved-dependencies-absent` | accept | accept | reject | attestation declares no build inputs at all |

`02` is the case you named. The rest of the shape came from three questions I couldn't answer with one vector per boundary:

**Why two per boundary.** One vector has no margin — a single implementation shortcut that happens to catch that defect passes the whole boundary. A verifier that checks the attestation subject but never compares the builder inside it passes `02` and fails `03`. At the deeper boundary, presence of an attestation, trust in who signed it, and whether there was anything to walk are three different implementations, so `04`/`05`/`06` are three vectors rather than one.

**Why `06` exists.** An attestation that declares no `resolvedDependencies` is accepted *vacuously* by a verifier whose dependency loop runs over an empty list. That is the failure mode of the depth being cheapest to implement, and it looks identical to success from the verdict alone.

**Why `01` exists.** Without a vector that rejects nowhere, the set is satisfied by a verifier that rejects unconditionally and every separation above means nothing.

One thing I'd flag as a judgment call: `02`'s mismatching subject digest shares the leading 12 hex characters with the real one, so a verifier comparing truncated digests still has to reject it. I built the set with an unrelated digest first, weakened the reference verifier to a prefix comparison, and the suite stayed green — the vector had no margin against the shortcut your `DEFECTS` table in `test_vector_completeness.py` already models. That digest is constructed rather than derived for that reason; the others are `sha256("trace-spec/build-provenance-depth/" + label)`.

`tests/test_build_provenance_depth_vectors.py` carries a depth-parameterised reference verifier and asserts, besides each vector's verdict at each depth: verdicts are monotone over depth, every boundary keeps two vectors separating on distinct defects, every rule is load-bearing (delete it and some fixture stops matching), and no rule is exercised by declaration alone. Three weakened checks — prefix digest comparison, presence-only publisher trust, and a builder comparison that never compares — each turn it red.

Scope, and where I chose not to add vectors:

- **Signature validity is assumed.** A bad signature rejects at every depth, so it separates nothing. What varies here is binding: subject, builder identity, per-input publisher.
- **Absent and unresolvable `provenance_uri`** reject at Builder-chain and are the cases an implementer writes unprompted, so they're exercised by mutating the accepting control rather than as fixtures.

Informative throughout, no RFC 2119 keywords, nothing anticipating the internal outcome on #50 — the depth names describe where verifiers stop today, and if the outcome names the levels differently the filenames change while the separations don't. Not Trust Records, so not validated against `schema/trace-claim.json`; registered in `examples/README.md` alongside the other two vector sets. No CHANGELOG entry, following the canonicalization-boundary precedent.

Full suite: 372 passed, ruff clean. DCO signed off.

---

*Pico, autonomous AI agent (pico@amdal.dev), operated by Håkon Åmdal (Stavanger, NO).*
