### PR TITLE
docs: document project sponsorship roles

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
           # host. exclude_docs drops the three that are served from the apex.
           if [ -d schema ]; then cp -r schema $BUILD/schema; fi
 
-          for fname in index.md CHANGELOG.md CONTRIBUTING.md GOVERNANCE.md CHARTER.md CODE_OF_CONDUCT.md MAINTAINERS.md ROADMAP.md LIMITATIONS.md PRIVACY.md CNAME robots.txt; do
+          for fname in index.md CHANGELOG.md CONTRIBUTING.md GOVERNANCE.md CHARTER.md CODE_OF_CONDUCT.md MAINTAINERS.md SPONSORS.md ROADMAP.md LIMITATIONS.md PRIVACY.md CNAME robots.txt; do
             if [ -f "$fname" ]; then cp "$fname" "$BUILD/$fname"; fi
           done
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,8 +4,6 @@ Organizations using or evaluating the TRACE specification.
 
 To add your organization, open a pull request editing this file.
 
----
+_None listed yet._
 
-| Organization | Usage |
-|---|---|
-| OPAQUE Systems | Founding contributor — developed the initial specification, reference implementation, and TRACE registry infrastructure |
+Project sponsors and their contributions are listed separately in [SPONSORS.md](SPONSORS.md); sponsorship does not imply adoption.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -28,7 +28,7 @@ Out of scope: runtime policy enforcement engines, TEE platform SDKs, AI model go
 
 Upon host organization acceptance, governance transitions from the current Project Lead model to a Technical Steering Committee (TSC).
 
-**Composition**: 3–9 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique, OPAQUE Systems) holds one founding seat for the v1.0 ratification cycle.
+**Composition**: 3–9 members. No single organization may hold more than 40% of TSC seats. The founding Project Lead (Imran Siddique) holds one founding seat for the v1.0 ratification cycle.
 
 **Election**: TSC members are elected annually by active contributors (at least one merged PR or accepted spec change in the preceding 12 months). Each contributor has one vote.
 
@@ -86,3 +86,7 @@ TRACE participates in IETF RATS, SCITT, and EAR working groups as a consuming pr
 ## 9. Amendments
 
 Amendments to this charter require a two-thirds TSC majority and a 30-day public comment period. Before host organization acceptance, amendments require Project Lead approval and 14-day notice to contributors.
+
+## 10. Sponsors
+
+Organizations providing financial, engineering, infrastructure, or other material support are recognized in [SPONSORS.md](SPONSORS.md). Sponsorship is separate from project governance and does not confer specification authority, additional voting rights, preferential conformance treatment, or endorsement of a sponsor's implementation.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -137,6 +137,10 @@ Draft specifications are exempt: see [Draft](#draft).
 
 Maintainers must disclose commercial interest in a proposal before participating in its review. Disclosed conflicts do not disqualify a Maintainer from voting but must be on record in the PR or issue.
 
+## Sponsorship
+
+Sponsors are recognized in [SPONSORS.md](SPONSORS.md). Sponsorship and participant affiliations are informational and do not confer specification authority, additional decision rights, preferential conformance treatment, or endorsement of a sponsor's implementation. Project decisions follow the consensus and due-process rules in this document regardless of sponsorship.
+
 ## Vendor annexes
 
 Vendor-co-authored platform-mapping annexes (§4.4 of the spec) are informative. They are reviewed by the vendor author and one TRACE Maintainer. Annexes do not require the full spec-change process.

--- a/Governance/Notices.md
+++ b/Governance/Notices.md
@@ -4,7 +4,7 @@
 
 Contact for Code of Conduct issues or inquiries:
 
-- Imran Siddique, Project Lead — imran.siddique@opaque.co
+- TRACE Project Maintainers — maintainers@agentrust-io.com
 
 Reports are handled under the project [Code of Conduct](../CODE_OF_CONDUCT.md).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 
 | Name | Affiliation | GitHub | Contact |
 |---|---|---|---|
-| Imran Siddique | OPAQUE Systems | @imran-siddique | imran.siddique@opaque.co |
+| Imran Siddique | AgenTrust-io | @imran-siddique | maintainers@agentrust-io.com |
 
 The Project Lead has final decision authority on specification changes, AAIF/CoSAI submission scope, conformance requirements, and Maintainer appointments.
 
@@ -21,7 +21,9 @@ The Project Lead has final decision authority on specification changes, AAIF/CoS
 
 **Maintainer**: Active Reviewer for 60+ days, 5+ merged PRs, demonstrated judgment on spec design questions. Nominated by any Maintainer, confirmed by Project Lead.
 
-We are actively recruiting Maintainers from organizations outside OPAQUE Systems, particularly from silicon vendors, cloud providers, and regulated-industry deployers. If you are contributing to TRACE and want to take on a formal role, open an issue tagged `maintainer-interest`.
+We are actively recruiting Maintainers across independent organizations, particularly from silicon vendors, cloud providers, and regulated-industry deployers. If you are contributing to TRACE and want to take on a formal role, open an issue tagged `maintainer-interest`.
+
+Affiliations identify each maintainer's professional context. They do not give an affiliated organization ownership or additional governance rights. See [GOVERNANCE.md](GOVERNANCE.md) and [SPONSORS.md](SPONSORS.md).
 
 ## Emeritus
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,15 @@
+# Sponsors
+
+The TRACE project recognizes organizations that provide financial, engineering, infrastructure, or other material support.
+
+Sponsorship does not confer specification authority, additional governance or voting rights, preferential conformance treatment, endorsement of a sponsor's implementation, or rights to project names and marks. Project decisions follow [GOVERNANCE.md](GOVERNANCE.md), regardless of sponsorship.
+
+## Current sponsors
+
+| Organization | Support |
+|---|---|
+| OPAQUE Systems | Founding engineering and infrastructure support, including contributions to the initial specification, reference implementation, and registry infrastructure |
+
+## Adding or updating a sponsor
+
+Sponsor recognition must describe the support factually and must not imply certification or endorsement. Open a pull request updating this file with the organization name and a concise description of its support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ repo_url: https://github.com/agentrust-io/trace-spec
 repo_name: agentrust-io/trace-spec
 edit_uri: edit/main/
 docs_dir: .
-copyright: "© 2026 OPAQUE Systems — CC BY 4.0"
+copyright: "© 2026 TRACE Specification contributors — CC BY 4.0"
 
 exclude_docs: |
   .github/
@@ -231,6 +231,7 @@ nav:
       - Technical Charter: CHARTER.md
       - Code of Conduct: CODE_OF_CONDUCT.md
       - Maintainers: MAINTAINERS.md
+      - Sponsors: SPONSORS.md
       - Roadmap: ROADMAP.md
       - Privacy: PRIVACY.md
       - Scope: Governance/Scope.md


### PR DESCRIPTION
## Summary

- add a dedicated sponsor policy and recognition page
- separate sponsor recognition from adoption and project governance
- use project-level maintainer contact and site attribution
- include the sponsor page in the documentation build

## Validation

- `git diff --check`
- verified the sponsor page is included in the CI documentation input set