### PR TITLE
fix(readme and index.md): Quick start code sample doesn't run

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each question maps to a claim a third party can check for themselves.
 | Under which policy? | `policy.bundle_hash` + `policy.enforcement_mode` |
 | What data did it touch? | `data_class` |
 | Which tools were called? | `tool_transcript.hash` + `tool_transcript.call_count` |
-| Is the record independently anchored? | `anchoring.receipt_uri` (SCITT) |
+| Is the record independently anchored? | `transparency` (SCITT receipt URI) |
 
 ## Quick start
 
@@ -55,16 +55,26 @@ pip install agentrust-trace
 ```
 
 ```python
-from agentrust_trace import TrustRecord, sign_record
+import time
+from agentrust_trace import generate_key, sign_record
 
-record = TrustRecord(
-    subject="spiffe://trust.example.org/agent/payments-processor",
-    model_id="claude-sonnet-4-6",
-    platform="amd-sev-snp",
-    policy_hash="sha256:b2c3d4...",
-)
-signed = sign_record(record, key=signing_key)
+key = generate_key()
+
+record = {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": int(time.time()),
+    "subject": "spiffe://trust.example.org/agent/payments-processor",
+    "model": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+    "runtime": {"platform": "amd-sev-snp", "measurement": "sha256:" + "0" * 64},
+    "policy": {"bundle_hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
+    "data_class": "confidential",
+    "build_provenance": {"slsa_level": 1, "digest": "sha256:" + "e" * 64},
+    "appraisal": {"status": "none", "verifier": "https://verifier.example.org"},
+}
+
+signed = sign_record(record, key)
 ```
+See the [Quickstart guide](https://trace.agentrust-io.com/quickstart/) for key persistence, validation, and anchoring the record to a transparency log.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ record = {
 
 signed = sign_record(record, key)
 ```
-See the [Quickstart guide](https://trace.agentrust-io.com/quickstart/) for key persistence, validation, and anchoring the record to a transparency log.
+See the [Quickstart guide](https://trace.agentrust-io.com/docs/quickstart/) for key persistence, validation, and anchoring the record to a transparency log.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ record = {
     "iat": int(time.time()),
     "subject": "spiffe://trust.example.org/agent/payments-processor",
     "model": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
-    "runtime": {"platform": "amd-sev-snp", "measurement": "sha256:" + "0" * 64},
+    "runtime": {"platform": "software-only", "measurement": "sha256:" + "0" * 64},
     "policy": {"bundle_hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
     "data_class": "confidential",
     "build_provenance": {"slsa_level": 1, "digest": "sha256:" + "e" * 64},

--- a/index.md
+++ b/index.md
@@ -20,15 +20,24 @@ pip install agentrust-trace
 ```
 
 ```python
-from agentrust_trace import TrustRecord, sign_record
+import time
+from agentrust_trace import generate_key, sign_record
 
-record = TrustRecord(
-    subject="spiffe://trust.example.org/agent/payments-processor",
-    model_id="claude-sonnet-4-6",
-    platform="amd-sev-snp",
-    policy_hash="sha256:b2c3d4...",
-)
-signed = sign_record(record, key=signing_key)
+key = generate_key()
+
+record = {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": int(time.time()),
+    "subject": "spiffe://trust.example.org/agent/payments-processor",
+    "model": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+    "runtime": {"platform": "software-only", "measurement": "sha256:" + "0" * 64},
+    "policy": {"bundle_hash": "sha256:" + "b" * 64, "enforcement_mode": "enforce"},
+    "data_class": "confidential",
+    "build_provenance": {"slsa_level": 1, "digest": "sha256:" + "e" * 64},
+    "appraisal": {"status": "none", "verifier": "https://verifier.example.org"},
+}
+
+signed = sign_record(record, key)
 ```
 
 ## What a Trust Record proves
@@ -42,7 +51,7 @@ Each question maps to a claim a third party can check without asking you.
 | Under which policy? | `policy.bundle_hash` + `policy.enforcement_mode` |
 | What data did it touch? | `data_class` |
 | Which tools were called? | `tool_transcript.hash` + `tool_transcript.call_count` |
-| Is the record independently anchored? | `anchoring.receipt_uri` (SCITT) |
+| Is the record independently anchored? | `transparency` (SCITT receipt URI) |
 
 ## Where to start
 


### PR DESCRIPTION
## What this changes

The README's and index.md's Quick start example crashes immediately if executed via copy-paste it constructs `TrustRecord(...)` with fields like `model_id`, `platform`, and `policy_hash` that don't exist on the model (they're nested under `model.*`, `runtime.*`, `policy.*`) and skips several required fields, passes a `TrustRecord` object to `sign_record()` which expects a dict, and references an undefined `signing_key` variable. Running it raises 12 pydantic validation errors.

Replaced it with a minimal working example (verified by actually running it) that mirrors the pattern already used correctly in `docs/quickstart.md`.

Also fixed one row in the "What a Trust Record proves" table: it referenced `anchoring.receipt_uri`, a field that doesn't exist anywhere in the schema or model. The actual field is `transparency`.

## Type of change

- [x] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)
