### PR TITLE
test(provenance): a depth vector set must also separate how far the list is read

### DIFF
--- a/examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
+++ b/examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
@@ -31,6 +31,12 @@
               },
               "resolvedDependencies": [
                 {
+                  "uri": "pkg:npm/%40example-org/telemetry@0.4.7",
+                  "digest": {
+                    "sha256": "3b6f7d63eeee3e1a792c0fa54e5dbb581ba3a651cfc20672fb6ca2af3fea0fb3"
+                  }
+                },
+                {
                   "uri": "pkg:npm/%40example-org/agent-core@1.8.2",
                   "digest": {
                     "sha256": "fb6bfb2c7ffab3de12cbac5639014ae049aafb4dbb36390f251c82f63cf2d2cb"
@@ -40,12 +46,6 @@
                   "uri": "pkg:pypi/requests@2.32.3",
                   "digest": {
                     "sha256": "a30964f520316ef09eb682027001f6f142547f350fadaeef8be4bb1b48f6d49c"
-                  }
-                },
-                {
-                  "uri": "pkg:npm/%40example-org/telemetry@0.4.7",
-                  "digest": {
-                    "sha256": "3b6f7d63eeee3e1a792c0fa54e5dbb581ba3a651cfc20672fb6ca2af3fea0fb3"
                   }
                 }
               ]

--- a/tests/test_build_provenance_depth_vectors.py
+++ b/tests/test_build_provenance_depth_vectors.py
@@ -354,3 +354,66 @@ def test_surface_mutation_rejects_at_every_depth() -> None:
     mutated = _mutate(digest="sha256:" + "0" * 64)
     for depth in DEPTHS:
         assert verify(mutated, depth)["outcome"] == "reject"
+
+
+def _checking_only_first(count: int) -> tuple[Rule, ...]:
+    """The rule set of a verifier that walks `resolvedDependencies` and stops early."""
+
+    def truncated(check: Callable[[dict[str, Any]], bool]) -> Callable[[dict[str, Any]], bool]:
+        def run(vector: dict[str, Any]) -> bool:
+            dependencies = _resolved_dependencies(vector)
+            if not dependencies:
+                return check(vector)
+            trimmed = copy.deepcopy(vector)
+            statement = _attestation(trimmed)
+            assert statement is not None
+            build_definition = statement["predicate"]["buildDefinition"]
+            build_definition["resolvedDependencies"] = dependencies[:count]
+            return check(trimmed)
+
+        return run
+
+    walks_the_list = ("dependency_attestation_missing", "dependency_publisher_untrusted")
+    return tuple(
+        Rule(rule.code, rule.depth, truncated(rule.check))
+        if rule.code in walks_the_list
+        else rule
+        for rule in RULES
+    )
+
+
+@pytest.mark.parametrize("count", [1, 2])
+def test_a_verifier_that_stops_early_in_the_dependency_list_is_caught(count: int) -> None:
+    """Distinct failure codes are not enough on their own.
+
+    `test_each_boundary_is_separated_by_two_independent_vectors` asks that the two
+    vectors introduce different codes. A verifier can run every dependency check and
+    still be wrong by running them over too few dependencies, and that defeats distinct
+    codes without emitting one: every check is implemented, so no code is missing.
+
+    Both dependency vectors once placed their defect last, so a verifier reading any
+    proper prefix of the list accepted both while still rejecting the absent-list vector
+    — presenting as a `dependency_chain` verifier having read one dependency of three.
+    At least one vector must therefore fail for a verifier that stops early.
+    """
+    weakened = _checking_only_first(count)
+    walks_the_list = {"dependency_attestation_missing", "dependency_publisher_untrusted"}
+    # Only the vectors whose rejection depends on reading the list. 06 rejects because
+    # the list is absent, which an early-stopping verifier still catches, so counting it
+    # would satisfy this assertion without testing anything.
+    separating = [
+        (name, vector)
+        for name, vector in FIXTURES
+        if verify(vector, "builder_chain")["outcome"] == "accept"
+        and walks_the_list & set(verify(vector, "dependency_chain")["failures"])
+    ]
+    assert separating, "no vector rejects on a rule that walks resolvedDependencies"
+    caught = [
+        name
+        for name, vector in separating
+        if verify(vector, "dependency_chain", weakened)["outcome"] == "reject"
+    ]
+    assert caught, (
+        f"a verifier checking only the first {count} of resolvedDependencies is accepted "
+        f"by every vector that separates this boundary: {[n for n, _ in separating]}"
+    )


### PR DESCRIPTION
Builds on #166. Its rule is right and this is the next layer of it.

#166 asks for two vectors per boundary on distinct defects, because one vector has no margin: a single implementation shortcut that happens to catch that defect passes the whole boundary. The dependency boundary meets that rule and still admits one shortcut, and it is the shortcut that boundary exists to catch.

Both `04` and `05` place their defective dependency last in a list of three. So a verifier that walks `resolvedDependencies` and stops early accepts both, while still rejecting `06`, whose list is absent. Measured on `e7dd4fe`, with the two rules that walk the list restricted to the first k entries:

```
k    01 control   04        05        06
1    accept       accept    accept    reject
2    accept       accept    accept    reject
3    accept       reject    reject    reject
```

At k=1 that verifier presents as having implemented `dependency_chain` having read one dependency of three.

`test_each_boundary_is_separated_by_two_independent_vectors` does not see this, and is right not to. It asks that the two vectors introduce distinct failure codes, and they do. Every check is implemented here. The shortcut is in how many entries each one runs over, so no code goes missing and no rule-level guard can see it.

The fix is to move `04`'s unattested dependency to the front. Nothing else changes: every rule fires on the same vectors and every expected verdict is unchanged, since the rules quantify over the whole list.

`test_a_verifier_that_stops_early_in_the_dependency_list_is_caught` is added so the ordering cannot be undone by a later edit. It considers only the vectors that reject on a rule which walks the list: counting `06` would satisfy the assertion without testing anything.

Load-bearing, checked rather than assumed: restore `04`'s original ordering and both parametrizations fail. 378 pass; `ruff` clean on the same paths before and after.

Scope is `examples/` and `tests/` only. No `src`, schema, workflow or dependency changes.

---

## Reproduction


```bash
git fetch origin pull/169/head:pr169 && git checkout pr169
```

**The table.** `_checking_only_first(k)` is the rule set of a verifier that walks `resolvedDependencies` and stops after k entries. Restoring `04` to its state on `e7dd4fe` reproduces the measurement in the description:

```bash
git checkout e7dd4fe -- examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json

python - <<'PY'
import sys; sys.path.insert(0, "tests")
from test_build_provenance_depth_vectors import FIXTURES, verify, _checking_only_first
print("k    " + "  ".join(f"{n.split('-')[0]:8}" for n, _ in FIXTURES))
for k in (1, 2, 3):
    print(f"{k}    " + "  ".join(
        f'{verify(v, "dependency_chain", _checking_only_first(k))["outcome"]:8}'
        for _, v in FIXTURES))
PY
```

```
k    01        02        03        04        05        06
1    accept    reject    reject    accept    accept    reject
2    accept    reject    reject    accept    accept    reject
3    accept    reject    reject    reject    reject    reject
```

Both dependency vectors accept at k=1 and k=2. `06` rejects at every k, since its list is absent rather than under-read, which is why the new test excludes it.

**The same script after the fix**, with `04` back to this branch's ordering:

```
k    01        02        03        04        05        06
1    accept    reject    reject    reject    accept    reject
2    accept    reject    reject    reject    accept    reject
3    accept    reject    reject    reject    reject    reject
```

`04` now rejects at k=1. `05` still accepts, which is the intended shape: the boundary needs at least one vector that an early-stopping verifier cannot pass, not all of them.

**Load-bearing.** The two lines above and below are the whole check:

```bash
git checkout e7dd4fe -- examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
pytest -q tests/test_build_provenance_depth_vectors.py    # 2 failed, 29 passed

git checkout pr169 -- examples/build-provenance-depth/04-builder-chain-accepts-dependency-unattested.json
pytest -q tests/test_build_provenance_depth_vectors.py    # 31 passed
```

Run against the full suite on 3.11: 378 passed, 1 skipped.
