### PR TITLE
test(canonicalization): a second vector for the form a careful implementer reaches

### DIFF
--- a/examples/canonicalization-boundary/04-utf16-key-order-nested.json
+++ b/examples/canonicalization-boundary/04-utf16-key-order-nested.json
@@ -1,0 +1,58 @@
+{
+  "name": "utf16-key-order-nested",
+  "description": "The divergence of vector 03 moved inside a nested object, so that a canonicalizer sorting by UTF-16 code units at the outer levels and by code points below them passes 03 and fails here. Without it the closest non-conformant form is caught by one vector, and the boundary disappears with that vector.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "confidential",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA",
+        "zmeta": {
+          "zk😀": "sorts-first-under-rfc-8785",
+          "zk�": "sorts-second-under-rfc-8785"
+        }
+      }
+    },
+    "signature": "yXsht9nU--Hvr8K7xHq72MOU6xyVhsCKw0_YcAdDff641JNlPG1d2qAZ_zwXaLe48agijvRk3MVZioG85aAiBg"
+  },
+  "expected": {
+    "outcome": "verified"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact",
+    "sort_keys_compact_utf8"
+  ]
+}

--- a/examples/canonicalization-boundary/gen_boundary_vectors.py
+++ b/examples/canonicalization-boundary/gen_boundary_vectors.py
@@ -167,6 +167,32 @@ def main() -> None:
         ["sort_keys_default", "sort_keys_compact", "sort_keys_compact_utf8"],
     )))
 
+    r = copy.deepcopy(BASE_RECORD)
+    # The same UTF-16 divergence as vector 03, one level deeper. Every key at the top
+    # of `jwk` is ASCII here, so a canonicalizer that sorts by code units at the outer
+    # levels and recurses with the default sort agrees with RFC 8785 on vector 03 and
+    # separates only here. Measured: sorting by code units to depth 2 passes 03 and
+    # fails this one, which is the second, distinct defect #124 asks a boundary to have.
+    #
+    # The margin this adds is positional rather than mechanistic. Key ordering is the
+    # only RFC 8785 divergence this schema can reach at all, since no field is typed
+    # `number` and IEEE 754 serialization is therefore unreachable, which
+    # `test_number_divergence_is_still_unreachable` pins.
+    r["cnf"] = {"jwk": {"zmeta": {
+        "zk\U0001f600": "sorts-first-under-rfc-8785",
+        "zk\ufffd": "sorts-second-under-rfc-8785",
+    }}}
+    out.append(("04-utf16-key-order-nested.json", vector(
+        "utf16-key-order-nested",
+        "The divergence of vector 03 moved inside a nested object, so that a "
+        "canonicalizer sorting by UTF-16 code units at the outer levels and by code "
+        "points below them passes 03 and fails here. Without it the closest "
+        "non-conformant form is caught by one vector, and the boundary disappears "
+        "with that vector.",
+        r,
+        ["sort_keys_default", "sort_keys_compact", "sort_keys_compact_utf8"],
+    )))
+
     for name, doc in out:
         (OUT / name).write_text(
             json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"

--- a/tests/test_canonicalization_boundary.py
+++ b/tests/test_canonicalization_boundary.py
@@ -15,6 +15,7 @@ distinction it no longer makes.
 from __future__ import annotations
 
 import json
+from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,7 @@ def test_vector_set_is_complete() -> None:
         "01-non-ascii-values.json",
         "02-non-bmp-values.json",
         "03-utf16-key-order.json",
+        "04-utf16-key-order-nested.json",
     ]
 
 
