### PR TITLE
fix(docs): the two v0.2 surfaces #207's guard did not cover

### DIFF
--- a/docs/tutorials/verifying-a-trust-record.md
+++ b/docs/tutorials/verifying-a-trust-record.md
@@ -91,7 +91,7 @@ When you supply a key, the library first requires it to identify the same public
 
 ## Validate the Schema
 
-Signature verification confirms the record was not modified after signing. It says nothing about whether the record conforms to the TRACE v0.1 schema. A valid signature over a malformed record is still a malformed record.
+Signature verification confirms the record was not modified after signing. It says nothing about whether the record conforms to the TRACE v0.2 schema. A valid signature over a malformed record is still a malformed record.
 
 Call `validate_json()` to check schema conformance. It raises `jsonschema.ValidationError` on the first violation:
 

--- a/src/agentrust_trace/adapters/agt.py
+++ b/src/agentrust_trace/adapters/agt.py
@@ -130,7 +130,7 @@ class TraceAGTAdapter:
             session: AGT session data collected after ``govern_fn.close_session()``.
 
         Returns:
-            A plain JSON-serialisable dict conforming to the TRACE v0.1 schema.
+            A plain JSON-serialisable dict conforming to the TRACE v0.2 schema.
             The ``cnf.jwk`` placeholder carries no key material until ``sign_record()``
             populates it from the signing key.
         """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -116,6 +116,8 @@ _CURRENT_RECORD_SURFACES = (
     pathlib.Path("src") / "agentrust_trace" / "models.py",
     pathlib.Path("docs") / "schema.md",
     pathlib.Path("docs") / "integration" / "cmcp.md",
+    pathlib.Path("src") / "agentrust_trace" / "adapters" / "agt.py",
+    pathlib.Path("docs") / "tutorials" / "verifying-a-trust-record.md",
 )
 
 


### PR DESCRIPTION
Follow-up to #207, which fixed four surfaces labelling v0.2 records as v0.1 and added a guard in `test_version.py` reading the version out of the packaged schema's `eat_profile` const.

Two more surfaces carry the same defect and sit outside `_CURRENT_RECORD_SURFACES`, so the guard passes while both still drift.

| Site | What it says | What it does |
|---|---|---|
| `src/agentrust_trace/adapters/agt.py:133` | "conforming to the TRACE v0.1 schema" | line 144 writes `"eat_profile": "tag:agentrust-io.com,2026:trace-v0.2"` |
| `docs/tutorials/verifying-a-trust-record.md:94` | "conforms to the TRACE v0.1 schema" | describes `validate_json()`, which `validate.py:13` pins to `trace-v0.2.json` |

Both are added to the tuple, so the class stays closed rather than being closed once.

## Proof the guard cases are real

Reverting only the two content fixes and keeping the widened tuple:

```
FAILED test_no_current_surface_labels_the_record_with_a_superseded_version[src\agentrust_trace\adapters\agt.py]
FAILED test_no_current_surface_labels_the_record_with_a_superseded_version[docs\tutorials\verifying-a-trust-record.md]
2 failed, 8 passed, 1 skipped
```

With the fixes in place: `10 passed, 1 skipped`.

## Surfaces deliberately not included

`docs/integration/agt.md`, `CHANGELOG.md`, `SECURITY.md`, `spec/trace-v0.1.md` and `docs/crosswalks/` all reference v0.1 because they are about v0.1. @lywinged's scoping on those was right and this does not change it.

## Type of change

- [x] Editorial (typo, link fix, clarification, no normative effect)

## Spec section

None. No normative text is modified.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [x] `CHANGELOG.md` updated, n/a, no normative change
- [x] Breaking changes marked, n/a
- [x] Backward compatibility statement, n/a