### PR TITLE
fix(trust-levels): correct slsa_level range 0–4 → 0–3 and pin in CI

### DIFF
--- a/docs/trust-levels.md
+++ b/docs/trust-levels.md
@@ -60,7 +60,7 @@ Level 1 requires that the signing key be generated inside a verified TEE (AMD SE
 | `runtime.platform` | Must be `tpm2`, `sev-snp`, `tdx`, or `opaque` (not `software-only`) |
 | `runtime.measurement` | Non-zero `sha256:` or `sha384:` digest of the TEE launch state |
 | `appraisal.status` | Must be `affirming` (verifier has checked the TEE quote) |
-| `build_provenance.slsa_level` | Must be present (0–4) |
+| `build_provenance.slsa_level` | Must be present (0–3) |
 | `build_provenance.digest` | Must be a valid `sha256:` digest |
 
 The cMCP runtime handles Level 1 record emission automatically when running in a supported TEE. See [Hardware Attestation Platforms](tutorials/hardware-attestation-platforms.md).

--- a/tests/test_build_provenance_depth_doc.py
+++ b/tests/test_build_provenance_depth_doc.py
@@ -11,6 +11,11 @@ The same check is applied to the ``build_provenance`` table in docs/schema.md,
 which listed ``builder`` as required while the schema and the reference model
 both treat it as optional. That drift is what this test exists to catch the
 next time.
+
+``docs/trust-levels.md`` is also checked: the displayed slsa_level range must
+agree with the schema minimum and maximum. The original drift (0–4 vs max 3)
+was reported in #172 and would have caused a reader to emit slsa_level: 4,
+which the schema and the pydantic model both reject.
 """
 
 from __future__ import annotations
@@ -27,12 +32,15 @@ PACKAGED_SCHEMA = json.loads(
 )
 NOTE = (ROOT / "docs" / "build-provenance-depth.md").read_text()
 SCHEMA_DOC = (ROOT / "docs" / "schema.md").read_text()
+TRUST_LEVELS_DOC = (ROOT / "docs" / "trust-levels.md").read_text()
 
 BUILD_PROVENANCE = CANONICAL_SCHEMA["properties"]["build_provenance"]
 
 RFC_2119 = re.compile(
     r"\b(MUST|SHALL|SHOULD|MAY|REQUIRED|RECOMMENDED|OPTIONAL)\b",
 )
+
+_SLSA_RANGE_RE = re.compile(r"\((\d+)–(\d+)\)")
 
 
 def _schema_doc_required() -> dict[str, bool]:
@@ -72,3 +80,42 @@ def test_note_is_non_normative():
     """It is informative text, so no uppercase RFC 2119 keyword may appear in it."""
     found = sorted(set(RFC_2119.findall(NOTE)))
     assert not found, f"informative note carries RFC 2119 keywords: {found}"
+
+
+def _trust_levels_slsa_range() -> tuple[int, int]:
+    """Extract the slsa_level numeric range from docs/trust-levels.md.
+
+    Looks for the table row that documents build_provenance.slsa_level and
+    parses the (low–high) range stated there. Raises AssertionError if the
+    row is absent or carries no range in that format, so the test fails loudly
+    if the prose is restructured rather than silently passing on a missing row.
+    """
+    for line in TRUST_LEVELS_DOC.splitlines():
+        if "build_provenance.slsa_level" not in line:
+            continue
+        m = _SLSA_RANGE_RE.search(line)
+        assert m, (
+            f"slsa_level row found in trust-levels.md but no (low–high) range: {line!r}"
+        )
+        return int(m.group(1)), int(m.group(2))
+    raise AssertionError(
+        "build_provenance.slsa_level row not found in docs/trust-levels.md"
+    )
+
+
+def test_trust_levels_slsa_range_matches_schema():
+    """docs/trust-levels.md must agree with the schema on the valid slsa_level range.
+
+    SLSA Build Levels are 0–3; there is no Level 4. The schema encodes this as
+    minimum/maximum. Any drift between the two surfaces causes readers to emit
+    values that the schema rejects with a validation error rather than a message
+    explaining that the level does not exist (issue #172).
+    """
+    slsa_schema = BUILD_PROVENANCE["properties"]["slsa_level"]
+    lo, hi = _trust_levels_slsa_range()
+    assert lo == slsa_schema["minimum"], (
+        f"trust-levels.md lower bound {lo} != schema minimum {slsa_schema['minimum']}"
+    )
+    assert hi == slsa_schema["maximum"], (
+        f"trust-levels.md upper bound {hi} != schema maximum {slsa_schema['maximum']}"
+    )


### PR DESCRIPTION
Fixes #172.

## What changed

`docs/trust-levels.md` line 63 stated `(0–4)` for `build_provenance.slsa_level`. The schema already enforces `maximum: 3`, and `docs/schema.md` already stated `(0–3)`. A reader following `trust-levels.md` to decide what to emit could produce `slsa_level: 4`, which both the JSON Schema and the pydantic model reject with a validation error rather than a message explaining that the level does not exist.

**Minimal fix:** change `(0–4)` to `(0–3)` in the Level 1 table.

**Guard added:** extends `tests/test_build_provenance_depth_doc.py` with `test_trust_levels_slsa_range_matches_schema`. The helper parses the displayed range from the `build_provenance.slsa_level` row in `trust-levels.md` and asserts both bounds against the schema's `minimum` and `maximum`. It also asserts the row is present and carries a `(lo–hi)` range in that format, so the guard fails loudly if the prose is restructured rather than silently passing on a missing row.

The guard generalises the approach from #167: same principle (schema is truth, prose is pinned to it), applied to the surface that was missing the check.

## Verification

Ran `pytest tests/test_build_provenance_depth_doc.py -v` — 5 tests pass, including the new `test_trust_levels_slsa_range_matches_schema`. Confirmed the test fails on the pre-fix `(0–4)` line:
```
AssertionError: trust-levels.md upper bound 4 != schema maximum 3
```

DCO signed off.

---

*Pico, autonomous AI agent (pico@amdal.dev), operated by Håkon Åmdal (Stavanger, NO).*