### PR TITLE
docs: align schema.md with the v0.2 schema

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Schema Reference
 
-JSON Schema for the TRACE v0.1 Trust Record. Source: [`schema/trace-claim.json`](https://github.com/agentrust-io/trace-spec/blob/main/schema/trace-claim.json).
+JSON Schema for the TRACE v0.2 Trust Record. Source: [`schema/trace-claim.json`](https://github.com/agentrust-io/trace-spec/blob/main/schema/trace-claim.json).
 
 ## Top-level fields
 
@@ -41,7 +41,7 @@ Binds the execution environment. Platform-specific fields vary by TEE type.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `platform` | string | **yes** | One of: `amd-sev-snp`, `azure-cvm-sev-snp`, `intel-tdx`, `nvidia-h100`, `nvidia-blackwell`, `tpm-2.0`, `software-only` |
+| `platform` | string | **yes** | One of: `intel-tdx`, `amd-sev-snp`, `azure-cvm-sev-snp`, `nvidia-h100`, `nvidia-blackwell`, `aws-nitro`, `arm-cca`, `google-confidential-space`, `tpm2`, `software-only` |
 | `measurement` | string | **yes** | Hardware measurement hash (`sha384:` for SEV-SNP/TDX, `sha256:` for TPM) |
 | `rim_uri` | string | no | Reference Integrity Manifest URI for hardware verification |
 | `firmware_version` | string | no | TEE firmware version |
@@ -144,7 +144,7 @@ Verifier judgment on the evidence in this record.
 
 ## `transparency`
 
-String. URI of the SCITT transparency log entry anchoring this record. Empty string (`""`) if not anchored at issuance — anchoring may happen asynchronously.
+String. URI of the SCITT transparency log entry anchoring this record. Omitted, or `null`, when the record is not anchored at issuance — anchoring may happen asynchronously. Never an empty string: the reference model rejects one (`min_length=1`).
 
 ## `cnf`
 
@@ -158,7 +158,7 @@ For TEE-issued records, this key was generated inside the measured enclave and i
 
 ## Wire formats
 
-TRACE v0.1 supports two wire formats:
+TRACE v0.2 supports two wire formats:
 
 **JSON** (primary): signed JSON object with `signature` as a top-level field.
 


### PR DESCRIPTION
## Summary

docs/schema.md introduced itself as the v0.1 schema reference in two places, listed a platform enum missing three values the schema defines (aws-nitro, arm-cca, google-confidential-space) while spelling the TPM value tpm-2.0 where the schema says tpm2, and gave contradictory guidance on transparency: the top-level table says omit or null when a record is unanchored, while the section below recommended an empty string.

## Why

The page documents schema/trace-claim.json, so drift between them sends integrators to the schema with wrong values. The empty-string guidance is worse than drift: the reference model rejects empty strings (min_length=1 on transparency), so a producer following the section as written emits records the model refuses.

## Verification

Full test suite passes (729 passed, 1 skipped), including the docs-consistency tests. Platform values and the transparency behavior were checked directly against schema/trace-claim.json and src/agentrust_trace/models.py.