### PR TITLE
spec: add an assurance-neutral references block (#197)

### DIFF
--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -124,6 +124,7 @@ The Trust Record is the unit of evidence. All fields are required unless marked 
 | `data_class` | Classification of inputs and outputs | Classification label bound to per-call execution |
 | `tool_transcript` | MCP / A2A tool calls invoked, parameters classified, responses filtered | MCP / A2A protocol transcripts bound to TEE measurement |
 | `origin` | OPTIONAL. Where the evidence came from, when that is not this runtime. See §3.1.1. | — |
+| `references` | OPTIONAL. Facts outside this record that it points at. Assurance-neutral: see §3.1.2. <!-- CHANGED: #197 - new optional assurance-neutral reference block --> | — |
 | `build_provenance` | How the running code and model were built | SLSA Provenance v1.0 |
 | `appraisal` | Verifier's appraisal of evidence | EAR (EAT Attestation Results) |
 | `transparency` | Inclusion proof on append-only log | SCITT Receipt URI |
@@ -158,6 +159,37 @@ A Trust Record normally describes an execution and is produced by the runtime th
 `origin` is absent on every hardware profile in this specification and on every record a TEE-backed runtime produces. Absence means `self`.
 
 **This block does not launder assurance in either direction.** It cannot raise a record: nothing about naming your producer makes unattested evidence attested. It cannot lower one either: a record with a hardware platform and a verified quote is what it is, whether or not it says `origin: self`.
+
+#### 3.1.2 `references`: facts this record points at
+
+<!-- CHANGED: #197 - new subsection -->
+
+`origin` records where evidence *came from* and can lower assurance. `references` records what a record *points at* and cannot. Those are different questions and the spec previously had only the first, so any record that needed to reference something external had to use `origin` and take `runtime.platform: "software-only"` with it.
+
+A `references` entry is a pointer, not evidence. What the signature attests is that this record points there, not the truth of what it points at. The pointer is produced inside the boundary that produced the record; the target is not.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `rel` | yes | Relationship type. Registered set, see below. |
+| `id` | yes | Identifier of the referenced fact within the resolver's system. |
+| `resolver` | yes | Identifier of the party obliged to resolve `id`. |
+| `retention` | no | Period for which `resolver` undertakes to keep `id` resolvable, as an ISO 8601 duration. |
+| `digest` | no | Digest of the referenced object, when the producer holds it at issue time. |
+
+Registered `rel` values:
+
+- **`authorized-intent`**. An authorization decided before execution, held in another system.
+- **`approval-outcome`**. An attributable human approval attached to a step-up or defer decision.
+- **`behavior-trace`**. A behavioural record of what the agent did, of which this record is the environment evidence.
+
+1. `references` MUST NOT affect `runtime.platform`. A record carrying `references` and no `origin` block is `self` and carries whatever platform value it actually earned.
+2. The record signature MUST cover `references`, under the canonicalisation in §3.2.2.
+3. A verifier MUST NOT reject a record because an entry in `references` cannot be resolved, and MUST NOT treat a resolved reference as attested evidence.
+4. A producer that cannot name a `resolver` MUST omit the entry rather than emit one with an empty or self-asserted resolver.
+
+Rule 3 is what makes the block safe to add. A reference that could invalidate a record would hand whoever controls the target a way to invalidate evidence they do not hold, and a reference that counted as evidence would be the assurance laundering §3.1.1 exists to prevent.
+
+**Unsettled, and deliberately named rather than hidden.** `retention` states an undertaking and nothing in this specification enforces it. A reference is worth only the ability to resolve it later, and transparency-log practice shows that gap is real rather than theoretical: a record can remain valid and become unreachable when the index that addressed it is removed. §7 open question 3 covers the same ground for `transparency` and the two should be resolved together.
 
 ### 3.2 Wire format
 


### PR DESCRIPTION
Implements the proposal in #197. Normative change, so please read that issue first for the argument.

## What this fixes

A self-produced, hardware-attested Trust Record has no way to reference a fact outside itself.

`origin.source_event_id` is the right shape, defined as "Identifier of the source event in that system, so a record traces back to it". But §3.1.1 scopes `origin` to records assembled from someone else's evidence, and requires that a record whose `origin.kind` is not `self` **MUST** carry `runtime.platform: "software-only"`, with verifiers rejecting it otherwise.

So today, the moment a record points outward, it stops being a hardware attested record.

## Why one mechanism rather than a third field

Three open items are the same shape:

| Item | Wants to bind |
|---|---|
| #179 | authorized pre-execution intent |
| #191 | attributable human-approval outcomes |
| AAIF Observability & Traceability WG | a behavioural execution identifier |

Two bespoke fields is a pattern. Three is a design failure. Each becomes a registered `rel` value here instead.

## The rule that makes it safe

**The signature attests that this record points somewhere. It does not attest the truth of what it points at.** The pointer is produced inside the boundary that produced the record; the target is not.

That gives three normative consequences, all in the diff:

- `references` MUST NOT affect `runtime.platform`
- a verifier MUST NOT reject a record because a reference cannot be resolved
- a verifier MUST NOT treat a resolved reference as attested evidence

Without the second rule, whoever controls the target could invalidate evidence they do not hold. Without the third, this becomes the assurance laundering §3.1.1 exists to prevent.

## §3.1.1 is untouched

This does not weaken that MUST. It stops it being applied to a job it was not written for. Records assembled from third-party evidence still take `software-only`, exactly as now.

## Backward compatibility

Non-breaking. New optional field, existing records do not carry it, existing verifiers ignore unknown fields. No wire format or algorithm change. Per CONTRIBUTING a schema PR must track a merged spec change, so the schema and conformance vectors follow once the shape here is agreed rather than in this PR.

## What I have deliberately left unresolved

`resolver` and `retention` are the interesting fields and I do not expect one round of review to get them right.

A reference is worth only the ability to resolve it later. That is not hypothetical: in the npm keyv compromise the poisoned packages carried valid provenance logged in a transparency service, and fifteen days on the attestations could not be fetched, because the only working index was the artifact digest and unpublishing removed the metadata holding it. Log intact, records unreachable.

TRACE has the same exposure through `transparency`. §7 open question 3 is the same problem for that field and I think the two want resolving together. The spec text says `retention` is an undertaking that nothing here enforces, rather than implying otherwise.

## Sponsor

Not yet named. CONTRIBUTING says proposals are evaluated on the technical argument alone and that a normative PR without a sponsor is not rejected on that basis, so raising it this way deliberately. Happy to have a maintainer carry it, or to name a sponsor if reviewers would rather.