### PR TITLE
docs: reflect the Linux Foundation contribution announcement

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,9 +1,9 @@
 # Technical Charter — TRACE
 
-**Hosting**: The Linux Foundation, as its own series: "TRACE Specification, a Series of LF Projects, LLC". This supersedes the earlier proposal to split the technical workstream to CoSAI and the specification, IP, and trademark to the Linux Foundation entity hosting the Model Context Protocol. CoSAI participates as a technical-liaison partner for WS4 interoperability, not as a host.  
-**Status**: Draft — formation with LF Projects, LLC is in progress; effective when the Technical Charter takes effect.
+**Hosting**: The Linux Foundation, as its own series: "TRACE Specification, a Series of LF Projects, LLC". The Linux Foundation [announced the contribution](https://www.linuxfoundation.org/press/linux-foundation-welcomes-trace-to-advance-verifiable-runtime-evidence-for-ai-workloads) on 25 August 2026. The technical workstream is hosted by the Coalition for Secure AI (CoSAI). This supersedes the earlier proposal to split the specification, IP, and trademark to the Linux Foundation entity hosting the Model Context Protocol.  
+**Status**: Draft. The Linux Foundation has accepted the contribution; the Technical Charter and Project Contribution Agreement are still being executed with LF Projects, LLC. This charter is effective when the Technical Charter takes effect.
 
-> **Note for external contributors:** This charter is a working draft and has not yet been accepted by a host organization. Governance terms, IP policy, and conformance mark ownership described here are proposed, not final. Do not implement production systems based on governance commitments in this document until v1.0 ratification.  
+> **Note for external contributors:** The Linux Foundation has accepted TRACE, but this charter is still a working draft and the Technical Charter has not yet taken effect. Governance terms, IP policy, and conformance mark ownership described here are proposed, not final. Do not implement production systems based on governance commitments in this document until v1.0 ratification.  
 **Version**: 0.1 (aligned with spec v0.1)
 
 ---

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -151,7 +151,9 @@ Information disclosed in connection with any Project activity, including but not
 
 ## Linux Foundation hosting
 
-TRACE Specification is hosted at the Linux Foundation as a Series of LF Projects, LLC. Project formation is underway: the Technical Charter and Project Contribution Agreement are being executed with LF Projects, LLC. This document is the governance authority until the Technical Charter takes effect, at which point governance transitions to a Technical Steering Committee as described in [CHARTER.md](CHARTER.md), and the Technical Charter controls where the two differ.
+TRACE Specification is hosted at the Linux Foundation as a Series of LF Projects, LLC. The Linux Foundation [announced the contribution of TRACE](https://www.linuxfoundation.org/press/linux-foundation-welcomes-trace-to-advance-verifiable-runtime-evidence-for-ai-workloads) on 25 August 2026. The technical workstream is hosted by the Coalition for Secure AI (CoSAI).
+
+Formation paperwork is still in progress: the Technical Charter and Project Contribution Agreement are being executed with LF Projects, LLC. This document is the governance authority until the Technical Charter takes effect, at which point governance transitions to a Technical Steering Committee as described in [CHARTER.md](CHARTER.md), and the Technical Charter controls where the two differ.
 
 ## Amendments
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See the [Quickstart guide](https://trace.agentrust-io.com/docs/quickstart/) for 
 
 ## Standards alignment
 
-Hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC", under [LF Projects policies](https://lfprojects.org/policies/). Related standardization track in [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
+Hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC", under [LF Projects policies](https://lfprojects.org/policies/). The Linux Foundation [announced the contribution](https://www.linuxfoundation.org/press/linux-foundation-welcomes-trace-to-advance-verifiable-runtime-evidence-for-ai-workloads) on 25 August 2026, developed with AMD, Intel, Microsoft, OPAQUE and TII. The technical workstream is hosted by CoSAI; see [CoSAI WS4](https://github.com/oasis-open-projects/coalition-for-secure-ai). Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
The Linux Foundation [announced the contribution of TRACE](https://www.linuxfoundation.org/press/linux-foundation-welcomes-trace-to-advance-verifiable-runtime-evidence-for-ai-workloads) on 25 August 2026. Three documents still read as though nothing had happened, and one contradicts the announcement outright.

Anyone arriving from the press release lands on these files first, so they are the ones that need to be right.

### What changed

| File | Was | Now |
|---|---|---|
| `GOVERNANCE.md` | "Project formation is underway" and nothing else | Records the announcement, keeps the caveat that the Technical Charter and PCA are still being executed |
| `CHARTER.md` | "CoSAI participates as a technical-liaison partner for WS4 interoperability, not as a host" | The announcement states the technical workstream is hosted by CoSAI. Corrected |
| `CHARTER.md` | Status "formation is in progress"; note said no host organization had accepted TRACE | LF has accepted; the Technical Charter has still not taken effect |
| `README.md` | Standards alignment named CoSAI WS4 as a related track | Links the announcement, names AMD, Intel, Microsoft, OPAQUE and TII, states CoSAI hosts the technical workstream |

### What did not change

No governance terms. The Technical Charter is still not in effect, this document set is still the governance authority until it is, and the "do not implement production systems based on governance commitments here" warning stays.

`CHARTER.md` is charter text, so this needs Project Lead sign-off rather than a routine docs merge. Flagging that rather than assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lb7ktpQ4jdFMPVdcPJXnU