### PR TITLE
fix(docs): tracker number and two swapped issue/pull link paths

### DIFF
--- a/docs/verification-outcome-statements.md
+++ b/docs/verification-outcome-statements.md
@@ -49,9 +49,9 @@ Moving these into the record would be a schema change, which is out of scope for
 
 ## Open questions
 
-- Rows describing approval-bearing receipts - approval preceding execution, applicable approver authority, scope covering the action taken - depend on profile work routed through [#191](https://github.com/agentrust-io/trace-spec/issues/191) and sit behind the [#116](https://github.com/agentrust-io/trace-spec/pull/116) version boundary. Until that lands, they remain open questions rather than settled guidance.
+- Rows describing approval-bearing receipts - approval preceding execution, applicable approver authority, scope covering the action taken - depend on profile work routed through [#191](https://github.com/agentrust-io/trace-spec/issues/191) and sit behind the [#116](https://github.com/agentrust-io/trace-spec/issues/116) version boundary. Until that lands, they remain open questions rather than settled guidance.
 - Comparability of `transitive` across verifiers stays open until the coverage-URI follow-up named in [verification.md](verification.md#transitive-is-a-floor-on-effort-not-a-comparable-claim) settles. Until then, a `transitive` value supports an effort-floor statement only, not a claim that two verifiers covered identical dependency sets.
-- Whether `appraisal.policy_ref` gains reproducibility guarantees (a digest binding for the referenced appraisal policy) is an unresolved design question tracked in [#187](https://github.com/agentrust-io/trace-spec/issues/187). Until then, a bounded statement cites the appraisal policy by reference, and second-verifier reproduction of an appraisal verdict is not guaranteed.
+- Whether `appraisal.policy_ref` gains reproducibility guarantees (a digest binding for the referenced appraisal policy) is an unresolved design question tracked in [#190](https://github.com/agentrust-io/trace-spec/issues/190). Until then, a bounded statement cites the appraisal policy by reference, and second-verifier reproduction of an appraisal verdict is not guaranteed.
 
 ## Related
 


### PR DESCRIPTION
## What this changes

Two reference targets in `docs/verification-outcome-statements.md`, carrying three defects of two kinds: one wrong referent, and two link paths swapped between `/issues/` and `/pull/`.

1. The open-questions bullet pointed the `appraisal.policy_ref` reproducibility question at [agentrust-io/trace-spec#187](https://github.com/agentrust-io/trace-spec/pull/187). That link resolves, but it names the wrong item: #187 is a merged pull request (its changes include the revocation bundle schemas), and the open issue tracking the question is [agentrust-io/trace-spec#190](https://github.com/agentrust-io/trace-spec/issues/190). The reference now names the open issue and links it as an issue.
2. The same line reached #187 through an `/issues/` path, and two lines up, [agentrust-io/trace-spec#116](https://github.com/agentrust-io/trace-spec/issues/116) was linked through a `/pull/` path; #116 is an open issue. Each swapped path resolves only by GitHub's redirect, so both read as correct on click-through. The path on the agentrust-io/trace-spec#116 line is corrected in place, and its number was already right. The path on the other line is not corrected: the link to agentrust-io/trace-spec#187 is removed together with its referent, so no corrected link to it survives in the result.

Every word outside the two changed links is unchanged. The version-boundary line therefore asserts exactly what it asserted before. The `appraisal.policy_ref` line does not: "tracked in" names the item that tracks the question, so pointing it at agentrust-io/trace-spec#190 instead of agentrust-io/trace-spec#187 changes what that line asserts.

## Type of change
- [x] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change
- [ ] Breaking spec change
- [ ] Schema change
- [ ] Example addition

## Spec section
None; `docs/` only.

## Checklist
- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not applicable, non-normative
- [ ] Breaking changes marked: not applicable
- [ ] Backward compatibility statement: not applicable

---

*Amended 2026-08-29: two claims this body made about the diff were wrong as written and have been replaced. Prompted by lywinged's review 5054851341.*
