### PR TITLE
fix(provenance): establish cnf object boundary

### DIFF
--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -376,7 +376,8 @@ def verify_record(
     if not signature:
         raise ProvenanceError("record carries no signature")
 
-    embedded = (record.get("cnf") or {}).get("jwk")
+    cnf = _as_object(record.get("cnf"), "cnf")
+    embedded = cnf.get("jwk")
     if embedded:
         # Compared by RFC 7638 thumbprint, not by dict equality. A JWK is identified by
         # its key material; `kid`, `use` and `alg` are optional members that carry none

--- a/tests/test_provenance_cnf_boundary.py
+++ b/tests/test_provenance_cnf_boundary.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from agentrust_trace.provenance import ProvenanceError, build_record, verify_record
+from agentrust_trace.sign import _canonical_bytes, generate_key, key_to_jwk
+
+TOOLS = [
+    {
+        "name": "search",
+        "description": "search the docs",
+        "input_schema": {"type": "object"},
+    }
+]
+ARTIFACT = {
+    "package": "pkg:npm/%40acme/mcp-search@2.1.0",
+    "digest": "sha256:" + "a" * 64,
+}
+_MISSING = object()
+
+
+def _signed_with_cnf(cnf: object = _MISSING):
+    key = generate_key()
+    record = build_record(
+        kind="publisher-asserted",
+        publisher="did:web:acme.example",
+        tools=TOOLS,
+        artifact=ARTIFACT,
+    )
+    if cnf is not _MISSING:
+        record["cnf"] = cnf
+    body = _canonical_bytes(record)
+    signature = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
+    return {**record, "signature": signature}, key_to_jwk(key)
+
+
+@pytest.mark.parametrize(
+    "bad_cnf",
+    [
+        "not-an-object",
+        ["unexpected"],
+        1,
+        True,
+        "",
+        [],
+        0,
+        False,
+    ],
+)
+def test_non_object_cnf_is_refused_through_provenance_error(bad_cnf) -> None:
+    record, trusted = _signed_with_cnf(bad_cnf)
+    with pytest.raises(ProvenanceError, match="cnf must be an object"):
+        verify_record(record, trusted)
+
+
+@pytest.mark.parametrize("cnf", [_MISSING, None, {}])
+def test_missing_null_and_empty_object_cnf_preserve_existing_behavior(cnf) -> None:
+    record, trusted = _signed_with_cnf(cnf)
+    verify_record(record, trusted)
+
+
+def test_valid_embedded_cnf_jwk_still_verifies() -> None:
+    key = generate_key()
+    trusted = key_to_jwk(key)
+    record = build_record(
+        kind="publisher-asserted",
+        publisher="did:web:acme.example",
+        tools=TOOLS,
+        artifact=ARTIFACT,
+    )
+    record["cnf"] = {"jwk": trusted}
+    body = _canonical_bytes(record)
+    record["signature"] = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
+
+    verify_record(record, trusted)


### PR DESCRIPTION
## What

Closes #251.

`provenance.verify_record()` now establishes `cnf` through the existing `_as_object()` boundary before reading `jwk`.

This keeps malformed externally supplied `cnf` values inside the verifier's documented `ProvenanceError` rejection boundary instead of:

- leaking `AttributeError` for truthy non-object values; or
- laundering falsey non-object values through `(... or {})` as though `cnf` were absent.

Missing `cnf`, explicit `null`, an empty object, and a valid embedded JWK keep their existing behavior.

## Scope

No schema or normative specification change. No new validator is introduced; this reuses the object-boundary helper already used for `identity` and `tool_catalog` in the same function.

## Regression evidence

The added matrix signs the actual malformed/edge records with the trusted key before verification, so a rejection cannot be attributed to an unrelated invalid signature.

Covered controls:

- truthy non-objects: string, list, integer, boolean;
- falsey non-objects: empty string, empty list, zero, false;
- missing / `null` / `{}` controls;
- valid embedded `cnf.jwk` control.

Mutation property: restoring the old `(record.get("cnf") or {}).get("jwk")` path makes the truthy vectors escape through host-language exceptions and the falsey vectors cease to be rejected.

## Non-claim

This is exception-safety and API-contract consistency in the MCP provenance verifier. It does not change provenance trust semantics or claim a cryptographic vulnerability.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial matrix design, and drafting. `altrudev` reviewed the bounded claim and remains responsible for the contribution.