### PR TITLE
docs(nav): the one page on the site with no nav entry

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,6 +223,7 @@ nav:
       - How the conformance vectors are built: docs/conformance-method.md
   - RFCs:
       - Composable zero-knowledge proofs: docs/rfcs/composable-zk-assurance.md
+      - A2A delegation-link verification profile: docs/rfcs/a2a-delegation-profile.md
   - Project:
       - Limitations: LIMITATIONS.md
       - Changelog: CHANGELOG.md


### PR DESCRIPTION
## What this changes

One line in `mkdocs.yml`. No content change.

`docs/rfcs/a2a-delegation-profile.md` is the only one of the site's 48 pages with no `nav:` entry — 47 entries, 48 pages, and this is the page they do not cover.

This is also the same fix already applied once. `8380993` — *"Adopt-the-shared-design-system-and-unhide-ten-pages"*, 2026-08-19 — added exactly ten nav entries, one of them `docs/rfcs/composable-zk-assurance.md`, which had landed in #162 three days earlier without one. #184 merged four days *after* that sweep and did not touch `mkdocs.yml`, so its RFC is in the state the sweep existed to clear. Nothing in #184's description, comments or reviews mentions the nav, so this reads as the same omission rather than a decision.

It is not unreachable, and this PR is not claiming that: `CHANGELOG.md` links it, `examples/delegation-link/README.md` links it, it is in `sitemap.xml`, and the search index carries 13 entries for it. What it has no path from is the navigation.

Measured by reproducing the deployed build rather than a local one — `.docs_build` assembled the way `docs.yml` assembles it, the same `sed` applied to `docs_dir`, `--strict` added:

| | exit | warnings | pages that link to it |
|---|---|---|---|
| `main` | 0 | none | **2** — `CHANGELOG`, and the page itself |
| with the nav entry | 0 | none | **49** — all of them, via the sidebar |

Nothing else moves. Comparing the two site trees file by file: 49 files differ, none added, none removed, and no page loses a link. 48 of them gain exactly one — the sidebar entry. The forty-ninth is the RFC's own page, which gains 17: its table of contents, which the theme renders only for a page it navigates to. Its rendered `<article>` is byte-identical across the two builds, same SHA-256 and same 35,201 characters, and `sitemap.xml` and the search index are identical in both.

`llms.txt` is untouched by design rather than by omission: the `llmstxt` plugin takes an explicit `sections:` list, and that list names no RFC at all — `composable-zk-assurance.md` is absent from it too.

## Type of change

- [x] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None. The RFC is a draft proposal that binds nothing, and its text is not modified.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [x] `CHANGELOG.md` updated (for any normative change) — n/a, no normative change
- [x] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text — n/a
- [x] Backward compatibility statement included (for breaking changes) — n/a
