### PR TITLE
fix(provenance): enforce tool_catalog.tool_count

### DIFF
--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -66,6 +66,14 @@ def _as_object(value: Any, field: str) -> dict[str, Any]:
     return value
 
 
+def _tool_count(catalog: dict[str, Any]) -> int:
+    """Return the required catalog count as a JSON integer."""
+    value = catalog.get("tool_count")
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ProvenanceError("tool_catalog.tool_count must be a non-negative integer")
+    return value
+
+
 class ToolCatalogMismatch(ProvenanceError):
     """The server offered a tool set the record does not describe.
 
@@ -344,6 +352,7 @@ def verify_record(
     catalog = _as_object(record.get("tool_catalog"), "tool_catalog")
     if not _DIGEST_RE.match(str(catalog.get("hash", ""))):
         raise ProvenanceError("tool_catalog.hash is not a sha256: digest")
+    _tool_count(catalog)
 
     # Freshness. `issued_at` has been required and type-checked since the format
     # existed, with an error message explaining that a record with no issue time
@@ -442,4 +451,10 @@ def check_tool_catalog(record: dict[str, Any], tools: list[dict[str, Any]]) -> N
             f"({len(tools)} tools offered, record declares {declared_count}). "
             "The signature may be perfectly valid; this is about the server, not the "
             "document."
+        )
+    declared_count = _tool_count(catalog)
+    if declared_count != len(tools):
+        raise ProvenanceError(
+            f"tool_catalog.tool_count declares {declared_count} tools, but the matching "
+            f"catalog contains {len(tools)}"
         )

--- a/tests/test_provenance_tool_count.py
+++ b/tests/test_provenance_tool_count.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from agentrust_trace.provenance import (
+    ProvenanceError,
+    ToolCatalogMismatch,
+    build_record,
+    check_tool_catalog,
+    sign_record,
+    verify_record,
+)
+from agentrust_trace.sign import generate_key, key_to_jwk
+
+TOOLS = [
+    {
+        "name": "search",
+        "description": "search the docs",
+        "input_schema": {"type": "object"},
+    },
+    {
+        "name": "fetch",
+        "description": "fetch a page",
+        "input_schema": {"type": "object"},
+    },
+]
+ARTIFACT = {
+    "package": "pkg:npm/%40acme/mcp-search@2.1.0",
+    "digest": "sha256:" + "a" * 64,
+}
+_MISSING = object()
+
+
+def _signed_with_count(count: object = _MISSING):
+    key = generate_key()
+    record = build_record(
+        kind="publisher-asserted",
+        publisher="did:web:acme.example",
+        tools=TOOLS,
+        artifact=ARTIFACT,
+    )
+    if count is _MISSING:
+        del record["tool_catalog"]["tool_count"]
+    else:
+        record["tool_catalog"]["tool_count"] = count
+    return sign_record(record, key), key_to_jwk(key)
+
+
+@pytest.mark.parametrize("bad_count", [_MISSING, -1, True, "2", None])
+def test_verify_record_refuses_malformed_or_missing_tool_count(bad_count) -> None:
+    record, trusted = _signed_with_count(bad_count)
+    with pytest.raises(ProvenanceError, match="tool_catalog.tool_count must be"):
+        verify_record(record, trusted)
+
+
+@pytest.mark.parametrize("bad_count", [2.0, "2", True, -1, None])
+def test_check_tool_catalog_alone_refuses_malformed_count(bad_count) -> None:
+    record, _ = _signed_with_count(bad_count)
+    with pytest.raises(ProvenanceError, match="tool_catalog.tool_count must be"):
+        check_tool_catalog(record, TOOLS)
+
+
+def test_wrong_positive_count_is_detected_when_live_catalog_is_checked() -> None:
+    record, trusted = _signed_with_count(999)
+
+    verify_record(record, trusted)
+    with pytest.raises(ProvenanceError, match="declares 999 tools") as excinfo:
+        check_tool_catalog(record, TOOLS)
+    assert not isinstance(excinfo.value, ToolCatalogMismatch)
+
+
+def test_correct_count_and_hash_still_verify() -> None:
+    record, trusted = _signed_with_count(len(TOOLS))
+    verify_record(record, trusted)
+    check_tool_catalog(record, TOOLS)
+
+
+def test_hash_mismatch_remains_a_tool_catalog_mismatch() -> None:
+    record, trusted = _signed_with_count(len(TOOLS))
+    verify_record(record, trusted)
+
+    offered = [TOOLS[0]]
+    with pytest.raises(ToolCatalogMismatch, match="about the server, not the document"):
+        check_tool_catalog(record, offered)
+
+
+def test_hash_mismatch_outranks_a_malformed_count() -> None:
+    record, _ = _signed_with_count("2")
+    with pytest.raises(ToolCatalogMismatch):
+        check_tool_catalog(record, [TOOLS[0]])


### PR DESCRIPTION
## Current restack

Restacked onto current `main` at `98aae176aa9ae4053d944624dad7629c76789ff7`.

Exact head: `251c8b6efe1cd722d166ed734c83c47a9a77d583`.

The branch is one commit ahead / zero behind and changes exactly the same two files. Fresh exact-head CI and CodeQL both pass. The previous `@lywinged` approval was on pre-restack head `7b4ee0ba103ec369fb3d1bd8056b29964190f6e0` and was correctly dismissed by GitHub after the rewrite; no exact-head approval is claimed.

## What

Closes #256.

The server-provenance format marks `tool_catalog.tool_count` as required, but the reference consumer never made it load-bearing. A correctly signed record could carry the right catalog hash for two tools and `tool_count: 999`; both `verify_record()` and `check_tool_catalog()` still succeeded.

This change adds one shared `_tool_count()` boundary and uses it from both consumer entry points:

- `verify_record()` now requires a non-negative JSON integer and excludes `bool` explicitly;
- `check_tool_catalog()` validates the same field even when called independently;
- after the live hash matches, `check_tool_catalog()` checks that the signed count equals the number of offered tools.

## Error semantics

The existing distinction is preserved.

- If the live catalog hash differs, `ToolCatalogMismatch` still means the signed paper may be fine and the server in front of the verifier is different.
- If the hash matches but the signed count disagrees with the matching live list, the record contradicts its own catalog metadata. That is a plain `ProvenanceError`, not `ToolCatalogMismatch`.

## Regression coverage

Focused tests cover:

- missing count;
- negative count;
- boolean count;
- string count;
- `null` count;
- floating-point count, pinning the JSON-integer boundary;
- independent `check_tool_catalog()` validation of malformed counts;
- hash mismatch outranking malformed-count validation;
- correct hash with wrong positive count;
- correct hash and count control;
- ordinary live hash mismatch preserving `ToolCatalogMismatch`.

The wrong-positive-count test deliberately verifies the paper first, then proves the live catalog check is the step that makes the semantic count disagreement load-bearing.

## Scope

No wire-format or schema change is made here. This PR does change the reference consumer's live-catalog semantics by making the signed count load-bearing after a matching hash. The current `spec/server-provenance-v1.md` §5 steps do not explicitly require that live-count comparison, so whether the normative text should be aligned is left to the maintainers/spec process rather than claimed as settled by this implementation PR.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, restack preparation, and exact-diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.