### PR TITLE
test(conformance): adequacy criteria for a vector set, applied to every set here

### DIFF
--- a/docs/conformance-method.md
+++ b/docs/conformance-method.md
@@ -1,0 +1,187 @@
+# How the conformance vectors are built, and how the set is checked for holes
+
+*Informative. This page describes method, not requirements, and carries no RFC 2119
+keywords.*
+
+A conformance suite makes a promise: an implementation that passes it has done the
+things the specification asks for. That promise is only as good as the suite's
+coverage, and coverage is usually assumed rather than established. A suite that never
+exercises a rule certifies implementations that skip that rule entirely — silently,
+and with a green badge.
+
+This page describes how the action-receipt vectors in
+`examples/action-receipts/conformance/`
+are built, and how the set itself is checked. The checking part found seven rules in
+the receipt verifier with no vector behind them.
+
+## 1. Vectors are data, not tests
+
+Each vector is a JSON file stating the inputs, the trust anchors, and the outcome any
+conformant verifier must produce:
+
+```jsonc
+{
+  "context":  { /* what the verifier is told: session, call, freshness policy */ },
+  "action":   { /* the action and its canonical reference */ },
+  "trusted_issuer_keys": { /* the pinned key set — nothing self-authenticates */ },
+  "receipt":  { /* the artifact under test, genuinely signed */ },
+  "expected": { "status": "...", "failures": [...], "warnings": [...] }
+}
+```
+
+Nothing in a vector names a language, a function, or an API. An implementation writes a
+small adapter that feeds the JSON to its own verifier and compares against `expected`;
+the vectors themselves are portable.
+
+This is worth stating because it is easy to get wrong. One set I wrote began as tests
+against a single library's function signature. Those tests were correct, and they were
+not conformance vectors: no second implementation could run them. The shape matters
+more than the assertions, and the two are easy to confuse while the assertions are
+passing.
+
+**Every artifact in a vector is genuinely signed, including in the negative cases.**
+A vector that expects a rejection must reject for the reason it names. If its signature
+were malformed, the rejection would come from the signature check instead, the vector
+would pass, and it would have stopped testing the rule in its own filename.
+
+## 2. The set is checked against the verifier, automatically
+
+The interesting question is not whether the vectors pass. It is whether they cover
+what the verifier does. Three questions, in increasing strength:
+
+**Are there dead expectations?** A vector naming a failure code that nothing can emit
+holds an assertion that can never fail. Usually it means a rule was renamed or removed
+and the vector was left behind.
+
+**Is every rule exercised?** For each code the verifier can emit, is there a vector that
+expects it? A rule with no vector is a check an implementation can omit while passing.
+
+**Is every rule load-bearing — twice?** The strongest form: *delete the rule and count
+the vectors that notice.* A rule can be named by a vector and still not be load-bearing —
+if another rule fires on the same input, removing it changes no outcome and nothing
+distinguishes an implementation that performs the check from one that skips it. And one
+load-bearing vector is existence, not margin: any change that weakens or retires that
+single vector silently removes the rule's coverage. So the floor is two
+([#124](https://github.com/agentrust-io/trace-spec/issues/124)), and a ratchet keeps
+anything above the floor from quietly decaying back toward it.
+
+**Are the two vectors different tests, or two copies?** Two identical vectors have
+margin two and prove nothing extra. #124's definition: vectors are independent if a
+single implementation defect causes one to pass and the other to fail. That is made
+executable by declaring, for every rule, at least one *weakened* variant of its check —
+a plausible implementation shortcut: comparing digest prefixes, case-normalising
+identifiers, granting clock tolerance, validating signature structure without
+cryptography. The suite fails unless some declared defect deviates one of the rule's
+vectors while leaving another undisturbed. The declaration is itself fail-closed: a
+rule with no declared defect fails, so "what bug would your second vector catch that
+your first would not?" is answered when the rule is added.
+
+The strong criteria subsume the first two questions, which are kept because they are
+cheap and their failure messages are more direct.
+
+### The inventory is the registry the verifier consumes
+
+The obvious implementation is a list of rules kept next to the tests. That list is
+guaranteed to drift: it is correct only until someone adds a rule and forgets it, and
+the failure is silent in exactly the direction that matters.
+
+The first replacement recovered the inventory from the verifier's source with `ast` —
+every string literal appended to a failure or warning list. The
+[#124 review](https://github.com/agentrust-io/trace-spec/issues/124) identified that
+this has the mirror failure mode: a rule written as `extend([...])`, `+=`, an f-string
+or a named constant is invisible to the walk, and the suite reports complete coverage
+over an inventory that is quietly missing entries.
+
+The resolution, from the same review: the verifier itself consumes an explicit registry
+of named rules, and the registry *is* the inventory. A check that is not registered
+never runs, so it cannot exist outside the inventory; a residual guard fails on any
+code that would emit around the registry. Mutation follows the same principle — a rule
+is deleted by rebuilding the registry without its entry, or weakened by substituting
+its check, never by pattern-matching source text. If no vector's outcome changes under
+a deletion, that rule has no vector standing behind it.
+
+## 3. Fixtures and their checker cannot vouch for each other
+
+A green run proves the vectors and the verifier agree. Both are usually written by the
+same person in the same sitting, so agreement is close to guaranteed and says little.
+The failure it cannot see: a shared helper that canonicalizes or decodes incorrectly,
+used both to generate the fixtures and to check them. Everything agrees, and agrees with
+nothing else in the world.
+
+So every signature is re-derived through a path that shares no code with either: it
+imports nothing from the library, reuses no helper from the vector modules, and
+reconstructs each signing input from the JSON directly. Any vector whose signature is
+not re-derived by that path is a failure unless it is explicitly declared
+signature-free with a reason — the "missing receipt" case is the only one, since the
+absence of a receipt is the thing it tests.
+
+## 4. What this found
+
+Seven rules in the receipt verifier had no vector at all:
+
+| Rule | What an implementation could have skipped |
+|---|---|
+| `action_ref_invalid` | Recomputing the action reference instead of trusting the declared value |
+| `call_id_mismatch` | Checking that the receipt is bound to *this* call |
+| `session_id_mismatch` | Checking that it is bound to *this* session |
+| `evidence_hash_mismatch` | Recomputing the evidence digest, so a swapped evidence body passes |
+| `issuer_key_unknown` | Consulting the pinned key set at all |
+| `receipt_from_future` | Rejecting a receipt issued after the verification time |
+| `decision_invalid` | Refusing to read an unrecognised decision verb as accept or reject |
+
+Each is a check a conforming implementation could have omitted entirely while passing
+the published suite. Two are load-bearing for the trust model rather than merely tidy:
+without `issuer_key_unknown` a receipt authenticates itself — a signature verifies
+against whatever key it names, and only the pinned set says which keys the verifier can
+check, so a receipt under an unpinned key is surfaced as unverified rather than valid or
+invalid — and without `evidence_hash_mismatch` the signature covers a digest whose
+document may have been replaced.
+
+## 5. The checker's own false positives
+
+Three of its first findings were bugs in the checker, not in the suite. They are
+recorded because a completeness checker that reports the wrong thing is worse than
+none: it converts attention into noise, and the next person stops reading it.
+
+| Symptom | Cause |
+|---|---|
+| Every rule reported as non-load-bearing | Mutants were executed into a bare namespace, so `@dataclass` raised before a single vector ran. It read as "every rule matters" while testing nothing. |
+| A real outcome reported as unreachable | The scanner walked an entire conditional expression and collected the literal being *compared against* as if it were an outcome. |
+| A real warning reported as emitted by no rule | It scanned inline `failures=[...]` arguments but not `warnings=[...]`. |
+
+The pattern in all three: the check failed *open* — it reported a problem where there
+was none, which is survivable, rather than passing where there was one, which is not.
+That direction was not designed in, and a checker of this kind should be built so that
+its own breakage is loud. Hence the guard that asserts the inventory was non-empty
+before any conclusion is drawn from it.
+
+## 6. What this does not establish
+
+- **Not that the rules are right.** Completeness is a property of the vectors relative
+  to the verifier. If the verifier implements the wrong rule, a complete set pins the
+  wrong rule down precisely.
+- **Not that the specification is complete.** A rule absent from both the verifier and
+  the vectors is invisible to this method. Only reading the specification finds it.
+- **Not that an implementation is correct.** Passing shows it agrees on these inputs.
+  Behaviour on inputs no vector describes is unconstrained.
+- **Not that the vectors are adversarial enough.** Two independent vectors per rule is
+  a floor, not a proof of adversarial coverage: independence is demonstrated against
+  the *declared* defects, and a shortcut nobody thought to declare is a shortcut the
+  pair may still share. The declaration requirement makes the blind spot enumerable,
+  not empty.
+
+The method answers one question — *could an implementation skip this check and still
+pass?* — and answers it mechanically. That is narrower than "is the suite good", and it
+is the part that was previously left to assumption.
+
+## Reproducing
+
+```bash
+pip install -e ".[dev]"
+pytest tests/test_vector_completeness.py -v          # the completeness checks
+pytest tests/test_fixture_signatures_independent.py  # the independent signature path
+```
+
+Signing keys are derived from published seeds, so every vector set regenerates
+byte-for-byte and only public JWKs appear in the files. They are deliberately
+deterministic test keys with no standing.

--- a/tests/adequacy.py
+++ b/tests/adequacy.py
@@ -1,0 +1,113 @@
+"""Criteria a conformance vector set has to meet to be worth running.
+
+A vector set is a claim about what an implementation must do. The claim is only
+as strong as the set's ability to fail an implementation that does not do it, and
+a set can pass every one of its own assertions while failing that. These are the
+ways it happens that we have actually seen, each with the vector set it was found
+on:
+
+1. **No control, in either direction.** If every vector expects rejection, an
+   implementation that rejects unconditionally satisfies the whole set. If every
+   vector expects acceptance, one that accepts unconditionally does. Both halves
+   are needed and the second is the one that gets forgotten: a set written to show
+   that certain inputs *do* verify reads as complete while pinning nothing, which
+   is the shape `canonicalization-boundary` has here.
+
+2. **No margin.** One vector per boundary has no margin: a single implementation
+   shortcut that happens to reject that one vector passes the boundary. Two vectors
+   introducing distinct failure codes force the boundary itself to be implemented.
+   Established in agentrust-io/trace-spec#124.
+
+   Margin is counted per *boundary*, never per failure code, and the two are not
+   the same unit. A boundary covered the way #124 asks for produces two vectors
+   carrying two different codes, so counting by code reports the correct design as
+   a shortfall. This was written the wrong way round first and the set that caught
+   it was the one that had done it right. A set therefore has to say what its
+   boundaries are; where it does not, the code is used and that assumption is the
+   set's to justify.
+
+3. **A rule that nothing pins.** If deleting a rule from the verifier changes no
+   expected verdict, the set does not cover it, whatever its name suggests. Only
+   deletion establishes this; reading does not.
+
+4. **A weakness shared across a boundary's vectors.** Distinct failure codes are
+   not sufficient. Both dependency vectors of the build-provenance set placed
+   their defect last in a list, so a verifier that read one entry of three passed
+   both while still rejecting the absent-list vector, presenting as having
+   implemented the rule. Every check was present; the shortcut was in how many
+   entries each one ran over, so no code went missing and no code-level guard
+   could see it. Found in #169, on a set that already satisfied 1 through 3.
+
+Criteria 1 and 2 are decidable from the fixtures alone and are implemented here.
+Criteria 3 and 4 need to run the set's own verifier under mutation, so each set
+implements them in its own module; this file states them so that a set which omits
+them omits something named rather than something nobody thought of.
+"""
+from __future__ import annotations
+from collections import defaultdict
+from collections.abc import Iterable
+
+ACCEPTING = frozenset({"accept", "verified", "pass"})
+
+
+class Vector:
+    """One fixture, reduced to what adequacy is decided on."""
+
+    __slots__ = ("name", "outcome", "codes", "boundary")
+
+    def __init__(self, name: str, outcome: str, codes: Iterable[str] = ()):
+        self.name, self.outcome = name, outcome
+        self.codes = tuple(c for c in codes if c)
+        self.boundary: str | None = None
+
+    @property
+    def accepts(self) -> bool:
+        return self.outcome in ACCEPTING
+
+
+def trivially_satisfied_by(vectors: list[Vector]) -> str | None:
+    """The unconditional implementation this set cannot fail, if there is one.
+
+    Returns ``"reject"`` when no vector expects acceptance, ``"accept"`` when none
+    expects rejection, and ``None`` when the set pins both directions.
+    """
+    if not any(v.accepts for v in vectors):
+        return "reject"
+    if all(v.accepts for v in vectors):
+        return "accept"
+    return None
+
+
+def boundaries_without_margin(
+    vectors: list[Vector], boundary_of=None
+) -> dict[str, list[str]]:
+    """Boundaries covered by exactly one vector, each with that vector named.
+
+    *boundary_of* maps a vector to the boundary it separates. It defaults to the
+    vector's failure codes, which is right only where one code means one rule; a set
+    whose boundaries are coarser than its codes must supply it, or every correctly
+    covered boundary reads as a shortfall.
+
+    The return is the shortfall itself rather than a boolean, because a set short in
+    a named place is in a different position from one nobody has measured.
+    """
+    key = boundary_of or (lambda v: v.codes)
+    by_boundary: dict[str, list[str]] = defaultdict(list)
+    for v in vectors:
+        for b in key(v):
+            by_boundary[b].append(v.name)
+    return {b: names for b, names in sorted(by_boundary.items()) if len(names) < 2}
+
+
+def report(label: str, vectors: list[Vector], boundary_of=None) -> str:
+    thin = boundaries_without_margin(vectors, boundary_of)
+    lines = [f"{label}: {len(vectors)} vectors, "
+             f"{sum(v.accepts for v in vectors)} accepting, "
+             f"{len({c for v in vectors for c in v.codes})} distinct failure codes"]
+    trivial = trivially_satisfied_by(vectors)
+    if trivial:
+        lines.append(f"  NO CONTROL: a verifier that answers {trivial!r} to everything "
+                     f"passes this set")
+    for boundary, names in thin.items():
+        lines.append(f"  NO MARGIN: {boundary} is covered only by {names[0]}")
+    return "\n".join(lines)

--- a/tests/test_adequacy_all_sets.py
+++ b/tests/test_adequacy_all_sets.py
@@ -1,0 +1,202 @@
+"""Run the adequacy criteria over every vector set in the repository, ours included.
+
+The criteria come from defects found on real sets. A standard that only ever measures
+other people's work is advocacy, so this module measures every set by the same loader
+and records the shortfalls where they fall rather than where it would be comfortable.
+
+Where they fall today: `canonicalization-boundary`, which is ours, expects acceptance
+in every vector, so it cannot tell a conformant verifier from one that accepts
+unconditionally. That is recorded in `KNOWN_ONE_DIRECTIONAL` with the record asserted
+exactly, so it cannot widen unnoticed and the entry is deleted when the missing
+direction is added. `build-provenance-depth` carries a margin at every boundary and
+nothing is recorded against it.
+
+A set is measured here or named in `MEASURED_ELSEWHERE` with the test that covers it.
+Neither is possible to skip: `test_every_vector_set_on_disk_is_measured_somewhere`
+compares both against what is actually in `examples/`, because a hand-maintained list
+of what gets graded is the same defect these criteria exist to catch, in the one place
+it would otherwise be invisible.
+"""
+from __future__ import annotations
+import json
+import pathlib
+
+import pytest
+
+from tests.adequacy import Vector, boundaries_without_margin, report, trivially_satisfied_by
+
+EXAMPLES = pathlib.Path(__file__).resolve().parents[1] / "examples"
+
+
+def _load(directory: str, outcome_of, codes_of, boundary_of=None) -> list[Vector]:
+    out = []
+    for path in sorted((EXAMPLES / directory).glob("*.json")):
+        expected = json.loads(path.read_text())["expected"]
+        v = Vector(path.stem, outcome_of(expected), codes_of(expected))
+        v.boundary = boundary_of(expected) if boundary_of else None
+        out.append(v)
+    assert out, f"no vectors loaded from {directory}; the loader is measuring nothing"
+    return out
+
+
+def build_provenance_depth() -> list[Vector]:
+    """Deepest depth only: a vector's rule is the one that rejects it furthest in."""
+    def separates_at(e) -> str | None:
+        """The shallowest depth at which this vector stops agreeing with a verifier
+        that establishes everything.
+
+        Not `outcome` alone. Upstream moved the signal: a vector that cannot be
+        established at a depth now reports `accept` with `verified_depth` short of
+        that depth and the reason under `unresolved`, which distinguishes "failed"
+        from "could not be established" and is the better shape. Reading only the
+        verdict scores those vectors as separating nothing, which is the same
+        mistake as reading a verdict and missing a statement.
+        """
+        for d in _depths(e):
+            at = e[d]
+            if (at["outcome"] != "accept"
+                    or at.get("unresolved")
+                    or at.get("verified_depth", d) != d):
+                return d
+        return None
+
+    def deepest(e) -> dict:
+        return e[_depths(e)[-1]]
+
+    def codes(e) -> list[str]:
+        at = deepest(e)
+        return list(at["failures"]) + list(at.get("unresolved", []))
+
+    return _load("build-provenance-depth",
+                 lambda e: deepest(e)["outcome"], codes, separates_at)
+
+
+def canonicalization_boundary() -> list[Vector]:
+    return _load("canonicalization-boundary",
+                 lambda e: e["outcome"], lambda e: [e.get("failure")])
+
+
+def _depths(expected: dict) -> list[str]:
+    """The depth names this set uses, read from a fixture rather than restated here.
+
+    Upstream renamed them from `builder_chain` / `dependency_chain` to `builder` /
+    `transitive` and this module broke loudly, which is the design working and also
+    the reason not to write the names down twice. A set that renames a depth again
+    changes nothing here.
+    """
+    return [k for k, v in expected.items() if isinstance(v, dict) and "outcome" in v]
+
+
+def _depth_boundary(v: Vector) -> tuple[str, ...]:
+    """The shallowest depth that rejects this vector, read from its own verdicts.
+
+    This set's boundaries are coarser than its failure codes: #124 asks for two
+    vectors per boundary carrying *different* codes, so counting by code reports a
+    correctly covered boundary as thin.
+
+    Taken from `expected`, never from the filename. A name-derived boundary is
+    silently wrong the moment a vector is renamed, and the verdicts that define the
+    boundary are already in the fixture.
+    """
+    return (v.boundary,) if v.boundary else ()
+
+
+SETS = {
+    "build-provenance-depth": (build_provenance_depth, _depth_boundary),
+    "canonicalization-boundary": (canonicalization_boundary, None),
+}
+
+# Every set must be able to fail both unconditional implementations. A set that
+# only ever expects rejection is passed by one that rejects everything; a set that
+# only ever expects acceptance is passed by one that accepts everything, and that
+# half is the one that gets left out.
+# One set is knowingly one-directional. `canonicalization-boundary` detects a
+# non-conformant canonicalizer by the fact that it *rejects* records a conformant
+# verifier accepts, so every vector in it expects acceptance and the set cannot tell
+# a correct verifier from one that accepts unconditionally. That second implementation
+# is a real failure, not a hypothetical, so this is a gap rather than a design: it
+# closes when the set gains one record signed over a non-JCS form, which a conformant
+# verifier must reject. Recorded rather than skipped, and asserted exactly, so it
+# cannot widen and cannot be forgotten.
+KNOWN_ONE_DIRECTIONAL = {"canonicalization-boundary": "accept"}
+
+
+@pytest.mark.parametrize("name", sorted(SETS))
+def test_no_set_is_satisfied_by_an_unconditional_answer(name: str) -> None:
+    vectors = SETS[name][0]()
+    trivial = trivially_satisfied_by(vectors)
+    if name in KNOWN_ONE_DIRECTIONAL:
+        assert trivial == KNOWN_ONE_DIRECTIONAL[name], (
+            f"{name} is recorded as passable by {KNOWN_ONE_DIRECTIONAL[name]!r}-everything "
+            f"and now measures {trivial!r}. Update the record, or delete the entry if the "
+            f"missing direction was added.\n{report(name, vectors)}")
+        return
+    assert trivial is None, (
+        f"{name} is satisfied by an implementation that answers {trivial!r} to "
+        f"everything, so it pins nothing:\n{report(name, vectors)}")
+
+
+# The shortfall this repository currently carries, stated exactly. Widening it fails
+# here; closing it fails here too, and the entry is then deleted.
+KNOWN_THIN: dict[str, dict[str, str]] = {}
+
+
+@pytest.mark.parametrize("name", sorted(SETS))
+def test_margin_shortfall_is_exactly_what_is_recorded(name: str) -> None:
+    load, boundary_of = SETS[name]
+    vectors = load()
+    thin = {b: names[0] for b, names in boundaries_without_margin(vectors, boundary_of).items()}
+    expected = KNOWN_THIN.get(name, {})
+    assert thin == expected, (
+        f"{name}: the set of rules carried by a single vector changed.\n"
+        f"  now recorded: {sorted(expected)}\n"
+        f"  measured    : {sorted(thin)}\n"
+        f"Add the second vector and remove the entry, or record the new one.\n"
+        f"{report(name, vectors, boundary_of)}")
+
+
+def test_the_loader_reads_a_different_set_for_each_name() -> None:
+    """A loader returning the same vectors under three names would pass everything
+    above while measuring one set three times."""
+    seen = {name: tuple(v.name for v in load()) for name, (load, _) in SETS.items()}
+    assert len(set(seen.values())) == len(seen), f"two sets loaded identically: {seen}"
+
+
+# A set named here is a claim that something else measures it, together with the thing
+# that does. Without the assertion below, `SETS` is a hand-maintained list of what gets
+# graded, and a set added later is simply not graded, with nothing failing to say so.
+# That is the defect these criteria exist to catch, so leaving it in the instrument is
+# the one place it could not be caught.
+MEASURED_ELSEWHERE = {
+    "action-receipts": "tests/test_vector_completeness.py, which recovers its rule "
+                       "inventory from the verifier's source rather than restating it",
+}
+
+
+def test_every_vector_set_on_disk_is_measured_somewhere() -> None:
+    on_disk = {
+        path.name
+        for path in EXAMPLES.iterdir()
+        if path.is_dir() and any(path.rglob("*.json"))
+    }
+    accounted = set(SETS) | set(MEASURED_ELSEWHERE)
+    unmeasured = on_disk - accounted
+    assert not unmeasured, (
+        f"vector sets with nothing grading them: {sorted(unmeasured)}. Add a loader to "
+        "SETS, or name the test that covers the set in MEASURED_ELSEWHERE. A set in "
+        "neither is not adequate or inadequate, it is unmeasured."
+    )
+    stale = accounted - on_disk
+    assert not stale, (
+        f"named here but not on disk: {sorted(stale)}. A stale entry hides a renamed "
+        "set: the new name reads as unmeasured and the old one keeps this quiet."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(MEASURED_ELSEWHERE))
+def test_the_test_named_as_measuring_a_set_elsewhere_exists(name: str) -> None:
+    named = MEASURED_ELSEWHERE[name].split(",")[0].strip()
+    assert (EXAMPLES.parent / named).is_file(), (
+        f"{name} is recorded as measured by {named!r}, which does not exist. The record "
+        "is then an assertion that nothing checks."
+    )


### PR DESCRIPTION
A conformance vector set is a claim: **a verifier that does not implement these rules
will fail this set.** Nothing in the repository checked that claim, and it is not implied
by the vectors passing.

#169 and #170 both came out of asking it. Both were sets that were green.

- **#169**: `build-provenance-depth` reported the same verdict at every depth, so a
  verifier that resolved one link and assumed the rest matched passed it.
- **#170**: `canonicalization-boundary` separated its closest form by a single vector,
  and that vector put the divergence at the top level, where the obvious implementation
  already sorts.

Neither was found by reading a vector. Both were found by asking what a set fails to
distinguish.

## The criteria

Four, each from a defect on a real set rather than from first principles:

| Criterion | The defect behind it |
|---|---|
| A set must fail **both** unconditional implementations | a set of all-rejections is passed by a verifier that rejects everything |
| Every boundary needs **more than one** vector | one vector cannot separate a check that reads the head of a list from one that reads all of it |
| Every set on disk is **measured, or named with the test that measures it** | a hand-maintained list of what gets graded silently stops being complete |
| Shortfalls are **recorded exactly** | a gap that is skipped can widen; a gap asserted to its exact extent cannot |

## What it says about this repository today

Applied to every set, by the same loader, with the results recorded where they fall.

```
build-provenance-depth      margin at every boundary, nothing recorded
canonicalization-boundary   one-directional: every vector expects acceptance
action-receipts             covered by tests/test_vector_completeness.py
```

**`canonicalization-boundary` is mine.** Every vector in it expects acceptance, so the
set cannot tell a conformant verifier from one that accepts unconditionally. That second
implementation is a real failure mode, not a hypothetical, so it is a gap and not a
design. It is recorded in `KNOWN_ONE_DIRECTIONAL` with the record asserted, so it cannot
widen quietly, and the entry is deleted when the set gains a record signed over a non-JCS
form that a conformant verifier must reject.

I mention this first because a standard that only ever measures other people's work is
advocacy. The only shortfall this currently records is on a set I wrote.

## The guard on the instrument itself

`SETS` is a hand-maintained list of what gets graded, which is the third criterion's
defect, sitting in the one place it would otherwise be invisible: a set added later would
simply not be graded, and nothing would fail to say so.

`test_every_vector_set_on_disk_is_measured_somewhere` compares `SETS` and
`MEASURED_ELSEWHERE` against what is actually in `examples/`, in both directions, since a
stale entry hides a renamed set as effectively as a missing one.

Rather than assert these fail for the right reason, I broke each and recorded which test
went red:

| Mutation | Test that caught it |
|---|---|
| an unlisted set directory appears | `test_every_vector_set_on_disk_is_measured_somewhere` |
| an entry names a set that is not on disk | the same |
| the directory scan stops finding anything | the same |
| `MEASURED_ELSEWHERE` names a test file that does not exist | `test_the_test_named_as_measuring_a_set_elsewhere_exists` |

## What this costs, said before it happens rather than after

**A future PR that adds a thin vector set will go red here**, and the failure will name
the boundary and the vector rather than a line number. That is the intended behaviour and
it is a policy consequence of merging a test, so it should be a decision rather than a
surprise. The escape hatch is deliberate and visible: record the shortfall in
`KNOWN_THIN` with its exact extent, which documents the gap instead of hiding it, and the
entry is deleted when someone writes the second vector.

## Scope

Tests and an informative document. No normative text, no RFC 2119 keyword, no schema
change, so no sponsor is needed under `GOVERNANCE.md`. Same class as #169, #171 and #175.

`485 passed, 1 skipped`; `ruff check src tests scripts` clean; `mypy` clean. Branched off
`main` at `697e20a`.

The criteria are also usable outside this repository, since they read `expected` and
nothing else. If they are more useful in trace-tests than here, say so and I will move
them.
