### PR TITLE
test(intent-bridge): the only validation of tool_call.name and declaration.impact had no test

### DIFF
--- a/tests/test_intent_bridge.py
+++ b/tests/test_intent_bridge.py
@@ -16,10 +16,14 @@ from agentrust_trace.intent_bridge import (
 from agentrust_trace.sign import key_to_jwk
 
 
-def _fixture() -> tuple[dict, Ed25519PrivateKey, dict, str, str, dict, dict]:
+def _fixture(
+    scope: dict | None = None,
+    tool_call: dict | None = None,
+    declaration: dict | None = None,
+) -> tuple[dict, Ed25519PrivateKey, dict, str, str, dict, dict]:
     key = Ed25519PrivateKey.generate()
-    declaration = {"impact": "external-side-effect", "purpose": "send invoice"}
-    tool_call = {"name": "send_invoice", "arguments": {"invoice_id": "INV-7"}}
+    declaration = declaration or {"impact": "external-side-effect", "purpose": "send invoice"}
+    tool_call = tool_call or {"name": "send_invoice", "arguments": {"invoice_id": "INV-7"}}
     authorization = {
         "authorization_id": "auth-7",
         "decision": "allow",
@@ -27,7 +31,7 @@ def _fixture() -> tuple[dict, Ed25519PrivateKey, dict, str, str, dict, dict]:
         "authorizer_key_id": "key-7",
         "authorized_at": 100,
         "expires_at": 200,
-        "scope": {"tools": ["send_invoice"], "impacts": ["external-side-effect"]},
+        "scope": scope or {"tools": ["send_invoice"], "impacts": ["external-side-effect"]},
         "pic": {
             "profile": "PIC-CJSON/1.0",
             "intent_digest": "sha256:" + "1" * 64,
@@ -94,6 +98,63 @@ def test_deny_and_scope_fail_closed() -> None:
             pic_intent_digest=intent, pic_args_digest=args,
             tool_call=outside, transcript=transcript, now=150,
         )
+
+
+def _verify(
+    bridge: dict, key: Ed25519PrivateKey, declaration: dict,
+    intent: str, args: str, tool_call: dict, transcript: dict,
+) -> None:
+    verify_bridge(
+        bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+        pic_intent_digest=intent, pic_args_digest=args,
+        tool_call=tool_call, transcript=transcript, now=150,
+    )
+
+
+def test_the_baseline_scope_verifies_so_the_two_below_refuse_on_scope_alone() -> None:
+    """The control for the pair that follows. Without it they show only that something failed."""
+    _verify(*_fixture({"tools": ["send_invoice"], "impacts": ["external-side-effect"]}))
+
+
+def test_a_tool_outside_the_authorized_scope_is_refused_on_that_ground() -> None:
+    """This line is the only validation of `tool_call["name"]` in the module.
+
+    It reads as a policy comparison against `scope.tools` and it is one, but there is no
+    `_object` and no `_nonempty_string` on the field anywhere, so it is also the only shape
+    guard on a caller-supplied input. Delete it and a `tool_call` carrying no `name` key at
+    all, digested and signed honestly by the issuer, verifies: every digest matches, the
+    transcript matches, the window is open, and nothing else looks at the field.
+
+    `test_deny_and_scope_fail_closed` cannot stand in for this and should not try. Its
+    record violates three rules at once, so which fires first is not this suite's business,
+    and its input changes the executed call, which changes `tool_call_digest` by
+    construction and so can only ever reach the family the digest already refuses.
+    """
+    with pytest.raises(AuthorizationMismatch, match="outside the authorized tool scope"):
+        _verify(*_fixture({"tools": ["read_invoice"], "impacts": ["external-side-effect"]}))
+
+
+def test_an_impact_outside_the_authorized_scope_is_refused_on_that_ground() -> None:
+    """The same, for `declaration["impact"]`, which is guarded in exactly one place too."""
+    with pytest.raises(AuthorizationMismatch, match="outside the authorized impact scope"):
+        _verify(*_fixture({"tools": ["send_invoice"], "impacts": ["read-only"]}))
+
+
+def test_a_tool_call_with_no_name_at_all_is_refused() -> None:
+    """The shape case, which is what makes this line the only guard on the field.
+
+    Everything here is internally consistent: the issuer digested and signed exactly the
+    call that executed. Nothing else in the module looks at `tool_call["name"]`, so an
+    implementation that skipped the comparison when the key is absent would verify this.
+    """
+    with pytest.raises(AuthorizationMismatch, match="outside the authorized tool scope"):
+        _verify(*_fixture(tool_call={"arguments": {"invoice_id": "INV-7"}}))
+
+
+def test_a_declaration_with_no_impact_at_all_is_refused() -> None:
+    """The same for `declaration["impact"]`."""
+    with pytest.raises(AuthorizationMismatch, match="outside the authorized impact scope"):
+        _verify(*_fixture(declaration={"purpose": "send invoice"}))
 
 
 def test_expiry_and_required_transcript_are_enforced() -> None:


### PR DESCRIPTION
Tests only, no source change. Three tests for two lines that had none.

## What the two lines are

```python
if not isinstance(tool_call, dict):
    raise IntentBridgeError("tool_call must be an object")
if tool_call.get("name") not in tools:
    raise AuthorizationMismatch("executed tool is outside the authorized tool scope")
```

and the same shape for `declaration.get("impact")` against `scope.impacts`. They read as policy comparisons, and they are, but they are also **the only validation anywhere in the module of `tool_call["name"]` and `declaration["impact"]`**. There is no `_object`, no `_nonempty_string`, no schema pass on either field. Neither line had a test.

## What is behind each of them

A `tool_call` with no `name` key at all, honestly digested by the issuer and signed:

```
unmodified                     AuthorizationMismatch: executed tool is outside the authorized tool scope
tool-scope check removed       VERIFIED
```

`digest_jcs(tool_call)` matches, both PIC digests match, the transcript matches, the window is open. Nothing is self-contradictory: the issuer authorized exactly what executed. Line 180 is the whole of what stands between that record and a verified result. `declaration` without an `impact` key behaves the same way against line 184.

I originally reported these lines as redundant with the digest binding for every honestly issued record, and drafted an issue asking whether to test them or delete them. That was wrong. The substitutions I measured all changed the executed call, which changes `tool_call_digest` by construction, so they could only ever find the family where the digest fires. The malformed-but-consistent family is the one these lines exist for, and it does not appear in that experiment at all. The issue is not filed.

## The tests

`_fixture` takes defaulted `scope`, `tool_call` and `declaration` arguments, so each new test differs from the baseline in exactly one field. Called with no arguments it is byte-identical to the version on `25013c5`, checked by hashing its output under a fixed key, so the eight existing tests that share it are unaffected: 8 before, 13 after.

| test | measured |
|---|---|
| `..._baseline_scope_verifies_so_the_two_below_refuse_on_scope_alone` | the control: in-scope call verifies cleanly |
| `..._a_tool_outside_the_authorized_scope_is_refused_on_that_ground` | a named tool out of scope |
| `..._an_impact_outside_the_authorized_scope_is_refused_on_that_ground` | the same for impact |
| `..._a_tool_call_with_no_name_at_all_is_refused` | the shape case, the one that makes this the only guard on the field |
| `..._a_declaration_with_no_impact_at_all_is_refused` | the same for impact |

Removing either guard fails exactly its own tests and nothing else.

**Where these tests stop, measured rather than assumed.** Against three wrong-but-plausible
rewrites of the tool-scope line: a variant that skips the comparison when `name` is absent is
caught, which is the one that matters, because that is the record the section above is about. A
case-insensitive comparison and a prefix comparison both pass. I have not added tests for those
two, deliberately: nothing normative says the match is case-sensitive or exact, so a test
asserting it would pin a behaviour the project has not stated. If you want that pinned, say so and
it is two more tests.

The first three of these were written before that was measured, and none of them covered the
missing-key case the description above leads with. That is why the last two exist.

## One defect this turned up that is not fixed here

`test_deny_and_scope_fail_closed` does not test scope, and the measurement below is what shows it. Removing the three rules its record violates, in turn, in a fresh process each time:

```
0 removed  executed tool is outside the authorized tool scope
1 removed  tool_call_digest does not match the signed authorization
2 removed  transcript.before.tool_call does not match execution
3 removed  VERIFIED
```

With the scope check gone the test still passes, on the digest. Its name claims a scope assertion it does not make. An earlier draft of this PR "fixed" that by adding `match=`, which would have turned a fail-closed test into an assertion about the order of checks inside `verify_bridge`, against this repository's own principle in `test_the_reported_forgery_is_refused`: "Which rule fires first does not matter; that it verified at all was the bug." That hunk is gone and the assertion is untouched. The rename is a separate change and yours to want or not.

## Verification

```
ruff check src tests scripts     All checks passed!
python tools/check_dashes.py     no dashes outside examples/, spec/trace-v0.1.md
mypy src/agentrust_trace         Success: no issues found in 10 source files
pytest                           1020 passed, 1 skipped
```

`25013c5` is 1015 passed, 1 skipped, and the delta is the five added tests. Reproduced on a fresh clone. Deleting the raise and making the branch unreachable are the same mutation semantically, so that is one form rather than two; inverting the condition also breaks the accepting path and is uninformative. The claim rests on the isolating tests.

## Related, not filed as issues unless you want them

`spec/trace-v0.2.md` does not mention the bridge, and that is by design rather than a gap: `docs/integration/pic-trace-bridge-v1.md` opens "This informative profile ... It is an optional bridge; it does not make PIC a dependency of TRACE and it does not change the TRACE Trust Record schema." I checked because I was about to report the absence as a defect, which it is not.

Separately, `src/agentrust_trace` has 30 sites where neutralising the `raise` leaves the suite green. 29 are lines the suite never executes, which `pytest --cov --cov-report=term-missing` already reports in about eight seconds; this was the thirtieth. If a list of all 30, grouped by reachable and never-executed, would be useful, say so and I will send one issue with no proposed disposition attached.

## Type of change

- [ ] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

Tests only. No box fits, so none is checked rather than checking the least wrong one.

## Spec section

None.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN: description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)

No CHANGELOG entry: nothing observable changes for a consumer of this package.
