### PR TITLE
fix(provenance): require cnf.jwk during verification

### DIFF
--- a/src/agentrust_trace/provenance.py
+++ b/src/agentrust_trace/provenance.py
@@ -378,23 +378,25 @@ def verify_record(
 
     cnf = _as_object(record.get("cnf"), "cnf")
     embedded = cnf.get("jwk")
-    if embedded:
-        # Compared by RFC 7638 thumbprint, not by dict equality. A JWK is identified by
-        # its key material; `kid`, `use` and `alg` are optional members that carry none
-        # of it, and a key resolved from a JWKS endpoint normally has `kid` while
-        # `key_to_jwk` emits the bare minimum. Dict equality made that difference fatal
-        # and rejected records signed by exactly the right key.
-        from hmac import compare_digest
+    if not embedded:
+        raise ProvenanceError("record carries no cnf.jwk")
 
-        try:
-            matched = compare_digest(jwk_thumbprint(embedded), jwk_thumbprint(trusted_jwk))
-        except ValueError as exc:
-            raise ProvenanceError(f"the record's embedded key is unusable: {exc}") from exc
-        if not matched:
-            raise ProvenanceError(
-                "the record's embedded key is not the trusted key. A record signed by "
-                "some other key is a record about a server somebody else is describing."
-            )
+    # Compared by RFC 7638 thumbprint, not by dict equality. A JWK is identified by
+    # its key material; `kid`, `use` and `alg` are optional members that carry none
+    # of it, and a key resolved from a JWKS endpoint normally has `kid` while
+    # `key_to_jwk` emits the bare minimum. Dict equality made that difference fatal
+    # and rejected records signed by exactly the right key.
+    from hmac import compare_digest
+
+    try:
+        matched = compare_digest(jwk_thumbprint(embedded), jwk_thumbprint(trusted_jwk))
+    except ValueError as exc:
+        raise ProvenanceError(f"the record's embedded key is unusable: {exc}") from exc
+    if not matched:
+        raise ProvenanceError(
+            "the record's embedded key is not the trusted key. A record signed by "
+            "some other key is a record about a server somebody else is describing."
+        )
 
     pub = _pubkey_from_jwk(trusted_jwk)
     body = _canonical_bytes({k: v for k, v in record.items() if k != "signature"})

--- a/tests/test_provenance_cnf_boundary.py
+++ b/tests/test_provenance_cnf_boundary.py
@@ -55,10 +55,11 @@ def test_non_object_cnf_is_refused_through_provenance_error(bad_cnf) -> None:
         verify_record(record, trusted)
 
 
-@pytest.mark.parametrize("cnf", [_MISSING, None, {}])
-def test_missing_null_and_empty_object_cnf_preserve_existing_behavior(cnf) -> None:
+@pytest.mark.parametrize("cnf", [_MISSING, None, {}, {"jwk": None}])
+def test_missing_or_empty_cnf_jwk_is_refused(cnf) -> None:
     record, trusted = _signed_with_cnf(cnf)
-    verify_record(record, trusted)
+    with pytest.raises(ProvenanceError, match="no cnf.jwk"):
+        verify_record(record, trusted)
 
 
 def test_valid_embedded_cnf_jwk_still_verifies() -> None:

--- a/tests/test_provenance_cnf_boundary.py
+++ b/tests/test_provenance_cnf_boundary.py
@@ -55,7 +55,7 @@ def test_non_object_cnf_is_refused_through_provenance_error(bad_cnf) -> None:
         verify_record(record, trusted)
 
 
-@pytest.mark.parametrize("cnf", [_MISSING, None, {}, {"jwk": None}])
+@pytest.mark.parametrize("cnf", [_MISSING, None, {}, {"jwk": None}, {"jwk": {}}])
 def test_missing_or_empty_cnf_jwk_is_refused(cnf) -> None:
     record, trusted = _signed_with_cnf(cnf)
     with pytest.raises(ProvenanceError, match="no cnf.jwk"):


### PR DESCRIPTION
## Dependency

**Resolved.** #252 has merged into `main`, and this PR has been restacked onto that merged base. The predecessor commits are no longer part of this diff.

Restacked head: `62add138cf29de78fb6d35ec383c45972f64ae0d`.

Closes #255.

## What

The server-provenance format marks `cnf.jwk` as required. After #252, `verify_record()` safely establishes `cnf` as an object, but missing, `null`, or empty `cnf` still preserves the old behavior: the embedded confirmation-key check is skipped and the record is verified only against the externally supplied trusted key.

This follow-on makes the required signed binding load-bearing:

```python
cnf = _as_object(record.get("cnf"), "cnf")
embedded = cnf.get("jwk")
if not embedded:
    raise ProvenanceError("record carries no cnf.jwk")
```

The existing RFC 7638 thumbprint comparison then runs unconditionally for a present key.

## Regression coverage

The #252 matrix is retained for non-object `cnf` values. Its missing/`null`/empty-object control is deliberately changed to the required-field rule, and extended with falsey embedded-JWK cases that pin the `if not embedded` guard:

- truthy and falsey non-object `cnf` -> `ProvenanceError` from the object boundary;
- missing `cnf` -> `ProvenanceError`;
- `cnf: null` -> `ProvenanceError`;
- `cnf: {}` -> `ProvenanceError`;
- `cnf: {"jwk": null}` -> `ProvenanceError`;
- `cnf: {"jwk": {}}` -> `ProvenanceError`;
- valid matching embedded JWK -> unchanged success.

The records are signed over the exact malformed/edge bodies with the externally trusted key, so the refusal is not attributable to an unrelated bad signature.

## Scope

No new trust-anchor mechanism and no unauthenticated-forgery claim. The external trusted key still gates authentication. This makes the reference verifier enforce the confirmation-key member the provenance format already marks required.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, stacked-branch preparation, and diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.