### PR TITLE
test(intent-bridge): make the schema-constraint cases fail when the guard is gone

### DIFF
--- a/tests/test_intent_bridge.py
+++ b/tests/test_intent_bridge.py
@@ -134,41 +134,51 @@ def test_invalid_expiry_order_and_unknown_fields_are_rejected() -> None:
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("field", "value", "message"),
     [
-        ("authorization_id", ""),
-        ("authorizer", ""),
-        ("authorizer_key_id", ""),
-        ("authorized_at", -1),
-        ("expires_at", -1),
+        ("authorization_id", "", "authorization_id must be a non-empty string"),
+        ("authorizer", "", "authorizer must be a non-empty string"),
+        ("authorizer_key_id", "", "authorizer_key_id must be a non-empty string"),
+        ("authorized_at", -1, "authorized_at must be a non-negative integer"),
+        ("expires_at", -1, "expires_at must be a non-negative integer"),
     ],
 )
-def test_runtime_verifier_enforces_schema_scalar_constraints(field: str, value: object) -> None:
+def test_runtime_verifier_enforces_schema_scalar_constraints(
+    field: str, value: object, message: str
+) -> None:
     bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
     bridge["authorization"][field] = value
     bridge = sign_bridge(bridge["authorization"], key)
     trusted = {**key_to_jwk(key), "kid": "" if field == "authorizer_key_id" else "key-7"}
-    with pytest.raises(IntentBridgeError):
+    with pytest.raises(IntentBridgeError, match=message):
         verify_bridge(
             bridge, trusted, declaration=declaration, pic_intent_digest=intent,
-            pic_args_digest=args, tool_call=tool_call, transcript=transcript, now=0,
+            pic_args_digest=args, tool_call=tool_call, transcript=transcript, now=150,
         )
 
 
+_DUPLICATES = "must not contain duplicates"
+_NONEMPTY = "must be a non-empty array of non-empty strings"
+
+
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("field", "value", "message"),
     [
-        ("tools", ["send_invoice", "send_invoice"]),
-        ("tools", [""]),
-        ("impacts", ["external-side-effect", "external-side-effect"]),
-        ("impacts", [""]),
+        ("tools", ["send_invoice", "send_invoice"], _DUPLICATES),
+        ("tools", [""], _NONEMPTY),
+        ("tools", [], _NONEMPTY),
+        ("impacts", ["external-side-effect", "external-side-effect"], _DUPLICATES),
+        ("impacts", [""], _NONEMPTY),
+        ("impacts", [], _NONEMPTY),
     ],
 )
-def test_runtime_verifier_enforces_schema_scope_constraints(field: str, value: list[str]) -> None:
+def test_runtime_verifier_enforces_schema_scope_constraints(
+    field: str, value: list[str], message: str
+) -> None:
     bridge, key, declaration, intent, args, tool_call, transcript = _fixture()
     bridge["authorization"]["scope"][field] = value
     bridge = sign_bridge(bridge["authorization"], key)
-    with pytest.raises(IntentBridgeError):
+    with pytest.raises(IntentBridgeError, match=message):
         verify_bridge(
             bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
             pic_intent_digest=intent, pic_args_digest=args, tool_call=tool_call,


### PR DESCRIPTION
## What this changes

Tests only. No change under `src/`.

#203 added five runtime guards to `verify_bridge` and nine parametrised cases for them. Three of the five guards can be deleted today with the whole suite still green — measured on `main` at 4785fa7 by removing each guard, one at a time, and running `pytest`:

| guard removed | suite |
|---|---|
| the three `_nonempty_string` calls | **729 passed** |
| `or not value` — the `minItems` half of `_unique_nonempty_strings` | **729 passed** |
| item non-emptiness — the `minLength` half | **729 passed** |
| `authorization[field] < 0` | 1 failed |
| the duplicate check | 2 failed |

Two causes.

Both `pytest.raises` are bare `IntentBridgeError`, and `AuthorizationDenied` and `AuthorizationMismatch` subclass it, so a case passes on any rejection rather than the one it names. With the item-emptiness guard removed, `("tools", [""])` still raises — as `AuthorizationMismatch: executed tool is outside the authorized tool scope`.

And the scalar cases run at `now=0` while the fixture's `authorized_at` is `100`, so `authorization is not yet valid` catches four of the five before the guard they name is reached.

`minItems` additionally has no case at all: the four scope parameters cover the duplicate and empty-string halves, not the empty array.

Three changes fix all of it:

- `match=` on both `pytest.raises`, so a case can only pass on the rejection it names.
- The scalar cases at `now=150`, inside the fixture's validity window.
- `("tools", [])` and `("impacts", [])` added.

The verification is the same instrument that found the problem, re-run against the fixed file: removing any one of the five guards now turns it red — 3, 2, 2, 2 and 2 failures respectively, where three of those five were previously green. `ruff`, `mypy` and the full suite are clean at 731 passed, 1 skipped.

Context for why this file carries more weight than most: `agentrust_trace.intent_bridge` is in `__all__` but has no caller inside this repository and no conformance coverage in `agentrust-trace-tests`, so `tests/test_intent_bridge.py` is the only thing checking it.

## Type of change

- [x] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

Conformance tests, per CONTRIBUTING: "No sponsor is required for editorial changes, examples, conformance tests, tooling..."

## Spec section

None. `docs/integration/pic-trace-bridge-v1.md` and `schema/pic-trace-bridge-v1.json` are the artifacts under test; neither is modified.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [x] `CHANGELOG.md` updated (for any normative change) — n/a, no normative change
- [x] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text — n/a
- [x] Backward compatibility statement included (for breaking changes) — n/a
