### PR TITLE
fix(ci): pin sbom.yml actions to SHA and scope permissions to the job

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,22 +9,21 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: spdx-json
           output-file: sbom.spdx.json
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json


### PR DESCRIPTION
## What this changes

sbom.yml was running anchore/sbom-action@v0 which is a floating tag in a job that also holds id-token: write. If that tag ever pointed to something malicious, whatever ran could mint an OIDC token and push to this repo. Pinned it, along with actions/checkout and actions/upload-artifact, to exact commit SHAs.

Also moved contents: write and id-token: write from the top of the file down into the sbom job itself, so they only apply where they're actually needed instead of to the whole workflow.

Part of the CI hardening pass in agentrust-io/.github#30. 

## Type of change

- [ ] Editorial (typo, link fix, clarification — no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN — description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)
