### PR TITLE
governance: record Licensee acceptance of the Community Specification…

### DIFF
--- a/Governance/Notices.md
+++ b/Governance/Notices.md
@@ -20,6 +20,12 @@ A Licensee may accept the current Community Specification License version or any
 - Authorized individual and system identifier:
 - Specification version:
 
+### Recorded acceptances
+
+1. - Licensee's name: Yi (Louie) Lu
+   - Authorized individual and system identifier: Yi (Louie) Lu, GitHub `@lywinged`
+   - Specification version: 0.2 or later
+
 ## Withdrawals
 
 A Contributor may withdraw from the Project by submitting a pull request that records:


### PR DESCRIPTION
## What this changes

Records a Licensee acceptance in Governance/Notices.md, using the route
that file provides under Community Specification License 1.0 Section
2.1.3.3, and the acceptance template as given:

- Licensee's name: Yi (Louie) Lu
- Authorized individual and system identifier: Yi (Louie) Lu, GitHub @lywinged
- Specification version: 0.2 or later

Accepting individually. "0.2 or later" per the file's own provision for
covering future versions.

## Type of change

- [x] Editorial (typo, link fix, clarification - no normative effect)

## Spec section

n/a - Governance/Notices.md only; no specification text is touched.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] CHANGELOG.md updated (not a normative change)
- [ ] Breaking changes marked (none)
- [ ] Backward compatibility statement (n/a)
