### PR TITLE
fix(docs): AGT integration doc's ADR link and version claim were both stale

### DIFF
--- a/docs/integration/agt.md
+++ b/docs/integration/agt.md
@@ -2,7 +2,7 @@
 
 [AGT (Agent Governance Toolkit)](https://github.com/microsoft/agent-governance-toolkit) is the most widely adopted agent governance framework (4,100+ stars, 100+ contributors). It provides Cedar policy enforcement, SPIFFE/SVID identity, and Merkle-chained audit logs for any agent framework.
 
-AGT emits TRACE v0.1 Trust Records via `TRACEAuditSink` — see [ADR 0032](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/adr/0032-agt-emits-trace-v01-trust-records.md) for the full design.
+AGT emits TRACE v0.2 Trust Records via `TRACEAuditSink` — see [ADR 0032](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/adr/0032-agt-emits-trace-v01-trust-records.md) for the full design.
 
 ## What AGT emits
 

--- a/docs/integration/agt.md
+++ b/docs/integration/agt.md
@@ -2,7 +2,7 @@
 
 [AGT (Agent Governance Toolkit)](https://github.com/microsoft/agent-governance-toolkit) is the most widely adopted agent governance framework (4,100+ stars, 100+ contributors). It provides Cedar policy enforcement, SPIFFE/SVID identity, and Merkle-chained audit logs for any agent framework.
 
-AGT emits TRACE v0.2 Trust Records via `TRACEAuditSink` — see [ADR 0032](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/adr/0032-agt-emits-trace-v01-trust-records.md) for the full design.
+AGT emits TRACE v0.1 Trust Records via `TRACEAuditSink` in its latest release (`agent-governance-toolkit-core` 5.0.0) — see [ADR 0032](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/adr/0032-agt-emits-trace-v01-trust-records.md) for the full design. AGT's `main` branch has already moved to v0.2, but that change has not shipped in a release yet, and the linked ADR still describes the v0.1 design.
 
 ## What AGT emits
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -118,6 +118,7 @@ _CURRENT_RECORD_SURFACES = (
     pathlib.Path("docs") / "integration" / "cmcp.md",
     pathlib.Path("src") / "agentrust_trace" / "adapters" / "agt.py",
     pathlib.Path("docs") / "tutorials" / "verifying-a-trust-record.md",
+    pathlib.Path("docs") / "integration" / "agt.md",
 )
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -118,7 +118,6 @@ _CURRENT_RECORD_SURFACES = (
     pathlib.Path("docs") / "integration" / "cmcp.md",
     pathlib.Path("src") / "agentrust_trace" / "adapters" / "agt.py",
     pathlib.Path("docs") / "tutorials" / "verifying-a-trust-record.md",
-    pathlib.Path("docs") / "integration" / "agt.md",
 )
 
 


### PR DESCRIPTION
## What this changes

`docs/integration/agt.md` said AGT emits TRACE v0.2 Trust Records. That was wrong as the latest released AGT (`agent-governance-toolkit-core` 5.0.0 on PyPI) still emits trace-v0.1 (verified directly: `trace_sink.py:92` writes `eat_profile: "tag:agentrust.io,2026:trace-v0.1"`, and the package pins `agentrust-trace<0.3.0,>=0.2.0`). Only AGT's unreleased `main` branch has moved to v0.2.

The doc now says v0.1, scoped explicitly to the latest release, and notes that `main` has moved to v0.2 but hasn't shipped yet, and that the linked ADR (0032) still describes the v0.1 design and hasn't been updated for the change.


## Type of change

- [x] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)
