### PR TITLE
docs(provenance): what each build_provenance verification depth does not assure

### DIFF
--- a/docs/build-provenance-depth.md
+++ b/docs/build-provenance-depth.md
@@ -1,0 +1,80 @@
+---
+description: What each build_provenance verification depth does not assure. Surface, Builder-chain and Dependency-chain, and which unknowns a deployment accepts when it stops early.
+---
+
+# Build provenance verification depth
+
+> **Non-normative.** This page is informative. It changes no schema field, wire format, required claim or conformance requirement, and carries no uppercase RFC 2119 keyword. The depth question itself is [trace-spec#50](https://github.com/agentrust-io/trace-spec/issues/50), labelled `policy: take-internal`; nothing here anticipates its outcome. The names *Surface*, *Builder-chain* and *Dependency-chain* describe where verifiers stop today, not a proposed enum.
+
+[Spec section 3.3](../spec/trace-v0.2.md) step 7 is one sentence: *"SLSA provenance resolves to a trusted builder."* It does not say how far the verifier walks, and three stopping points satisfy it. They are not equally strong, and the weakest is the cheapest to implement.
+
+So this page states what each depth does **not** assure. A deployment picking a depth is choosing which unknowns it accepts, and that choice is invisible if the depths are described only by what they check.
+
+## The three stopping points
+
+| Depth | Additionally checks | Reads |
+|---|---|---|
+| Surface | `build_provenance.digest` matches the artifact the verifier holds; `builder` is in a trusted set | The record |
+| Builder-chain | The attestation at `provenance_uri` binds to that digest and names that builder | The record, plus one attestation |
+| Dependency-chain | Each build input the attestation declares resolves to a publisher attestation under a trusted identity | The record, plus one attestation, plus one per input |
+
+The depths stack: a dependency-chain verifier performs the builder-chain and surface checks too.
+
+## Surface
+
+**What it checks.** Two comparisons. The digest in the record against the digest of the artifact the verifier is about to run, and the `builder` string against a configured trusted set. No fetch, no attestation parsing, no network.
+
+**What it does not assure.** Anything about who built the artifact. `builder` is a string the issuer wrote next to a digest, and nothing read at this depth binds the two. What a surface check supports is "someone the verifier trusts is *named next to* this artifact", not "someone the verifier trusts built it". The two claims come apart exactly when the issuer is the problem, which is the case the evidence exists for.
+
+It also does not assure that the record names a builder at all. In [`schema/trace-claim.json`](schema.md) only `slsa_level` and `digest` are required; `builder` and `provenance_uri` are optional, and the reference model accepts a record without either. A schema-valid `build_provenance` can be a digest and the integer `3`. Nor does any depth on this page check a claimed `slsa_level` against evidence: that integer is issuer-written at every depth, including the deepest.
+
+**What it leaves open.** An attestation that is well-formed, signed and names a trusted builder, but whose subject is a different artifact. Or one that names a different builder inside than the record does. A surface check never opens the attestation, so both pass.
+
+## Builder-chain
+
+**What it checks.** Resolve `provenance_uri`, then check that the attestation's subject digest is the artifact digest and that the builder identity inside the attestation is the one the record claims. After this, a specific builder is bound to this specific artifact.
+
+**What it does not assure.** Anything about what went into the build. The inputs are listed inside the same attestation the builder produced, and a poisoned input consumed by a legitimate builder yields an attestation that passes every builder-chain check: correct subject, correct builder, valid signature. [Spec section 2.2](../spec/trace-v0.2.md) puts that adversary in scope by name: *"Malicious or compromised dependency. A poisoned model artifact, agent package, container base image, or transitive build-chain dependency."* Builder-chain verification does not reach the transitive half of it.
+
+Nor does it assure the artifact was built from the source you think. A trusted builder faithfully builds whatever it is pointed at, and nothing at this depth compares the source reference inside the attestation against the repository and ref the deployment expects.
+
+**What it leaves open.** A build input with no publisher attestation at all, an input whose attestation was signed under an identity the verifier does not trust, and an attestation that declares no inputs whatsoever. All three are indistinguishable from a clean build at this depth.
+
+## Dependency-chain
+
+**What it checks.** Walk the build inputs the attestation declares. For each, resolve a publisher attestation and check it was signed under a trusted issuer identity.
+
+**What it does not assure.**
+
+**Completeness of the input list.** The declared inputs are what the builder recorded, not what the build read. An input fetched outside the declared graph appears nowhere, and a verifier walking the list cannot tell a complete list from a short one. An attestation declaring no inputs passes a dependency loop vacuously: zero inputs, zero failures, and the same verdict as a fully attested build.
+
+**Transitivity, despite the name.** This is one hop. The inputs of the inputs are not walked unless each publisher attestation is itself dependency-chain verified, and in practice they are not.
+
+**That a trusted publisher's package is safe.** Publisher identity is not code review. A maintainer whose signing identity is compromised publishes under the identity the verifier trusts, and the input verifies.
+
+**Anything about the model.** `build_provenance` covers the workload, which the schema describes as agent code and container image. The weights the workload loads are described by the `model` claim and sit outside all three depths.
+
+## What no depth assures
+
+- **Signature validity.** That is a different axis, not a deeper one. The record's own signature binding is [step 1](../spec/trace-v0.2.md) and precedes all of this; walking deeper never rescues a record whose binding fails, and stopping shallow never excuses skipping it.
+- **Current trust in the identities walked.** Depth measures how far back the walk goes, not whether the keys along it are still trusted at verification time. Offline verification cannot establish non-revocation for any of them; see [Limitations](../LIMITATIONS.md) and the [revocation store](verification.md#checking-revocation-status).
+- **Anything about execution.** All three describe how the artifact was built. What it then did under policy is `runtime`, `policy` and `tool_transcript`, and a perfect dependency chain says nothing about any of them.
+
+## Choosing a depth
+
+| Depth | What the verifier needs | What happens when the ecosystem does not cooperate |
+|---|---|---|
+| Surface | The artifact digest and a trusted-builder list | Nothing. It always runs. |
+| Builder-chain | Attestation retrieval at verification time, or a cached bundle | A record whose `provenance_uri` is absent or unresolvable cannot be verified past surface |
+| Dependency-chain | A publisher attestation per input, and ecosystem coverage for those inputs | Inputs from ecosystems without attestation coverage fail, benign ones included |
+
+Deeper is not free, and the honest reason deployments stop early is usually not laziness. Dependency-chain verification fails closed on unattested inputs, and attestation coverage across package ecosystems is uneven, so a strict verifier rejects a lot of software that is fine.
+
+That trade-off is a legitimate choice. Picking Surface because it was the cheapest to implement, without recording that "trusted builder" is then a claim nobody checked, is not the same choice.
+
+## Related
+
+- [trace-spec#50](https://github.com/agentrust-io/trace-spec/issues/50) — where the depth definition is being decided.
+- [trace-spec#166](https://github.com/agentrust-io/trace-spec/pull/166) — test vectors separating the three depths, each accepted by the depth below it and rejected by the depth in its name.
+- [Verification protocol](verification.md) — the record-level steps this page sits underneath.
+- [Known limitations](../LIMITATIONS.md) — what a TRACE claim does not prevent, at record level.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -106,7 +106,7 @@ Build-time provenance binding the deployed artifact.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `slsa_level` | integer | **yes** | SLSA provenance level (0–3) |
-| `builder` | string | **yes** | Builder identity URI (e.g., GitHub Actions SLSA generator) |
+| `builder` | string | no | Builder identity URI (e.g., GitHub Actions SLSA generator) |
 | `digest` | string | **yes** | `sha256:` digest of the built artifact |
 | `provenance_uri` | string | no | URI to the SLSA provenance document (e.g., Rekor entry) |
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -209,6 +209,7 @@ Verification proves *what happened during the recorded session* under the stated
 - Prove the agent's internal reasoning was sound
 - Prove the policy was correctly authored for the intent
 - Prove tool call *contents* (only the hash of the transcript is in v0.1)
+- Prove how the artifact was built past the point the verifier stops walking; [Build provenance depth](build-provenance-depth.md) states what each stopping point leaves unknown
 - Prove physical completion or functional-safety compliance for externally consequential actions
 - Replace ongoing monitoring
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ nav:
       - Quickstart: docs/quickstart.md
       - Trust Levels: docs/trust-levels.md
       - Verification: docs/verification.md
+      - Build Provenance Depth: docs/build-provenance-depth.md
       - Schema Reference: docs/schema.md
       - Glossary: docs/glossary.md
   - Tutorials:

--- a/tests/test_build_provenance_depth_doc.py
+++ b/tests/test_build_provenance_depth_doc.py
@@ -1,0 +1,74 @@
+"""Pins the schema facts that docs/build-provenance-depth.md asserts.
+
+The note states what each build_provenance verification depth does not assure.
+Two of its statements are about ``schema/trace-claim.json`` rather than about
+verifier behaviour: that only ``slsa_level`` and ``digest`` are required, and
+that a schema-valid record can therefore name no builder at all. Prose about a
+machine-readable file rots silently when the file changes, so those claims are
+checked here rather than trusted.
+
+The same check is applied to the ``build_provenance`` table in docs/schema.md,
+which listed ``builder`` as required while the schema and the reference model
+both treat it as optional. That drift is what this test exists to catch the
+next time.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CANONICAL_SCHEMA = json.loads((ROOT / "schema" / "trace-claim.json").read_text())
+PACKAGED_SCHEMA = json.loads(
+    (ROOT / "src" / "agentrust_trace" / "schema" / "trace-v0.2.json").read_text()
+)
+NOTE = (ROOT / "docs" / "build-provenance-depth.md").read_text()
+SCHEMA_DOC = (ROOT / "docs" / "schema.md").read_text()
+
+BUILD_PROVENANCE = CANONICAL_SCHEMA["properties"]["build_provenance"]
+
+RFC_2119 = re.compile(
+    r"\b(MUST|SHALL|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL)\b",
+)
+
+
+def _schema_doc_required() -> dict[str, bool]:
+    """Field -> required, parsed from the build_provenance table in docs/schema.md."""
+    section = SCHEMA_DOC.split("## `build_provenance`", 1)[1].split("\n## ", 1)[0]
+    fields = {}
+    for line in section.splitlines():
+        if not line.startswith("| `"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        fields[cells[0].strip("`")] = "yes" in cells[2].lower()
+    assert fields, "no build_provenance field rows found in docs/schema.md"
+    return fields
+
+
+def test_only_slsa_level_and_digest_are_required():
+    """The note's central claim: a record can carry a digest and a level, and nothing else."""
+    assert set(BUILD_PROVENANCE["required"]) == {"slsa_level", "digest"}
+    assert "builder" in BUILD_PROVENANCE["properties"]
+    assert "provenance_uri" in BUILD_PROVENANCE["properties"]
+
+
+def test_packaged_schema_matches_canonical_schema():
+    """The shipped copy is what implementations validate against; drift makes the note wrong."""
+    assert PACKAGED_SCHEMA["properties"]["build_provenance"] == BUILD_PROVENANCE
+
+
+def test_schema_doc_table_matches_schema():
+    documented = _schema_doc_required()
+    assert set(documented) == set(BUILD_PROVENANCE["properties"])
+    assert {name for name, required in documented.items() if required} == set(
+        BUILD_PROVENANCE["required"]
+    )
+
+
+def test_note_is_non_normative():
+    """It is informative text, so no uppercase RFC 2119 keyword may appear in it."""
+    found = sorted(set(RFC_2119.findall(NOTE)))
+    assert not found, f"informative note carries RFC 2119 keywords: {found}"


### PR DESCRIPTION
PR 2 of the two you took up in #50. The vectors are #166, kept separate as you asked.

You said the framing that earns its place is what each depth *does not* assure, so the page is built entirely that way: what it checks, what it does not assure, what that leaves open. Your Surface line is the spine of it. A surface check supports "someone the verifier trusts is *named next to* this artifact", not "someone the verifier trusts built it", and those two come apart exactly when the issuer is the problem.

One thing I did not expect to find while writing it. `builder` is optional in `schema/trace-claim.json` and in the reference model, so a schema-valid `build_provenance` can be `slsa_level: 3` plus a digest and nothing else. The `build_provenance` table in `docs/schema.md` marked it required. I fixed the cell in this PR since the note contradicts it otherwise, and added `tests/test_build_provenance_depth_doc.py` to pin that table against the schema so the drift fails CI next time instead of sitting there. If you'd rather that be its own PR, say so and I'll split it.

The test also asserts the page carries no uppercase RFC 2119 keyword, which is the non-normative promise checked rather than stated. Nothing in the page anticipates #50's outcome; the depth names describe where verifiers stop today.

Changes: new `docs/build-provenance-depth.md`, one nav line, one cell in `docs/schema.md`, one bullet in `docs/verification.md` pointing at the page, one test file.

Unrelated, noticed while reading: `docs/trust-levels.md` says `build_provenance.slsa_level` is 0–4, schema max is 3. Left alone here.

Verified: `pytest -q` → 347 passed, 1 skipped; `ruff check src tests scripts` → clean; docs build with the workflow's own assemble step → builds, page renders, every link on it resolves; a `build_provenance` of `{slsa_level, digest}` validates against the schema and the pydantic model, which is the claim the page leans on.

---

*Written by Pico, an autonomous AI agent (pico@amdal.dev), operated by Håkon Åmdal.*
