### PR TITLE
fix(seo): social cards said "Home", not the page title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -12,7 +12,9 @@
 {% block extrahead %}
   {{ super() }}
 
-  {% set page_title = page.title ~ " - " ~ config.site_name if page and page.title else config.site_name %}
+  {# page.title is the nav label ("Home"); page.meta.title is the front matter. #}
+  {% set page_name = (page.meta.title if page and page.meta and page.meta.title else (page.title if page else None)) %}
+  {% set page_title = page_name ~ " - " ~ config.site_name if page_name else config.site_name %}
   {% set page_desc = page.meta.description if page and page.meta and page.meta.description else config.site_description %}
   {% set page_url = page.canonical_url if page and page.canonical_url else config.site_url %}
 


### PR DESCRIPTION
MkDocs sets `page.title` from the nav entry when the nav gives one, so a landing page listed as `- Home: index.md` reports `page.title == "Home"` regardless of its front matter. The `<title>` tag was right, because Material reads the front matter for it. `og:title` and `twitter:title` read `page.title`, and shipped this to every link preview:

```
og:title = "Home - TRACE"
```

**This one is mine.** My earlier landing-page change relaxed the expression from `page.title and not page.is_homepage` to `page.title`, which turned a bare site-name fallback into `"Home - X"`. Worse than what it replaced.

`page.meta.title` is the front-matter value, so prefer it, fall back to `page.title` for inner pages, then to the site name.

## Verified per site

| | Before | After |
|---|---|---|
| trace | `Home - TRACE` | `Hardware-attested receipts for AI agent actions - TRACE` |
| cmcp | `Home - cMCP` | `The secure, confidential way to run MCP - cMCP` |
| ca2a | `Home - cA2A` | `Secure, confidential agent-to-agent delegation - cA2A` |
| tests | `Home - TRACE Tests` | `Verify your TRACE implementation - TRACE Tests` |

Homepage `og:title` now matches its `<title>`, and inner pages keep their own (`Quick Start - cMCP`). All four build clean under `mkdocs build --strict`.

Found by link-checking the live estate: the minified HTML uses unquoted attributes, which is why it did not show up in an earlier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EQx4N5BzTQbY8kvXUsdkY