### PR TITLE
docs: make LIMITATIONS.md the source for the shared platform-state caveat

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -30,6 +30,12 @@ Signature validity is permanent; trust is not. Nothing inside a record can retra
 
 ## Platform state is not appraised
 
+<!-- This is the source copy of the marked block. cmcp and ca2a carry it
+     verbatim and their limitations-parity workflows check it against this
+     file, so a change here has to land before theirs. The paragraph after
+     the end marker is TRACE's own and is not shared. -->
+
+<!-- shared:platform-state-appraisal begin -->
 The SEV-SNP path here establishes that a report is authentic and which workload it
 describes: report signature, the VCEK to ASK to ARK chain with the ARK pinned by the
 operator, and measurement binding. Those are the right four checks and they are not
@@ -39,17 +45,22 @@ in dispute.
 report carries that separately in `PLATFORM_INFO` at offset 0x40: whether SMT is on,
 whether ECC is enabled, whether ciphertext hiding is enforced, and whether the
 firmware completed its boot-time DRAM alias check, which is AMD's mitigation for
-BadRAM (security bulletin SB-3015). A TRACE claim's runtime block carries the measurement and the evidence, and has no field for platform state, so a verifier reading a conformant claim cannot appraise it even where the producer checked it.
+BadRAM (security bulletin SB-3015).
 
 The practical consequence: a report from a machine with SMT enabled and the alias
 check never completed verifies exactly as cleanly as one from a machine with neither
 condition. If that distinction matters to your deployment, it has to be asserted
-explicitly, and today the spec does not assert it for you.
+explicitly.
 
 Related: [google/go-sev-guest#195](https://github.com/google/go-sev-guest/issues/195),
 where the reference verifier's own platform-info policy field is documented as a
 ceiling while four of its seven fields are enforced as minimums. Worth reading before
 writing any policy over these bits.
+<!-- shared:platform-state-appraisal end -->
+
+**In TRACE.** A TRACE claim's runtime block carries the measurement and the evidence
+and has no field for platform state, so a verifier reading a conformant claim cannot
+appraise it even where the producer checked it. The spec does not assert it for you.
 
 ## What Level 0 does not provide
 


### PR DESCRIPTION
The SEV-SNP platform-state caveat under `## Platform state is not appraised` is duplicated in `cmcp/LIMITATIONS.md` and `ca2a/LIMITATIONS.md`. The three copies were verbatim except for two sentences, and those two sentences are the only part that is genuinely project-specific.

Three hand-maintained copies of a security caveat drift, and the copy that goes stale is the one that quietly overstates what the project checks. `agent-manifest` shipped `PLATFORM_INFO` parsing and `appraise_platform_info()` on 2026-08-20, which is exactly the kind of change that needs to reach all three.

## Shape

The shared prose is wrapped in `<!-- shared:platform-state-appraisal begin/end -->` markers and this file is the source. The project-specific sentence moves out, below the end marker, as an **In TRACE** paragraph.

The full text stays in each repository on purpose. `LIMITATIONS.md` exists to state the bounds where a reader will actually meet them, so replacing the explanation with a link would weaken the one document whose job is to not hide anything. Companion PRs add a `limitations-parity` workflow to cmcp and ca2a that fetches this file and fails on drift, the same shape as the existing `schema-parity` check on the apex site.

Merge this one first: the other two check against `main` here.

Companions: agentrust-io/cmcp and agentrust-io/ca2a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY