### PR TITLE
test(sign): freeze the clock on the future-skew boundary

### DIFF
--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -374,15 +374,46 @@ def test_verify_record_accepts_record_within_default_future_skew():
     verify_record(record, key_to_jwk(key))
 
 
-def test_verify_record_future_skew_is_deployment_configurable():
-    key = generate_key()
-    record = _minimal_record()
-    record["iat"] = int(time.time()) + 601
-    record = sign_record(record, key)
+def test_verify_record_future_skew_is_deployment_configurable(monkeypatch):
+    """The future-skew bound, asserted at exactly its edge under a frozen clock.
 
+    This test used to set ``iat`` from ``int(time.time())``, which truncates,
+    while ``verify_record`` compares against an unrounded ``time.time()``. Writing
+    the true setup time as ``k + f`` and ``d`` for everything that elapses before
+    the comparison, ``age = f + d - 601``, so it raised only while ``f + d < 1``.
+    The margin was not one second out of six hundred, it was whatever remained of
+    the current second minus the test's own runtime, and the per-run failure
+    probability was ``d`` rather than anything fixed (#183).
+
+    Freezing rather than widening is deliberate. Moving the assertion to ``+660``
+    would remove the race by removing the test: an implementation whose comparison
+    is off by a few seconds would pass either way, and this is a security-relevant
+    freshness bound. With the clock frozen there is no race left, so the boundary
+    is pinned on both sides instead.
+
+    ``verify_record`` does a local ``import time``, which binds the same module
+    object, so patching the attribute here reaches it.
+    """
+    frozen = 1_800_000_000.0
+    monkeypatch.setattr(time, "time", lambda: frozen)
+
+    key = generate_key()
+
+    # 601s into the future is outside a 600s bound.
+    beyond = _minimal_record()
+    beyond["iat"] = int(frozen) + 601
+    beyond = sign_record(beyond, key)
     with pytest.raises(ValueError, match="max_future_skew_seconds=600"):
-        verify_record(record, key_to_jwk(key), max_future_skew_seconds=600)
-    verify_record(record, key_to_jwk(key), max_future_skew_seconds=602)
+        verify_record(beyond, key_to_jwk(key), max_future_skew_seconds=600)
+
+    # ...and inside a bound configured above it.
+    verify_record(beyond, key_to_jwk(key), max_future_skew_seconds=602)
+
+    # 600s into the future is exactly at the bound, and accepted.
+    at_edge = _minimal_record()
+    at_edge["iat"] = int(frozen) + 600
+    at_edge = sign_record(at_edge, key)
+    verify_record(at_edge, key_to_jwk(key), max_future_skew_seconds=600)
 
 
 def test_disabling_max_age_does_not_disable_future_bound():


### PR DESCRIPTION
Closes #183. Reported and diagnosed by @lywinged; the analysis below is theirs, the mutation results are mine.

## The defect

`tests/test_sign.py` set `iat` from `int(time.time())`, which truncates, while `verify_record` compares against an unrounded `time.time()`. Writing the true setup time as `k + f` and `d` for everything that elapses before the comparison:

```
iat  = k + 601
age  = (k + f + d) - (k + 601) = f + d - 601
raises  <=>  age < -600  <=>  f + d < 1
```

So the tolerance was never one second out of six hundred. It was whatever remained of the current second when the test started, minus its own runtime. `f` is uniform over `[0, 1)`, which makes the per-run failure probability `d` rather than anything fixed, and that is why this read as noise instead of a bug.

Confirmed at pinned `e0afe8eb`: `sign.py:436` is `age = time.time() - iat`, and `test_sign.py:380` was `int(time.time()) + 601`.

## Why freeze rather than widen

Moving the assertion to `+660` would remove the race by removing the test. An implementation whose comparison is off by a few seconds would pass either way, and this is a security-relevant freshness bound, not an incidental one.

`verify_record` does a local `import time` at `sign.py:327`, which binds the same module object, so a module-level `monkeypatch.setattr(time, "time", ...)` reaches it. With the clock frozen there is no race left, so the boundary gets pinned on both sides instead of one:

- 601s into the future is rejected at a 600s bound
- 600s into the future is accepted at the same bound
- the existing `max_future_skew_seconds=602` case is kept

## Both edges are load-bearing

Mutating `sign.py` one way at a time, with the test unchanged:

| mutation | result |
|---|---|
| `age < -max_future_skew_seconds - 2` (widen by 2s) | `Failed: DID NOT RAISE ValueError` |
| `age <= -max_future_skew_seconds` (strict to non-strict) | `ValueError: record is dated 600s in the future` |

The second one is the case the old test could not have caught: it never exercised the accepting side of the boundary, so an off-by-one that rejected a record exactly at the bound would have gone unnoticed.

Stability: the fixed test ran 20 consecutive times, 20 passed.

## Scope

That test alone, as agreed on the issue. The neighbours are fine and were checked: the `602` assertion needs `f + d >= -1`, which always holds, and `test_disabling_max_age_does_not_disable_future_bound` has a 3300-second margin.

## Scope note

Ran the full suite on this branch. The one unrelated failure,
`test_generators_reproduce_fixtures.py::test_generator_reproduces_its_committed_fixtures[delegation-link]`,
is a Windows line-ending artifact in my local environment and not a defect: the generator writes
platform line endings while the committed blobs are LF, and the regenerated fixtures are
byte-identical after normalising. It passes on CI.