@@ -102,6 +104,30 @@ def test_every_adhoc_form_is_caught_by_some_vector() -> None:
     """
     killed = {name for path in FIXTURE_PATHS for name in _load(path)["diverges_under"]}
     assert killed == set(ADHOC)
+
+
+def test_every_adhoc_form_is_caught_by_at_least_two_vectors() -> None:
+    """Covered once is covered until that vector changes.
+
+    `sort_keys_compact_utf8` is the form a careful implementer actually reaches, and
+    it was separated by `03` alone: weaken or retire that one vector and the closest
+    non-conformant canonicalizer passes the whole set, with every other assertion
+    here still green. This is the margin rule of agentrust-io/trace-spec#124 applied
+    to the set that measures the section 3.2.2 MUST.
+
+    `04` is the second vector, and it is a distinct defect rather than a restatement:
+    it moves the divergence inside a nested object, so a canonicalizer that sorts by
+    UTF-16 code units at the outer levels and by code points below them passes `03`
+    and fails `04`.
+    """
+    counts = Counter(name for path in FIXTURE_PATHS
+                     for name in _load(path)["diverges_under"])
+    assert set(counts) == set(ADHOC), "a form is separated by no vector at all"
+    thin = {name: n for name, n in counts.items() if n < 2}
+    assert not thin, (
+        f"separated by a single vector: {thin}. One vector is coverage until that "
+        "vector changes; two are required per boundary."
+    )
 
 
 def test_number_divergence_is_still_unreachable() -> None:


### PR DESCRIPTION
`test_every_adhoc_form_is_caught_by_some_vector` asserts that every ad-hoc form is separated by some vector, and every form is. Counting how many vectors separate each one gives a different answer.

| Ad-hoc form | Vectors that separate it |
|---|---|
| `sort_keys_default` | 3 |
| `sort_keys_compact` | 3 |
| `sort_keys_compact_utf8` | **1** |

`sort_keys_compact_utf8` is the form left after compact separators and `ensure_ascii` are both set correctly, which is to say the one a careful implementer actually reaches. It was separated by `03` alone. One vector is coverage until that vector changes: weaken or retire `03` and the closest non-conformant canonicalizer passes the whole set, with every other assertion in the module still green. That is the margin rule of #124 applied to the set that measures the section 3.2.2 MUST.

`04` moves `03`'s divergence inside a nested object, so it is a distinct defect rather than a restatement. A canonicalizer that sorts by UTF-16 code units at the outer levels and by code points below them accepts `03` and rejects `04`.

The margin this adds is positional rather than mechanistic, and worth naming as such: key ordering is the only RFC 8785 divergence this schema can reach at all, since no field is typed `number` and IEEE 754 serialization is therefore unreachable, which `test_number_divergence_is_still_unreachable` already pins.

## Reproduction

```bash
git fetch origin pull/170/head:pr170 && git checkout pr170
```

**The count in the table:**

```bash
python - <<'PY'
import json, pathlib
from collections import Counter
c = Counter(n for p in sorted(pathlib.Path("examples/canonicalization-boundary").glob("*.json"))
            for n in json.loads(p.read_text())["diverges_under"])
for form, n in sorted(c.items()): print(f"{form:26} {n}")
PY
```

On `HEAD~1` that prints `sort_keys_compact_utf8 1`; on this branch it prints `2`.

**The distinct defect.** A canonicalizer sorting by code units only to a given depth, then falling back to the default sort:

```bash
python - <<'PY'
import json, rfc8785
def ser(o, d, correct_to):
    if isinstance(o, dict):
        ks = sorted(o, key=lambda s: s.encode("utf-16-be")) if d <= correct_to else sorted(o)
        return "{" + ",".join(json.dumps(k, ensure_ascii=False) + ":" + ser(o[k], d+1, correct_to)
                              for k in ks) + "}"
    if isinstance(o, list):
        return "[" + ",".join(ser(x, d+1, correct_to) for x in o) + "]"
    return json.dumps(o, ensure_ascii=False)

for name in ("03-utf16-key-order", "04-utf16-key-order-nested"):
    r = {k: v for k, v in
         json.load(open(f"examples/canonicalization-boundary/{name}.json"))["record"].items()
         if k != "signature"}
    ok = ser(r, 0, 2).encode() == rfc8785.dumps(r)
    print(f"{name:34} {'accepts' if ok else 'REJECTS'}")
PY
```

```
03-utf16-key-order                 accepts
04-utf16-key-order-nested          REJECTS
```

**Load-bearing:**

```bash
git rm -q examples/canonicalization-boundary/04-utf16-key-order-nested.json
pytest -q tests/test_canonicalization_boundary.py   # 2 failed, 8 passed
git checkout -- examples/canonicalization-boundary/04-utf16-key-order-nested.json
pytest -q tests/test_canonicalization_boundary.py   # 12 passed
```

Full suite on 3.11: 379 passed, 1 skipped. `ruff check` clean. Scope is `examples/` and `tests/` only.
