### PR TITLE
docs: update project contact email

### DIFF
--- a/Governance/Notices.md
+++ b/Governance/Notices.md
@@ -4,7 +4,7 @@
 
 Contact for Code of Conduct issues or inquiries:
 
-- TRACE Project Maintainers — maintainers@agentrust-io.com
+- TRACE Project Maintainers — imransiddique@live.com
 
 Reports are handled under the project [Code of Conduct](../CODE_OF_CONDUCT.md).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 
 | Name | Affiliation | GitHub | Contact |
 |---|---|---|---|
-| Imran Siddique | AgenTrust-io | @imran-siddique | maintainers@agentrust-io.com |
+| Imran Siddique | AgenTrust-io | @imran-siddique | imransiddique@live.com |
 
 The Project Lead has final decision authority on specification changes, AAIF/CoSAI submission scope, conformance requirements, and Maintainer appointments.
 


### PR DESCRIPTION
## Summary

- replace a non-operational project email with the current contact address
- leave example identities and protocol data unchanged

## Validation

- git diff --check
- verified the retired operational address is absent