### PR TITLE
feat: bind PIC authorization to TRACE evidence

### DIFF
--- a/docs/integration/pic-trace-bridge-v1.md
+++ b/docs/integration/pic-trace-bridge-v1.md
@@ -1,0 +1,46 @@
+# PIC/TRACE authorization bridge v1
+
+This informative profile binds a separately authorized pre-execution decision to
+the TRACE evidence for the execution that followed it. It is an optional bridge;
+it does not make PIC a dependency of TRACE and it does not change the TRACE
+Trust Record schema.
+
+## Trust boundary
+
+The bridge is a detached authorization artifact signed by an authorizer key
+resolved by the verifier's trust configuration. The artifact contains an
+`authorizer_key_id`, which must match the trusted JWK's `kid`; the artifact
+never carries a public key or trust anchor. A plugin, runtime, or gateway cannot
+bootstrap its own authority by embedding a key in the signed object.
+
+The signature covers `profile` and the complete `authorization` object. Unknown
+fields are rejected so an implementation cannot silently ignore a new security
+meaning. A decision other than `allow`, an authorization outside its validity
+window, an expired authorization, or an invalid signature is not usable as
+authorization evidence.
+
+## Binding rules
+
+The `pic` member preserves PIC-CJSON/1.0's `intent_digest` and `args_digest`
+values. The bridge does not recompute those PIC digests; it compares the values
+provided by the PIC verifier. Bridge-specific `declaration_digest` and
+`tool_call_digest` are SHA-256 over RFC 8785/JCS bytes of the corresponding JSON
+objects.
+
+The verifier checks that the executed tool is in `scope.tools`, the declaration
+impact is in `scope.impacts`, and both bridge-specific digests match. If
+`transcript_required` is true, a complete `before` and `after` transcript is
+required, and `before.tool_call` must equal the executed call. This binds the
+authorization to the call and its execution evidence without claiming that
+TRACE proves the real-world outcome of the call.
+
+The reference implementation is `agentrust_trace.intent_bridge`; the versioned
+schema is `schema/pic-trace-bridge-v1.json`.
+
+## Failure semantics
+
+Malformed or unverifiable artifacts raise `IntentBridgeError`. A signed deny
+raises `AuthorizationDenied`. A valid authorization whose scope, digest, or
+transcript does not match the execution raises `AuthorizationMismatch`.
+Consumers must fail closed when the profile is required and any of these
+conditions occurs.

