### PR TITLE
fix(content-marking): require record.alg during verification

### DIFF
--- a/src/agentrust_trace/content_marking.py
+++ b/src/agentrust_trace/content_marking.py
@@ -145,7 +145,7 @@ def verify_assertion(assertion: dict[str, Any], record_bytes: bytes) -> dict[str
     ref = data.get("record")
     if not isinstance(ref, dict) or not ref.get("url"):
         raise ContentMarkingError("assertion carries no record reference")
-    alg = ref.get("alg", "sha256")
+    alg = ref.get("alg")
     expected = ref.get("hash")
     if not _DIGEST_RE.match(str(expected or "")):
         raise ContentMarkingError(f"record.hash {expected!r} is not a sha256:/sha384: digest")

--- a/src/agentrust_trace/content_marking.py
+++ b/src/agentrust_trace/content_marking.py
@@ -48,7 +48,7 @@ class RecordMismatch(ContentMarkingError):
 
     Its own type because it means something different from a malformed
     assertion: the document is well-formed and the thing it points at changed
-    after the asset was signed.
+after the asset was signed.
     """
 
 
@@ -146,6 +146,10 @@ def verify_assertion(assertion: dict[str, Any], record_bytes: bytes) -> dict[str
     if not isinstance(ref, dict) or not ref.get("url"):
         raise ContentMarkingError("assertion carries no record reference")
     alg = ref.get("alg")
+    if not isinstance(alg, str):
+        raise ContentMarkingError(
+            f"unsupported digest algorithm {alg!r}; use sha256 or sha384"
+        )
     expected = ref.get("hash")
     if not _DIGEST_RE.match(str(expected or "")):
         raise ContentMarkingError(f"record.hash {expected!r} is not a sha256:/sha384: digest")

--- a/src/agentrust_trace/content_marking.py
+++ b/src/agentrust_trace/content_marking.py
@@ -48,7 +48,7 @@ class RecordMismatch(ContentMarkingError):
 
     Its own type because it means something different from a malformed
     assertion: the document is well-formed and the thing it points at changed
-after the asset was signed.
+    after the asset was signed.
     """
 
 

--- a/tests/test_content_marking_required_alg.py
+++ b/tests/test_content_marking_required_alg.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentrust_trace.content_marking import ContentMarkingError, build_assertion, verify_assertion
+
+URL = "https://registry.example/records/abc123.json"
+
+
+def _record_bytes() -> bytes:
+    return json.dumps(
+        {
+            "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+            "iat": 1760000000,
+            "subject": "spiffe://example.org/agent/image-bot",
+            "data_class": "public",
+        }
+    ).encode()
+
+
+def test_missing_record_alg_is_refused_instead_of_defaulting_to_sha256() -> None:
+    raw = _record_bytes()
+    assertion = build_assertion(raw, url=URL)
+    del assertion["data"]["record"]["alg"]
+
+    with pytest.raises(ContentMarkingError, match="unsupported digest algorithm None"):
+        verify_assertion(assertion, raw)
+
+
+def test_null_record_alg_is_refused() -> None:
+    raw = _record_bytes()
+    assertion = build_assertion(raw, url=URL)
+    assertion["data"]["record"]["alg"] = None
+
+    with pytest.raises(ContentMarkingError, match="unsupported digest algorithm None"):
+        verify_assertion(assertion, raw)
+
+
+def test_explicit_sha256_and_sha384_still_verify() -> None:
+    raw = _record_bytes()
+    verify_assertion(build_assertion(raw, url=URL, alg="sha256"), raw)
+    verify_assertion(build_assertion(raw, url=URL, alg="sha384"), raw)

--- a/tests/test_content_marking_required_alg.py
+++ b/tests/test_content_marking_required_alg.py
@@ -34,7 +34,20 @@ def test_null_record_alg_is_refused() -> None:
     assertion = build_assertion(raw, url=URL)
     assertion["data"]["record"]["alg"] = None
 
+    # Pins the plausible near-miss where explicit null is treated as "unset"
+    # and silently replaced with the old SHA-256 default.
     with pytest.raises(ContentMarkingError, match="unsupported digest algorithm None"):
+        verify_assertion(assertion, raw)
+
+
+@pytest.mark.parametrize("bad_alg", [[1], [], {"a": 1}, {}])
+def test_unhashable_record_alg_is_refused_without_type_error(bad_alg) -> None:
+    raw = _record_bytes()
+    assertion = build_assertion(raw, url=URL)
+    assertion["data"]["record"]["alg"] = bad_alg
+    assertion["data"]["record"]["hash"] = "nope"
+
+    with pytest.raises(ContentMarkingError, match="unsupported digest algorithm"):
         verify_assertion(assertion, raw)
 
 


### PR DESCRIPTION
## What

Closes #253.

`content_marking.verify_assertion()` no longer invents SHA-256 when the signed assertion omits required `record.alg`.

The companion specification marks `record.alg` as required and permits `sha256` or `sha384`. The verifier previously used:

```python
alg = ref.get("alg", "sha256")
```

so a peer-produced assertion with no algorithm member could still verify when its digest happened to be SHA-256. The producer already emits the field; the gap was consumer-side validation of externally supplied assertions.

The verifier now reads the actual member and establishes that it is a string before passing it to `_digest()`:

```python
alg = ref.get("alg")
if not isinstance(alg, str):
    raise ContentMarkingError(...)
```

This both clears the static type boundary and prevents unhashable list/dict values from escaping as Python `TypeError` through `_ALGS` membership.

## Regression coverage

Focused tests cover:

- missing `record.alg` -> refusal rather than a SHA-256 default;
- `record.alg: null` -> refusal, including the plausible "null means unset/default" near-miss;
- unhashable list/dict algorithm values -> `ContentMarkingError`, never `TypeError`, even when the hash is malformed too;
- explicit SHA-256 -> unchanged success;
- explicit SHA-384 -> unchanged success.

The existing unsupported-algorithm producer test remains unchanged.

## Scope

No wire-format, schema, or normative text change. No algorithm-confusion or cryptographic vulnerability claim: this is required-field enforcement, primitive-type establishment, and signed-claim completeness in the reference consumer.

The released CI failure on the original head was the mypy `Any | None` argument passed to `_digest`. The current head contains the reviewed type narrowing and focused mutation-oriented coverage; fresh repository CI is still awaiting workflow approval and is not claimed green until it executes.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, CI reconciliation, and diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.