### PR TITLE
fix(docs): the record's own version label said v0.1 on four v0.2 surfaces

### DIFF
--- a/docs/integration/cmcp.md
+++ b/docs/integration/cmcp.md
@@ -105,7 +105,7 @@ After the session, fetch the TRACE record from the gateway:
 import httpx
 
 record = httpx.get("https://localhost:8443/trace/latest").json()
-# → full TRACE v0.1 Trust Record, Level 2, signed by TEE-bound key
+# → full TRACE v0.2 Trust Record, Level 2, signed by TEE-bound key
 ```
 
 Or let cMCP push it to the transparency registry automatically:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Schema Reference
 
-JSON Schema for the TRACE v0.1 Trust Record. Source: [`schema/trace-claim.json`](https://github.com/agentrust-io/trace-spec/blob/main/schema/trace-claim.json).
+JSON Schema for the TRACE v0.2 Trust Record. Source: [`schema/trace-claim.json`](https://github.com/agentrust-io/trace-spec/blob/main/schema/trace-claim.json).
 
 ## Top-level fields
 
@@ -158,7 +158,7 @@ For TEE-issued records, this key was generated inside the measured enclave and i
 
 ## Wire formats
 
-TRACE v0.1 supports two wire formats:
+TRACE v0.2 supports two wire formats:
 
 **JSON** (primary): signed JSON object with `signature` as a top-level field.
 

--- a/src/agentrust_trace/models.py
+++ b/src/agentrust_trace/models.py
@@ -257,7 +257,7 @@ class ConfirmationKey(BaseModel):
 
 
 class TrustRecord(BaseModel):
-    """TRACE v0.1 Trust Record — hardware-attested governance evidence for an AI agent execution."""
+    """TRACE v0.2 Trust Record — hardware-attested governance evidence for an AI agent execution."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -93,3 +93,62 @@ def test_module_version_matches_pyproject() -> None:
         )
 
     assert agentrust_trace.__version__ == _declared_version()
+
+
+# --- the record format's version, which is a different number in the same shape ------
+#
+# `__version__` above is the package's. This is the Trust Record's, and it drifted the
+# same way: the docstring on `TrustRecord` said v0.1 from the commit that introduced the
+# package through every release since, on a class whose `eat_profile` is
+# `Literal[...trace-v0.2]` and which therefore cannot hold a v0.1 record. `docs/schema.md`
+# said it twice more, four lines above a table requiring the v0.2 profile URI.
+#
+# Nothing failed, because nothing compared the label against the thing it labels. These
+# read the version out of the packaged schema, which is the artifact that decides it.
+
+_SCHEMA_DIR = _ROOT / "src" / "agentrust_trace" / "schema"
+_DOCS = _ROOT / "docs"
+
+# Surfaces that describe the *current* record and so must name the current version.
+# Documents scoped to an earlier version on purpose are not listed and are not the
+# subject: `docs/crosswalks/` is written against v0.1 deliberately.
+_CURRENT_RECORD_SURFACES = (
+    pathlib.Path("src") / "agentrust_trace" / "models.py",
+    pathlib.Path("docs") / "schema.md",
+    pathlib.Path("docs") / "integration" / "cmcp.md",
+)
+
+
+def _record_version() -> str:
+    """`"v0.2"`, read from the profile URI the packaged schema pins."""
+    import json
+
+    schema = json.loads((_SCHEMA_DIR / "trace-v0.2.json").read_text(encoding="utf-8"))
+    const = schema["properties"]["eat_profile"]["const"]
+    match = re.search(r"trace-(v\d+\.\d+)$", const)
+    assert match, f"the packaged schema's eat_profile const is not a profile URI: {const!r}"
+    return match.group(1)
+
+
+def test_the_packaged_schema_names_a_version() -> None:
+    """Guards the guard. If this returns nothing the checks below pass vacuously."""
+    assert _record_version() == "v0.2"
+
+
+@pytest.mark.parametrize("relative", _CURRENT_RECORD_SURFACES, ids=str)
+def test_no_current_surface_labels_the_record_with_a_superseded_version(
+    relative: pathlib.Path,
+) -> None:
+    current = _record_version()
+    text = (_ROOT / relative).read_text(encoding="utf-8")
+    stale = sorted(
+        {
+            m.group(0)
+            for m in re.finditer(r"TRACE (v\d+\.\d+)", text)
+            if m.group(1) != current
+        }
+    )
+    assert not stale, (
+        f"{relative} calls the record {stale}, but the packaged schema pins {current}. "
+        "Either the label is stale or the schema moved; they cannot both be right."
+    )


### PR DESCRIPTION
`TrustRecord`'s docstring names the version the specification goes out of its way to
disown, on a class that cannot hold one:

```python
class TrustRecord(BaseModel):
    """TRACE v0.1 Trust Record — hardware-attested governance evidence for an AI agent execution."""

    model_config = ConfigDict(extra="forbid")

    eat_profile: Literal["tag:agentrust-io.com,2026:trace-v0.2"]
```

It has said that since `fe79c55`, the commit that introduced the package, through every
release since.

## The four sites

| | What it says | What it is |
|---|---|---|
| `src/agentrust_trace/models.py:260` | "TRACE v0.1 Trust Record" | `eat_profile` is `Literal[...trace-v0.2]` |
| `docs/schema.md:3` | "JSON Schema for the TRACE v0.1 Trust Record" | source is `schema/trace-claim.json`, whose `eat_profile` const is the v0.2 URI |
| `docs/schema.md:161` | "TRACE v0.1 supports two wire formats" | the example ten lines below carries the v0.2 URI |
| `docs/integration/cmcp.md:108` | "full TRACE v0.1 Trust Record" | the library emits only v0.2 |

`docs/schema.md` contradicts itself within four lines: line 3 says v0.1, line 9 requires
`tag:agentrust-io.com,2026:trace-v0.2`, and the fields it documents include `origin` and
`references`.

## Why this is worth more than a typo fix

v0.1 is the single identifier the cutover exists to reject. A v0.2 verifier must refuse
it, and it was minted under a domain the project does not own. It is the least harmless
version string to leave on the primary model class, in the docstring that `help()`, IDE
hovers and generated API docs read from.

It is also the same shape as the drift `tests/test_version.py` already exists to guard,
on a different number. That file opens by recording a literal that disagreed with
`pyproject.toml` and shipped wrong through four releases because nothing compared it
against anything. This is that, for the record format.

## The guard

Reads the version out of the packaged schema's `eat_profile` const, which is the
artifact that decides it, and asserts that the surfaces describing the *current* record
agree with it.

`test_the_packaged_schema_names_a_version` guards the guard: without it, a const that no
longer parses as a profile URI would make every check pass while measuring nothing.

Rather than assume these fail for the right reason:

| Mutation | Test that went red |
|---|---|
| restore the old v0.1 docstring | the `models.py` case |
| write a future version into the docs | the `docs/schema.md` case |
| make the schema const unparseable | all three cases **and** the guard-the-guard |

## Three mentions deliberately left alone

Each is a decision rather than a typo, and none of them is mine to make:

- **`docs/crosswalks/acta-decision-receipts.md`** is written against v0.1 throughout and
  points readers at `spec/trace-v0.1.md`. Deliberate scoping or a stale document, but
  either way a call about the document rather than about a label.
- **`docs/integration/agt.md`** names an external ADR that genuinely is about v0.1. The
  external name is correct; whether the present-tense integration claim still holds is
  not something I can check from here.
- **`docs/tutorials/hardware-attestation-platforms.md`** says "TRACE v0.1 binds only
  `MRTD` in the `measurement` field". The label is stale, but whether the MRTD-only
  substance still holds in v0.2 is a technical claim, and I did not want to change one
  under cover of a version bump. Happy to follow up separately if you say which way it
  goes.

Those three are why the guard names its surfaces rather than scanning the tree: a
document scoped to an earlier version on purpose is not the defect.

`733 passed, 1 skipped`; `ruff check src tests scripts` clean; `mypy` clean. Branched
off `main` at `4785fa7`.
