### PR TITLE
docs: identify TRACE Specification as an LF Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
 [![CI](https://github.com/agentrust-io/trace-spec/actions/workflows/ci.yml/badge.svg)](https://github.com/agentrust-io/trace-spec/actions/workflows/ci.yml)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=flat)](https://discord.gg/grgzFEHgkj)
 
+<p align="center">
+  <strong>TRACE Specification is an <a href="https://www.linuxfoundation.org/">LF Project</a></strong>, hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC".
+</p>
+
 > **Developer Preview.** Launching at Confidential Computing Summit, June 23 2026.
 
 An open specification for hardware-attested AI agent governance records. TRACE defines the format, anchoring protocol, and verification rules for cryptographically provable evidence that an AI agent ran under a specific policy, in a verified hardware environment, on classified data, invoking identified tools, all bound into a single signed artifact rooted in silicon attestation.
@@ -78,7 +82,7 @@ signed = sign_record(record, key=signing_key)
 
 ## Standards alignment
 
-Being formed at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC". Related standardization track in [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
+Hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC", under [LF Projects policies](https://lfprojects.org/policies/). Related standardization track in [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
 
 ## Frequently asked questions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Status as of August 2026. Spec **v0.2** is current ([`spec/trace-v0.2.md`](spec/
 
 ## Later — v1.0 standard (2027)
 
-- TSC governance under "TRACE Specification, a Series of LF Projects, LLC" (formation in progress, see [#127](https://github.com/agentrust-io/trace-spec/pull/127); §6.1 of the spec still names the superseded CoSAI plus LF-MCP-entity plan and is corrected there)
+- TSC governance under "TRACE Specification, a Series of LF Projects, LLC" (formation with LF Projects, LLC complete; the TSC transition under [CHARTER.md](CHARTER.md) is the remaining step)
 - All §7 open questions resolved
 - Complete conformance certification program
 - Post-quantum signature profile (ML-DSA, tracking NIST SP 800-208)


### PR DESCRIPTION
Formation with LF Projects, LLC is complete. Jory Burson (LF, VP Standards) asked that the README refer to the project as an LF Project in its introductory matter, linking to the announcement or the LF website. No LF logo is required in the repo.

## Changes

- **README.md** — attribution line under the badge block: "TRACE Specification is an LF Project", hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC".
- **README.md** — Standards alignment moves from "Being formed at the Linux Foundation" to present tense, with a link to [LF Projects policies](https://lfprojects.org/policies/).
- **ROADMAP.md** — drops the stale "formation in progress" note from the v1.0 item. The TSC transition under CHARTER.md is what remains.

## Deliberately not changed here

`CHARTER.md`, `GOVERNANCE.md`, and `spec/trace-v0.2.md` §6.1 still describe formation as in progress. Governance amendments carry a minimum 14-day comment period under GOVERNANCE.md, and v0.2 is a published spec version, so those need their own PRs rather than riding along with a README edit.

Separately: `@thelinuxfoundation` has been invited as an admin on this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY