### PR TITLE
docs(schema): remove em dashes from Trust Record descriptions

### DIFF
--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -33,7 +33,7 @@
     }
   },
   "title": "TRACE Trust Record",
-  "description": "A TRACE v0.2 Trust Record — hardware-attested governance evidence for an AI agent execution.",
+  "description": "A TRACE v0.2 Trust Record: hardware-attested governance evidence for an AI agent execution.",
   "type": "object",
   "required": [
     "eat_profile",
@@ -405,7 +405,7 @@
     },
     "cnf": {
       "type": "object",
-      "description": "Confirmation key (RFC 8747) — binds the Trust Record to the TEE-held signing key.",
+      "description": "Confirmation key (RFC 8747) that binds the Trust Record to the TEE-held signing key.",
       "required": [
         "jwk"
       ],

--- a/src/agentrust_trace/schema/trace-v0.1.json
+++ b/src/agentrust_trace/schema/trace-v0.1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentrust.io/schema/trace-v0.1.json",
   "title": "TRACE Trust Record",
-  "description": "A TRACE v0.1 Trust Record — hardware-attested governance evidence for an AI agent execution.",
+  "description": "A TRACE v0.1 Trust Record: hardware-attested governance evidence for an AI agent execution.",
   "type": "object",
   "required": [
     "eat_profile",
@@ -241,7 +241,7 @@
     },
     "cnf": {
       "type": "object",
-      "description": "Confirmation key (RFC 8747) — binds the Trust Record to the TEE-held signing key.",
+      "description": "Confirmation key (RFC 8747) that binds the Trust Record to the TEE-held signing key.",
       "required": ["jwk"],
       "properties": {
         "jwk": {

--- a/src/agentrust_trace/schema/trace-v0.2.json
+++ b/src/agentrust_trace/schema/trace-v0.2.json
@@ -33,7 +33,7 @@
     }
   },
   "title": "TRACE Trust Record",
-  "description": "A TRACE v0.2 Trust Record — hardware-attested governance evidence for an AI agent execution.",
+  "description": "A TRACE v0.2 Trust Record: hardware-attested governance evidence for an AI agent execution.",
   "type": "object",
   "required": [
     "eat_profile",
@@ -405,7 +405,7 @@
     },
     "cnf": {
       "type": "object",
-      "description": "Confirmation key (RFC 8747) — binds the Trust Record to the TEE-held signing key.",
+      "description": "Confirmation key (RFC 8747) that binds the Trust Record to the TEE-held signing key.",
       "required": [
         "jwk"
       ],


### PR DESCRIPTION
House style is no em dashes in anything we publish. These two sentences are published three times over: in the normative schema, in the copy packaged with the SDK, and at the `$id` URL `agentrust-io.com` serves, which is what a validator fetches when it follows a Trust Record's schema reference.

## The change

| Before | After |
|---|---|
| `A TRACE v0.2 Trust Record — hardware-attested governance evidence…` | `A TRACE v0.2 Trust Record: hardware-attested governance evidence…` |
| `Confirmation key (RFC 8747) — binds the Trust Record to the TEE-held signing key.` | `Confirmation key (RFC 8747) that binds the Trust Record to the TEE-held signing key.` |

Rewritten rather than repunctuated, so neither reads like a dash was swapped for a colon and left dangling.

Files: `schema/trace-claim.json` (normative), `src/agentrust_trace/schema/trace-v0.2.json` (packaged, guarded by `test_validate.py`), and `src/agentrust_trace/schema/trace-v0.1.json`, which carries the identical two sentences. Leaving v0.1 behind means the next person greps, finds a hit, and cannot tell whether it was missed or deliberate.

**Description text only.** No constraint, property, `required` list or `$id` moves. Nothing that validates today stops validating.

## Why this one goes first

`agentrust-io.github.io` serves `schema/trace-v0.2.json`, and its `schema-parity` workflow byte-compares that file against `trace-spec/schema/trace-claim.json` on every PR and daily. The published copy cannot be cleaned until this lands. The site PR re-syncs it immediately afterwards.

## Note on two local failures

`test_safe_integer_range::test_every_schema_in_the_repository_is_classified` and the `delegation-link` generator fixture test fail on Windows **before** this change as well: `_schemas_on_disk()` compares `os.sep`-joined paths against forward-slash literals. Green on Linux CI, untouched here, and worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NL8o3PXq6kfs2SdmBv6ak