--- a/schema/pic-trace-bridge-v1.json
+++ b/schema/pic-trace-bridge-v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trace.agentrust-io.com/schema/pic-trace-bridge-v1.json",
+  "title": "PIC/TRACE Bridge Authorization v1",
+  "type": "object", "additionalProperties": false,
+  "required": ["profile", "authorization", "signature"],
+  "properties": {
+    "profile": {"const": "tag:agentrust-io.com,2026:pic-trace-bridge-v1"},
+    "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]{86}$"},
+    "authorization": {
+      "type": "object", "additionalProperties": false,
+      "required": ["authorization_id", "decision", "authorizer", "authorizer_key_id", "authorized_at", "expires_at", "scope", "pic", "declaration_digest", "tool_call_digest", "transcript_required"],
+      "properties": {
+        "authorization_id": {"type": "string", "minLength": 1},
+        "decision": {"enum": ["allow", "deny"]},
+        "authorizer": {"type": "string", "minLength": 1},
+        "authorizer_key_id": {"type": "string", "minLength": 1},
+        "authorized_at": {"type": "integer", "minimum": 0},
+        "expires_at": {"type": "integer", "minimum": 0},
+        "scope": {"type": "object", "additionalProperties": false, "required": ["tools", "impacts"], "properties": {
+          "tools": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+          "impacts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+        }},
+        "pic": {"type": "object", "additionalProperties": false, "required": ["profile", "intent_digest", "args_digest"], "properties": {
+          "profile": {"const": "PIC-CJSON/1.0"}, "intent_digest": {"$ref": "#/$defs/digest"}, "args_digest": {"$ref": "#/$defs/digest"}
+        }},
+        "declaration_digest": {"$ref": "#/$defs/digest"}, "tool_call_digest": {"$ref": "#/$defs/digest"},
+        "transcript_required": {"type": "boolean"}
+      }
+    }
+  },
+  "$defs": {"digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}}
+}

--- a/src/agentrust_trace/__init__.py
+++ b/src/agentrust_trace/__init__.py
@@ -93,3 +93,6 @@ __all__ = [*__all__, "provenance"]
 from agentrust_trace import content_marking as content_marking  # noqa: E402
 
 __all__ = [*__all__, "content_marking"]
+from agentrust_trace import intent_bridge as intent_bridge  # noqa: E402
+
+__all__ = [*__all__, "intent_bridge"]

--- a/src/agentrust_trace/intent_bridge.py
+++ b/src/agentrust_trace/intent_bridge.py
@@ -1,0 +1,164 @@
+"""Verify the optional PIC-CJSON/1.0 to TRACE authorization bridge."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from hmac import compare_digest
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from agentrust_trace.sign import _b64url_decode, _canonical_bytes, _pubkey_from_jwk
+
+BRIDGE_PROFILE = "tag:agentrust-io.com,2026:pic-trace-bridge-v1"
+PIC_PROFILE = "PIC-CJSON/1.0"
+
+__all__ = [
+    "BRIDGE_PROFILE", "PIC_PROFILE", "IntentBridgeError", "AuthorizationDenied",
+    "AuthorizationMismatch", "digest_jcs", "sign_bridge", "verify_bridge",
+]
+
+
+class IntentBridgeError(ValueError):
+    """The bridge is malformed, untrusted, stale, or cannot be evaluated."""
+
+
+class AuthorizationDenied(IntentBridgeError):
+    """The signed decision is not an authorization to execute."""
+
+
+class AuthorizationMismatch(IntentBridgeError):
+    """Execution evidence does not match the signed authorization."""
+
+
+def digest_jcs(value: dict[str, Any]) -> str:
+    """Return the SHA-256 digest of an RFC 8785 canonical JSON object."""
+    if not isinstance(value, dict):
+        raise IntentBridgeError("a digest input must be a JSON object")
+    return f"sha256:{hashlib.sha256(_canonical_bytes(value)).hexdigest()}"
+
+
+def sign_bridge(authorization: dict[str, Any], key: Ed25519PrivateKey) -> dict[str, Any]:
+    """Sign the complete authorization; key material is deliberately not embedded."""
+    artifact = {"profile": BRIDGE_PROFILE, "authorization": authorization}
+    signature = base64.urlsafe_b64encode(key.sign(_canonical_bytes(artifact))).rstrip(b"=")
+    return {**artifact, "signature": signature.decode("ascii")}
+
+
+def _object(value: Any, field: str, keys: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise IntentBridgeError(f"{field} must be an object")
+    unknown = set(value) - keys
+    if unknown:
+        raise IntentBridgeError(f"{field} contains unknown fields: {sorted(unknown)}")
+    return value
+
+
+def _digest(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("sha256:"):
+        raise IntentBridgeError(f"{field} must be a sha256 digest")
+    tail = value[7:]
+    if len(tail) != 64 or any(c not in "0123456789abcdef" for c in tail):
+        raise IntentBridgeError(f"{field} must contain 64 lowercase hexadecimal characters")
+    return value
+
+
+def verify_bridge(
+    bridge: dict[str, Any], trusted_authorizer_jwk: dict[str, Any], *,
+    declaration: dict[str, Any], pic_intent_digest: str, pic_args_digest: str,
+    tool_call: dict[str, Any], transcript: dict[str, Any] | None = None,
+    now: int | None = None,
+) -> dict[str, Any]:
+    """Verify the decision, trusted signature, scope, freshness, and execution binding.
+
+    PIC digests are compared as PIC-defined values and never recomputed here.
+    Bridge-specific declaration and tool-call digests use RFC 8785 JCS.  When a
+    transcript is required, both its before and after halves must be supplied.
+    """
+    root = _object(bridge, "bridge", {"profile", "authorization", "signature"})
+    if root.get("profile") != BRIDGE_PROFILE:
+        raise IntentBridgeError("unknown bridge profile; best-effort parsing is refused")
+    signature_value = root.get("signature")
+    if not isinstance(signature_value, str):
+        raise IntentBridgeError("signature must be a base64url string")
+    signature = _b64url_decode(signature_value, field="signature")
+    fields = {
+        "authorization_id", "decision", "authorizer", "authorizer_key_id",
+        "authorized_at", "expires_at", "scope", "pic", "declaration_digest",
+        "tool_call_digest", "transcript_required",
+    }
+    authorization = _object(root.get("authorization"), "authorization", fields)
+    missing = fields - set(authorization)
+    if missing:
+        raise IntentBridgeError(f"authorization is missing fields: {sorted(missing)}")
+
+    try:
+        _pubkey_from_jwk(trusted_authorizer_jwk).verify(
+            signature, _canonical_bytes({"profile": BRIDGE_PROFILE, "authorization": authorization})
+        )
+    except Exception as exc:
+        raise IntentBridgeError("authorization signature is invalid") from exc
+    trusted_kid = trusted_authorizer_jwk.get("kid")
+    if not isinstance(trusted_kid, str) or trusted_kid != authorization["authorizer_key_id"]:
+        raise IntentBridgeError("authorizer_key_id does not identify the trusted key")
+    if authorization["decision"] != "allow":
+        raise AuthorizationDenied("the signed decision is not allow")
+    for field in ("authorized_at", "expires_at"):
+        if not isinstance(authorization[field], int) or isinstance(authorization[field], bool):
+            raise IntentBridgeError(f"{field} must be an integer Unix timestamp")
+    instant = int(time.time()) if now is None else now
+    if instant < authorization["authorized_at"]:
+        raise IntentBridgeError("authorization is not yet valid")
+    if authorization["expires_at"] <= authorization["authorized_at"]:
+        raise IntentBridgeError("expires_at must be after authorized_at")
+    if instant >= authorization["expires_at"]:
+        raise IntentBridgeError("authorization has expired")
+
+    scope = _object(authorization["scope"], "authorization.scope", {"tools", "impacts"})
+    tools, impacts = scope.get("tools"), scope.get("impacts")
+    if not isinstance(tools, list) or not tools or not all(isinstance(v, str) for v in tools):
+        raise IntentBridgeError("authorization.scope.tools must be a non-empty string array")
+    if not isinstance(impacts, list) or not impacts or not all(isinstance(v, str) for v in impacts):
+        raise IntentBridgeError("authorization.scope.impacts must be a non-empty string array")
+    if not isinstance(tool_call, dict):
+        raise IntentBridgeError("tool_call must be an object")
+    if tool_call.get("name") not in tools:
+        raise AuthorizationMismatch("executed tool is outside the authorized tool scope")
+    if not isinstance(declaration, dict):
+        raise IntentBridgeError("declaration must be an object")
+    if declaration.get("impact") not in impacts:
+        raise AuthorizationMismatch("declaration impact is outside the authorized impact scope")
+
+    pic = _object(
+        authorization["pic"], "authorization.pic", {"profile", "intent_digest", "args_digest"}
+    )
+    if pic.get("profile") != PIC_PROFILE:
+        raise IntentBridgeError("authorization.pic.profile is not PIC-CJSON/1.0")
+    for name, actual in (("intent_digest", pic_intent_digest), ("args_digest", pic_args_digest)):
+        expected = _digest(pic.get(name), f"authorization.pic.{name}")
+        _digest(actual, name)
+        if not compare_digest(expected, actual):
+            raise AuthorizationMismatch(f"PIC {name} does not match the signed authorization")
+
+    digest_pairs = (
+        ("declaration_digest", digest_jcs(declaration)),
+        ("tool_call_digest", digest_jcs(tool_call)),
+    )
+    for name, actual in digest_pairs:
+        expected = _digest(authorization[name], f"authorization.{name}")
+        if not compare_digest(expected, actual):
+            raise AuthorizationMismatch(f"{name} does not match the signed authorization")
+
+    if not isinstance(authorization["transcript_required"], bool):
+        raise IntentBridgeError("transcript_required must be boolean")
+    if authorization["transcript_required"]:
+        if not isinstance(transcript, dict) or set(transcript) != {"before", "after"}:
+            raise AuthorizationMismatch("a full before/after transcript is required")
+        before = transcript.get("before")
+        if not isinstance(before, dict) or before.get("tool_call") != tool_call:
+            raise AuthorizationMismatch("transcript.before.tool_call does not match execution")
+        if not isinstance(transcript.get("after"), dict):
+            raise AuthorizationMismatch("transcript.after must contain the execution result")
+    return authorization

--- a/tests/test_intent_bridge.py
+++ b/tests/test_intent_bridge.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from agentrust_trace.intent_bridge import (
+    AuthorizationDenied,
+    AuthorizationMismatch,
+    IntentBridgeError,
+    digest_jcs,
+    sign_bridge,
+    verify_bridge,
+)
+from agentrust_trace.sign import key_to_jwk
+
+
+def _fixture() -> tuple[dict, Ed25519PrivateKey, dict, str, str, dict, dict]:
+    key = Ed25519PrivateKey.generate()
+    declaration = {"impact": "external-side-effect", "purpose": "send invoice"}
+    tool_call = {"name": "send_invoice", "arguments": {"invoice_id": "INV-7"}}
+    authorization = {
+        "authorization_id": "auth-7",
+        "decision": "allow",
+        "authorizer": "finance-policy",
+        "authorizer_key_id": "key-7",
+        "authorized_at": 100,
+        "expires_at": 200,
+        "scope": {"tools": ["send_invoice"], "impacts": ["external-side-effect"]},
+        "pic": {
+            "profile": "PIC-CJSON/1.0",
+            "intent_digest": "sha256:" + "1" * 64,
+            "args_digest": "sha256:" + "2" * 64,
+        },
+        "declaration_digest": digest_jcs(declaration),
+        "tool_call_digest": digest_jcs(tool_call),
+        "transcript_required": True,
+    }
+    bridge = sign_bridge(authorization, key)
+    transcript = {"before": {"tool_call": tool_call}, "after": {"status": "accepted"}}
+    return (
+        bridge, key, declaration, authorization["pic"]["intent_digest"],
+        authorization["pic"]["args_digest"], tool_call, transcript,
+    )
+
+
+def test_verify_bridge_accepts_authorized_bound_execution() -> None:
+    bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
+    result = verify_bridge(
+        bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+        pic_intent_digest=intent,
+        pic_args_digest=args, tool_call=tool_call, transcript=transcript, now=150,
+    )
+    assert result["authorization_id"] == "auth-7"
+
+
+@pytest.mark.parametrize("field", ["authorization", "signature"])
+def test_tampering_is_rejected(field: str) -> None:
+    bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
+    tampered = copy.deepcopy(bridge)
+    if field == "authorization":
+        tampered["authorization"]["decision"] = "deny"
+    else:
+        tampered["signature"] = "A" + tampered["signature"][1:]
+    with pytest.raises(IntentBridgeError):
+        verify_bridge(
+            tampered, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent,
+            pic_args_digest=args, tool_call=tool_call, transcript=transcript, now=150,
+        )
+
+
+def test_deny_and_scope_fail_closed() -> None:
+    bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
+    denied = copy.deepcopy(bridge)
+    denied["authorization"]["decision"] = "deny"
+    denied = sign_bridge(denied["authorization"], key)
+    with pytest.raises(AuthorizationDenied):
+        verify_bridge(
+            denied, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=tool_call, transcript=transcript, now=150,
+        )
+    outside = {"name": "delete_invoice", "arguments": {}}
+    with pytest.raises(AuthorizationMismatch):
+        verify_bridge(
+            bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=outside, transcript=transcript, now=150,
+        )
+
+
+def test_expiry_and_required_transcript_are_enforced() -> None:
+    bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
+    with pytest.raises(IntentBridgeError, match="expired"):
+        verify_bridge(
+            bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=tool_call, transcript=transcript, now=200,
+        )
+    with pytest.raises(AuthorizationMismatch, match="before/after"):
+        verify_bridge(
+            bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=tool_call, transcript=None, now=150,
+        )
+
+
+def test_invalid_expiry_order_and_unknown_fields_are_rejected() -> None:
+    bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
+    malformed = copy.deepcopy(bridge)
+    malformed["authorization"]["expires_at"] = 100
+    malformed = sign_bridge(malformed["authorization"], key)
+    with pytest.raises(IntentBridgeError, match="after"):
+        verify_bridge(
+            malformed, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=tool_call, transcript=transcript, now=100,
+        )
+    unknown = copy.deepcopy(bridge)
+    unknown["authorization"]["unexpected"] = True
+    with pytest.raises(IntentBridgeError, match="unknown fields"):
+        verify_bridge(
+            unknown, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args,
+            tool_call=tool_call, transcript=transcript, now=150,
+        )


### PR DESCRIPTION
## Summary`n`nImplements #179 as an optional PIC-CJSON/1.0 to TRACE authorization bridge.`n`n- Adds versioned bridge schema and informative threat-boundary documentation.`n- Signs the complete authorization without embedding trust anchors.`n- Binds authorizer_key_id to the trusted JWK kid.`n- Preserves PIC intent/args digests and adds JCS declaration/tool-call bindings.`n- Enforces authorization scope, validity, transcript before/after evidence, and fail-closed errors.`n- Adds six focused positive/negative security tests.`n`n## Evidence`n`n- python -m pytest -q --basetemp=.pytest-tmp: 478 passed, 1 skipped`n- ruff check src/agentrust_trace/intent_bridge.py tests/test_intent_bridge.py: passed`n- JSON Schema Draft 2020-12 meta-validation: passed`n- git diff --check: passed`n`nSigned-off-by: Imran Siddique <imran@agentrust.com>