### PR TITLE
spec: disclosed gaps in a receipt chain, and the receipt_gap_disclosed outcome (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Format: [Semantic Versioning](https://semver.org/). Spec versions follow `MAJOR.
 
 ## [Unreleased]
 
+### Added
+
+- **Section 3.3.4: disclosed gaps in a receipt chain (#117).** Under a profile requiring action receipts, a specification that offers only "complete" and "broken" rewards concealment: an operator who backfills a lost receipt scores better than one who reports the loss. A `GapDisclosure` is a signed chain element stating that receipts which would have occupied its position were never emitted. Coverage is structural rather than asserted: the disclosure links back to the element before the gap, the next element emitted links back to the disclosure, and verification is two link checks a verifier already performs on every ordinary element. No range fields exist, because a hash chain cannot express a range and an emitter cannot know its successor's hash at write time.
+
+  The action-receipt outcome `receipt_missing_required` is narrowed to silent absence, and `receipt_gap_disclosed` is added beside it, distinct by requirement, with acceptance a verifier policy input. It never satisfies a profile requiring independently proven completeness: a disclosed gap does not establish that the missing receipts existed, how many were lost, or that omission was not selective. A disclosure at the live tail, where no successor exists to seal it, is unverified rather than disclosed or invalid: a chain truncated immediately after a disclosure is indistinguishable from an honest tail, so whatever the tail is granted, truncation is granted too. Conformance vectors in `examples/action-receipts/gap-disclosure/`, two per rule with a byte-for-byte generator; the tail case is pinned by its own test. Proposed and authored from production operation of a per-action receipt emitter; carried per the maintainer-carry provision in CONTRIBUTING.
+
+  Two cross-references that predate the renumbering which introduced section 3.3.1 are updated to name section 3.3.2, where the text they cite now lives.
+
 ### Fixed
 
 - **The exported `SCHEMA` was the live object the validator reads.** `_schema()` is `lru_cache`d and `_validator()` is built over whatever it returns, so the name exposed "for downstream tooling that needs the raw dict" and the validator's schema were one object: lowering `SCHEMA["properties"]["iat"]["minimum"]` made a record dated 1970 valid to `validate_json()`, to `iter_errors()`, and to the structural gate inside `sign.verify_record()`, for every later call in the process. Nothing about the call site looks wrong, since adapting the raw dict is the use the comment invites. It is a deep copy now; a shallow one would leave the nested `properties` dicts shared and the same edit would still land.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -264,15 +264,16 @@ Keep the verification results separate:
 | Action issuance evidence | Canonical action digest, receipt signature, trusted issuer key, session or call binding, chain order | Successful physical completion |
 | Outcome evidence | Controller or monitor decision carried by the receipt payload | Functional-safety certification unless the issuer and profile explicitly claim it |
 
-For action receipts, a verifier should distinguish five common outcomes:
+For action receipts, a verifier should distinguish six common outcomes:
 
 | Outcome | Meaning |
 |---|---|
 | `receipt_valid_accepted` | The receipt is well-formed, trusted, bound to the call, and reports acceptance. |
 | `receipt_valid_rejected` | The receipt is well-formed, trusted, bound to the call, and reports controller or policy rejection. This is valid negative evidence. |
-| `receipt_missing_required` | The profile required a receipt, but none was present for the consequential action. |
+| `receipt_missing_required` | The profile required a receipt, and none was present for the consequential action, with no valid `GapDisclosure` occupying its position in the chain. Silent absence, treated as presumptively adversarial (spec section 3.3.4). |
+| `receipt_gap_disclosed` | Required receipts are absent, and a valid `GapDisclosure` occupies their position in the chain: the emitter reported the loss and sealed the report into the chain. Emitter-attested negative evidence, distinct from silence; whether it is accepted is a verifier policy input (spec section 3.3.4). |
 | `receipt_invalid` | The receipt is present but fails signature, digest, freshness, ordering, or call-binding checks against a key the verifier holds. |
-| `receipt_unverified` | The receipt names an issuer key the verifier has not pinned, and nothing else failed. Per section 3.3.1 of the spec this is unverified, not invalid: the receipt confers no trust and proves no wrongdoing, surfaced with an advisory rather than a failure. |
+| `receipt_unverified` | The receipt names an issuer key the verifier has not pinned, and nothing else failed. Per section 3.3.2 of the spec this is unverified, not invalid: the receipt confers no trust and proves no wrongdoing, surfaced with an advisory rather than a failure. |
 
 The key boundary is that a valid rejection is not malformed evidence. It is
 evidence that the downstream authority declined the action. A valid acceptance

--- a/examples/action-receipts/gap-disclosure/01-gap-disclosed-valid.json
+++ b/examples/action-receipts/gap-disclosure/01-gap-disclosed-valid.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosed-valid",
+  "description": "A disclosure spliced into the chain: it links back to a present element and the next element links back to it. Coverage is structural, so nothing is asserted about a range.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:cf36ee4d9b9dd71cb37c34dc57bcdacbb3c7b3ef42615a48409c2c4463c1b3d3",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_gap_disclosed",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "receipt_gap_disclosed"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/02-gap-disclosure-dangling-predecessor.json
+++ b/examples/action-receipts/gap-disclosure/02-gap-disclosure-dangling-predecessor.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-dangling-predecessor",
+  "description": "The disclosure links back to an element that is not in the chain. Half a splice is not a splice: it fixes nothing in place.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": false,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:cf36ee4d9b9dd71cb37c34dc57bcdacbb3c7b3ef42615a48409c2c4463c1b3d3",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_predecessor_absent"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/03-gap-disclosure-successor-does-not-link.json
+++ b/examples/action-receipts/gap-disclosure/03-gap-disclosure-successor-does-not-link.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-successor-does-not-link",
+  "description": "The next element after resumption links past the disclosure to the element before the gap, leaving the disclosure attached at one end only. A disclosure no successor names can be minted later and slid over any gap.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_not_sealed_by_successor"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/04-gap-disclosure-contradicted.json
+++ b/examples/action-receipts/gap-disclosure/04-gap-disclosure-contradicted.json
@@ -1,0 +1,74 @@
+{
+  "name": "gap-disclosure-contradicted",
+  "description": "Elements the disclosure implies are absent are present in the chain. A self-contradictory disclosure impeaches the emitter rather than excusing it.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:cf36ee4d9b9dd71cb37c34dc57bcdacbb3c7b3ef42615a48409c2c4463c1b3d3",
+      "successor_present": true,
+      "claimed_absent_but_present": [
+        "sha256:c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9"
+      ],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_contradicted"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/05-gap-disclosure-foreign-key.json
+++ b/examples/action-receipts/gap-disclosure/05-gap-disclosure-foreign-key.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-foreign-key",
+  "description": "Signed by a key the verifier trusts, but which is neither the key that signed the linked element nor an ancestor of it. A gap is where introducing an unrelated key is most useful and least distinguishable from recovery.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:3c543561f448216d7569a5c3f6edabfb4694ef3d79ab5bc4998d2d1d0c47980a",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "k1OEGRftz9gN8m6CWBaM_MHoi9pSleIws7Y3gS4AWPYDIgq_76ljP9ZQCmMlLapC8L059matDjbQKK0Vj36YBQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_issuer_not_chain_key"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/06-gap-disclosed-parent-key-null-estimate.json
+++ b/examples/action-receipts/gap-disclosure/06-gap-disclosed-parent-key-null-estimate.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosed-parent-key-null-estimate",
+  "description": "Signed by the hierarchical parent, because the crash took the session key with it, and the count of lost receipts is not bounded. The estimate is an unverifiable self-report either way; the chain links are what hold.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:38617e4db9e0cb7279fe4f9b2f9938aa686692c4e56ed4451c4bd61286f37a9f",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 3
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-workload-attestation",
+    "cause": "crash",
+    "receipts_lost_estimate": null,
+    "signature": "SQpH6hCFdjHPDivRcHc0PYHgrpAVpsKEOu6w9WlSbDs7c5ktGsLmrehbUtco-6ulNHcvKderbqudHNF8bmalAw"
+  },
+  "expected": {
+    "status": "receipt_gap_disclosed",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "receipt_gap_disclosed"
+    ],
+    "consecutive_disclosures": 3,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/07-gap-disclosure-unknown-key.json
+++ b/examples/action-receipts/gap-disclosure/07-gap-disclosure-unknown-key.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-unknown-key",
+  "description": "The named key is the one that signed the linked element, but the verifier does not hold it. Chain position does not confer trust \u2014 and the verifier's ignorance does not prove forgery. Unverifiable is not invalid (spec section 3.3.2): the disclosure is surfaced as unverified with an advisory, conferring nothing and accusing no one.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2027q1",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:5f3d5ff3bb8b196a81cb9f1614adb226a840a2eb30a53ced9f85bbf883b587d7",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2027q1",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "3OVGq6kohVs6Eg8IBse-PQyZVszCPinjTDyGwMJGlf36rMoDivcyCgGxL6c6amIGnZ6S-0icgTehZJUCPpHlCg"
+  },
+  "expected": {
+    "status": "gap_disclosure_unverified",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "disclosure_key_unknown"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/08-gap-disclosure-tampered.json
+++ b/examples/action-receipts/gap-disclosure/08-gap-disclosure-tampered.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-tampered",
+  "description": "Altered after signing, so the signature no longer covers its contents.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:28c867b119337dafd739982482e612bab1667de1c993d2edeab303adc669cb50",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "shutdown",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_signature_invalid"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "shutdown"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/09-gap-disclosure-key-case-variant.json
+++ b/examples/action-receipts/gap-disclosure/09-gap-disclosure-key-case-variant.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-key-case-variant",
+  "description": "The trusted set pins the right public key under a case-variant of the disclosure's issuer_key_id. Key identifiers are opaque strings: holding the key under a different spelling is not holding the key the disclosure names.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:cf36ee4d9b9dd71cb37c34dc57bcdacbb3c7b3ef42615a48409c2c4463c1b3d3",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "DID:WEB:FACTORY.EXAMPLE:SAFETY-CONTROLLER#ED25519-2026Q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "gap_disclosure_unverified",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "disclosure_key_unknown"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/10-gap-disclosure-signature-malformed.json
+++ b/examples/action-receipts/gap-disclosure/10-gap-disclosure-signature-malformed.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-signature-malformed",
+  "description": "The signature is valid base64url of the wrong length. Together with the tampered vector this separates structural validation from verification.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:63a0d2c102e487b710cf8e130d9f680f71803efe9e089d0ffa233b5f41364b70",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_signature_invalid"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/11-gap-disclosure-confusable-ancestor-key.json
+++ b/examples/action-receipts/gap-disclosure/11-gap-disclosure-confusable-ancestor-key.json
@@ -1,0 +1,77 @@
+{
+  "name": "gap-disclosure-confusable-ancestor-key",
+  "description": "Signed by a trusted key whose id is the permitted ancestor's id in a different case \u2014 a confusable registration, not the ancestor. Entitlement to disclose is bound to the chain's exact key ids.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:c9419cb47d7089bdb592077bfc8affeb2d6442cca6b6eafc3d8fbf40f43ef19d",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    },
+    "did:web:factory.example:safety-controller#ED25519-WORKLOAD-ATTESTATION": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "VVaRCvqm79Hib-vDRkLCnvAjgtm_qNIedhrdnglPNac"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ED25519-WORKLOAD-ATTESTATION",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "q0OJTMnU3j87iGnqWe2zQ5seF8SAfKPUtRG3JztZtsdUWTYP8tj3pzG6w4QBNUxWDlDtGWd6GeWVUhLPGlAvBg"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_issuer_not_chain_key"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/12-gap-disclosure-replayed-stream.json
+++ b/examples/action-receipts/gap-disclosure/12-gap-disclosure-replayed-stream.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-replayed-stream",
+  "description": "A disclosure honestly signed for a different session, presented against this one. Every structural check passes \u2014 the splice is sound, the key is entitled \u2014 because the disclosure was genuine where it was minted. Stream binding is the only thing that refuses the transplant.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:27f335fe7549fa68a09b8711ee05eab7c54447a2a10fa73e728ee6fc237a054a",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-01T08:00:00Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "nB83NMX6qU8NdDpDG4c7hKb9_4Kj9JqxMJhlUeBu0kbad2DmHD3WceaLSnKgzxCbuHeVpkbSolUX8Z_cBjiTCA"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_stream_mismatch"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/13-gap-disclosure-stream-case-variant.json
+++ b/examples/action-receipts/gap-disclosure/13-gap-disclosure-stream-case-variant.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-stream-case-variant",
+  "description": "The disclosure's session_id is this session's id upper-cased. Session identifiers are opaque: a case-normalising comparison reads this as bound to the stream, and it is not.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:332a69b3a03bcf17c414870775ae8ccba14a7696e2d9c9c9b43797d8c7b2bc7a",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "TRACE-SESSION-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "YIfDSNIUmnPUG-VXDYOqeeyhPogEeH36pC4nIufeiuCk01M1mFVhIy6PjsXpOVb-n7JBqPV7AmqZVyH6H9TMDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_stream_mismatch"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/14-gap-disclosure-predecessor-link-tail.json
+++ b/examples/action-receipts/gap-disclosure/14-gap-disclosure-predecessor-link-tail.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-predecessor-link-tail",
+  "description": "The disclosure's previous_receipt_hash matches the present predecessor's hash in all but the final character. A link to almost the right element is a link to nothing.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:d300b19c0adb8f40d1891034e257d0b5c7a44d7fcacd271152cf3914fc8ab3c9",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a0",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "2QmCKKsvJiheUIv6QamvoQtkZ77Rjjj0lQgJRRM3dY30fEBn4_sgFArF_8v_3YoU62TivAFdkv5Oy7_L92IvDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_predecessor_absent"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a0",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/15-gap-disclosure-seal-tail-mismatch.json
+++ b/examples/action-receipts/gap-disclosure/15-gap-disclosure-seal-tail-mismatch.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-seal-tail-mismatch",
+  "description": "The next element's previous_receipt_hash matches the disclosure's digest in all but the final character: sealed to a truncated comparison, unsealed in fact.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:cf36ee4d9b9dd71cb37c34dc57bcdacbb3c7b3ef42615a48409c2c4463c1b3d0",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_not_sealed_by_successor"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/16-gap-disclosure-contradicted-at-tail.json
+++ b/examples/action-receipts/gap-disclosure/16-gap-disclosure-contradicted-at-tail.json
@@ -1,0 +1,76 @@
+{
+  "name": "gap-disclosure-contradicted-at-tail",
+  "description": "Elements the disclosure implies are absent are present, and the disclosure sits at the live tail with no successor yet. Self-contradiction impeaches the emitter wherever it stands.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": null,
+      "successor_present": false,
+      "claimed_absent_but_present": [
+        "sha256:c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9"
+      ],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_contradicted"
+    ],
+    "warnings": [
+      "disclosure_not_yet_sealed"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/17-gap-disclosure-at-unsealed-tail.json
+++ b/examples/action-receipts/gap-disclosure/17-gap-disclosure-at-unsealed-tail.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-at-unsealed-tail",
+  "description": "A well-formed disclosure at the live tail of the chain: signed by the chain key, linked to a present predecessor, and with no successor yet to seal it. Not invalid \u2014 nothing is defective \u2014 and not disclosed either: half a splice covers nothing until the chain resumes and the seal can be checked. Re-verification after resumption upgrades it.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": null,
+      "successor_present": false,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "gap_disclosure_unverified",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "disclosure_not_yet_sealed"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/18-gap-disclosure-tail-with-stale-link.json
+++ b/examples/action-receipts/gap-disclosure/18-gap-disclosure-tail-with-stale-link.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-tail-with-stale-link",
+  "description": "The same unsealed tail, but the successor-link field in the verification context holds a leftover value from a previous verification. There is still no successor: sealed-ness is a fact about the chain, not about a field being non-null.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7",
+      "successor_present": false,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/1.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "0WTbD_j2neboOUN8WmkWbVweYp0R-rYWb53LnWWjSomFzAtiZlHDmbKBVbVQ_dlpOj7ZN8cWz6WWzsCwGyCQDQ"
+  },
+  "expected": {
+    "status": "gap_disclosure_unverified",
+    "controller_outcome": "unknown",
+    "failures": [],
+    "warnings": [
+      "disclosure_not_yet_sealed"
+    ],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/19-gap-disclosure-type-version-unknown.json
+++ b/examples/action-receipts/gap-disclosure/19-gap-disclosure-type-version-unknown.json
@@ -1,0 +1,72 @@
+{
+  "name": "gap-disclosure-type-version-unknown",
+  "description": "A well-signed disclosure whose type names a version this verifier does not implement. An unknown version is rejected rather than parsed best-effort.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:2072655dec5d5535d56acfaf1d006ce9118eeca871b05e01190e5f3789661c6b",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "type": "GapDisclosure/2.0",
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "xtjWyVMJzp4Bdx7cl537-cUK-L9RLo9QfBbgVWdM0GXWR6Wov-qWIy9NBd71bbGxST-YegDK83C_jTr-xFDmBg"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_type_unsupported"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/20-gap-disclosure-type-absent.json
+++ b/examples/action-receipts/gap-disclosure/20-gap-disclosure-type-absent.json
@@ -1,0 +1,71 @@
+{
+  "name": "gap-disclosure-type-absent",
+  "description": "A well-signed disclosure with no type member at all. A presence check and an equality check differ exactly here.",
+  "profile": "trace.action_receipt.conformance.v0",
+  "source": {
+    "issue": "agentrust-io/trace-spec#117",
+    "spec": "spec/trace-v0.2.md section 3.3.4"
+  },
+  "context": {
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "require_receipt": true,
+    "verification_time": "2026-07-06T15:24:00Z",
+    "max_receipt_age_seconds": 300,
+    "expected_previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "chain": {
+      "predecessor_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+      "predecessor_present": true,
+      "predecessor_issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+      "permitted_ancestor_key_ids": [
+        "did:web:factory.example:safety-controller#ed25519-workload-attestation"
+      ],
+      "successor_previous_receipt_hash": "sha256:e0832935b71ce78048d0ccfc80a5d451b3ae1fb87d1d0af24b4f567459935232",
+      "successor_present": true,
+      "claimed_absent_but_present": [],
+      "consecutive_disclosures": 1
+    }
+  },
+  "action": {
+    "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+    "action_type": "ros2.action.example_interfaces/Fibonacci",
+    "action_scope": "/abort_fibonacci_process",
+    "action_timestamp": "2026-07-06T15:22:13Z",
+    "action_ref": "sha256:e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3"
+  },
+  "trusted_issuer_keys": {
+    "did:web:factory.example:safety-controller#ed25519-2026q3": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+    },
+    "did:web:factory.example:safety-controller#ed25519-workload-attestation": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "Kay64UG8yvCyLhqU000LxzYeUm0L_hLIl5S8kyKWbdc"
+    },
+    "did:web:factory.example:safety-controller#ed25519-unrelated-but-trusted": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "XUDXAF07AOpCkKoxJLKnzU4nNa4X8rnk_j3gAv82Rig"
+    }
+  },
+  "gap_disclosure": {
+    "previous_receipt_hash": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "session_id": "trace-session-2026-07-06T15:22:11Z",
+    "issuer_key_id": "did:web:factory.example:safety-controller#ed25519-2026q3",
+    "cause": "crash",
+    "receipts_lost_estimate": 3,
+    "signature": "hS5tYu3UoPEiqdsO_FI0HCzomdvOYrwRXUpTO3OAGK7AuDTCNaHsWXiqH_4RRQMumOzTofkJTPGd8YC24u29Aw"
+  },
+  "expected": {
+    "status": "receipt_invalid",
+    "controller_outcome": "unknown",
+    "failures": [
+      "disclosure_type_unsupported"
+    ],
+    "warnings": [],
+    "consecutive_disclosures": 1,
+    "linked_predecessor": "sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+    "cause": "crash"
+  }
+}

--- a/examples/action-receipts/gap-disclosure/gen_gap_disclosure_vectors.py
+++ b/examples/action-receipts/gap-disclosure/gen_gap_disclosure_vectors.py
@@ -1,0 +1,461 @@
+"""Regenerate the gap-disclosure fixtures under the splice model.
+
+A disclosure is a chain element, not a description of a range: the argument for that
+shape is in spec/trace-v0.2.md section 3.3.4 and the review on
+agentrust-io/trace-spec#117. Deterministic keys; public JWKs only.
+
+01-08 are one vector per rule. 09-16 are the second set (upstream #124: two
+independent vectors per rule), each placed against an implementation shortcut its
+partner cannot detect — case-normalised key and session lookups, digest comparisons
+truncated to a prefix, structural signature validation, and a contradiction check
+gated on the sealed path. 12 and 13 cover `disclosure_stream_mismatch`, the rule the
+#117 review asked for: a disclosure must be bound to the receipt stream it excuses,
+or one honestly signed for stream A is a transplantable excuse for a gap in stream B.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import rfc8785
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+OUT = Path(__file__).resolve().parent
+PROFILE = "trace.action_receipt.conformance.v0"
+SESSION = "trace-session-2026-07-06T15:22:11Z"
+ISSUER = "did:web:factory.example:safety-controller"
+
+# The key that signed the element before the gap. Under the splice model this is the
+# only key entitled to disclose, together with its ancestors.
+KEY_ID = f"{ISSUER}#ed25519-2026q3"
+PARENT_KEY_ID = f"{ISSUER}#ed25519-workload-attestation"
+FOREIGN_KEY_ID = f"{ISSUER}#ed25519-unrelated-but-trusted"
+
+KEY = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+PARENT = Ed25519PrivateKey.from_private_bytes(bytes(range(32, 64)))
+FOREIGN = Ed25519PrivateKey.from_private_bytes(
+    hashlib.sha256(b"trace-spec#117 unrelated trusted key").digest()
+)
+
+# A distinct keypair registered under a case-variant of the parent's key id: the
+# confusable-identifier attack, for vector 11. Key ids are opaque strings, so the
+# variant names a different key, not the parent.
+CONFUSABLE_KEY_ID = f"{ISSUER}#ED25519-WORKLOAD-ATTESTATION"
+CONFUSABLE = Ed25519PrivateKey.from_private_bytes(
+    hashlib.sha256(b"trace-spec#117 confusable ancestor key").digest()
+)
+
+PREDECESSOR_HASH = "sha256:" + "a1" * 32
+
+# The two outcome names this set defines, held once each. #117's carry note expects
+# the disclosed outcome to keep its semantics and possibly not its name under the
+# vocabulary being unified across the "not established" threads; a rename is an edit
+# here, its twin in the fixture test, the spec section, the docs row, and one
+# regeneration.
+DISCLOSED = "receipt_gap_disclosed"
+UNVERIFIED = "gap_disclosure_unverified"
+
+
+def b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def jwk(key: Ed25519PrivateKey) -> dict[str, str]:
+    return {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": b64u(
+            key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        ),
+    }
+
+
+def digest(value: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(value)).hexdigest()
+
+
+def sign(disclosure: dict[str, Any], key: Ed25519PrivateKey) -> dict[str, Any]:
+    body = {k: v for k, v in disclosure.items() if k != "signature"}
+    return {**disclosure, "signature": b64u(key.sign(rfc8785.dumps(body)))}
+
+
+TRUSTED = {KEY_ID: jwk(KEY), PARENT_KEY_ID: jwk(PARENT), FOREIGN_KEY_ID: jwk(FOREIGN)}
+
+
+def base_disclosure() -> dict[str, Any]:
+    return {
+        "type": "GapDisclosure/1.0",
+        "previous_receipt_hash": PREDECESSOR_HASH,
+        "session_id": SESSION,
+        "issuer_key_id": KEY_ID,
+        "cause": "crash",
+        "receipts_lost_estimate": 3,
+    }
+
+
+def base_context(**over: Any) -> dict[str, Any]:
+    ctx: dict[str, Any] = {
+        "session_id": SESSION,
+        "require_receipt": True,
+        "verification_time": "2026-07-06T15:24:00Z",
+        "max_receipt_age_seconds": 300,
+        "expected_previous_receipt_hash": PREDECESSOR_HASH,
+        "chain": {
+            # The element the disclosure links back to, and whether it is in the chain.
+            "predecessor_hash": PREDECESSOR_HASH,
+            "predecessor_present": True,
+            # Who signed it. Issuer binding is derived from this, not supplied.
+            "predecessor_issuer_key_id": KEY_ID,
+            "permitted_ancestor_key_ids": [PARENT_KEY_ID],
+            # What the next emitted element links back to. Filled in per fixture once
+            # the disclosure has been signed and its digest is known.
+            "successor_previous_receipt_hash": None,
+            "successor_present": True,
+            # Elements the disclosure implicitly claims are absent but which are in
+            # fact present in the chain.
+            "claimed_absent_but_present": [],
+            "consecutive_disclosures": 1,
+        },
+    }
+    ctx["chain"].update(over)
+    return ctx
+
+
+def fixture(
+    name: str,
+    description: str,
+    disclosure: dict[str, Any],
+    expected: dict[str, Any],
+    context: dict[str, Any],
+    *,
+    link_successor: bool = True,
+    trusted: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if link_successor and context["chain"]["successor_previous_receipt_hash"] is None:
+        context["chain"]["successor_previous_receipt_hash"] = digest(disclosure)
+    return {
+        "name": name,
+        "description": description,
+        "profile": PROFILE,
+        "source": {
+            "issue": "agentrust-io/trace-spec#117",
+            "spec": "spec/trace-v0.2.md section 3.3.4",
+        },
+        "context": context,
+        "action": {
+            "agent_id": "spiffe://factory.example/agent/ros2-fibonacci/dev",
+            "action_type": "ros2.action.example_interfaces/Fibonacci",
+            "action_scope": "/abort_fibonacci_process",
+            "action_timestamp": "2026-07-06T15:22:13Z",
+            "action_ref": "sha256:" + "e3" * 32,
+        },
+        "trusted_issuer_keys": trusted if trusted is not None else TRUSTED,
+        "gap_disclosure": disclosure,
+        "expected": {
+            **expected,
+            # Reporting (spec section 3.3.4): each disclosed gap is reported with the
+            # predecessor it links and the cause when one was supplied. Echoed from
+            # the disclosure as carried, never judged: a tampered cause is reported
+            # as carried and refused by the signature rule, not by this field.
+            "linked_predecessor": disclosure.get("previous_receipt_hash"),
+            "cause": disclosure.get("cause"),
+        },
+    }
+
+
+def ok(consecutive: int = 1) -> dict[str, Any]:
+    return {
+        "status": DISCLOSED,
+        "controller_outcome": "unknown",
+        "failures": [],
+        "warnings": [DISCLOSED],
+        "consecutive_disclosures": consecutive,
+    }
+
+
+def bad(*failures: str) -> dict[str, Any]:
+    return {
+        "status": "receipt_invalid",
+        "controller_outcome": "unknown",
+        "failures": list(failures),
+        "warnings": [],
+        "consecutive_disclosures": 1,
+    }
+
+
+def unverified(*advisories: str) -> dict[str, Any]:
+    """Unverifiable is not invalid (spec section 3.3.2): advisory, no failures."""
+    return {
+        "status": UNVERIFIED,
+        "controller_outcome": "unknown",
+        "failures": [],
+        "warnings": list(advisories),
+        "consecutive_disclosures": 1,
+    }
+
+
+def main() -> None:
+    out: list[tuple[str, dict[str, Any]]] = []
+
+    out.append(("01-gap-disclosed-valid.json", fixture(
+        "gap-disclosed-valid",
+        "A disclosure spliced into the chain: it links back to a present element and "
+        "the next element links back to it. Coverage is structural, so nothing is "
+        "asserted about a range.",
+        sign(base_disclosure(), KEY), ok(), base_context())))
+
+    out.append(("02-gap-disclosure-dangling-predecessor.json", fixture(
+        "gap-disclosure-dangling-predecessor",
+        "The disclosure links back to an element that is not in the chain. Half a "
+        "splice is not a splice: it fixes nothing in place.",
+        sign(base_disclosure(), KEY),
+        bad("disclosure_predecessor_absent"),
+        base_context(predecessor_present=False))))
+
+    out.append(("03-gap-disclosure-successor-does-not-link.json", fixture(
+        "gap-disclosure-successor-does-not-link",
+        "The next element after resumption links past the disclosure to the element "
+        "before the gap, leaving the disclosure attached at one end only. A disclosure "
+        "no successor names can be minted later and slid over any gap.",
+        sign(base_disclosure(), KEY),
+        bad("disclosure_not_sealed_by_successor"),
+        base_context(successor_previous_receipt_hash=PREDECESSOR_HASH),
+        link_successor=False)))
+
+    out.append(("04-gap-disclosure-contradicted.json", fixture(
+        "gap-disclosure-contradicted",
+        "Elements the disclosure implies are absent are present in the chain. A "
+        "self-contradictory disclosure impeaches the emitter rather than excusing it.",
+        sign(base_disclosure(), KEY),
+        bad("disclosure_contradicted"),
+        base_context(claimed_absent_but_present=["sha256:" + "c9" * 32]))))
+
+    out.append(("05-gap-disclosure-foreign-key.json", fixture(
+        "gap-disclosure-foreign-key",
+        "Signed by a key the verifier trusts, but which is neither the key that signed "
+        "the linked element nor an ancestor of it. A gap is where introducing an "
+        "unrelated key is most useful and least distinguishable from recovery.",
+        sign({**base_disclosure(), "issuer_key_id": FOREIGN_KEY_ID}, FOREIGN),
+        bad("disclosure_issuer_not_chain_key"), base_context())))
+
+    out.append(("06-gap-disclosed-parent-key-null-estimate.json", fixture(
+        "gap-disclosed-parent-key-null-estimate",
+        "Signed by the hierarchical parent, because the crash took the session key "
+        "with it, and the count of lost receipts is not bounded. The estimate is an "
+        "unverifiable self-report either way; the chain links are what hold.",
+        sign({**base_disclosure(), "issuer_key_id": PARENT_KEY_ID,
+              "receipts_lost_estimate": None}, PARENT),
+        ok(consecutive=3), base_context(consecutive_disclosures=3))))
+
+    out.append(("07-gap-disclosure-unknown-key.json", fixture(
+        "gap-disclosure-unknown-key",
+        "The named key is the one that signed the linked element, but the verifier "
+        "does not hold it. Chain position does not confer trust — and the verifier's "
+        "ignorance does not prove forgery. Unverifiable is not invalid (spec "
+        "section 3.3.2): the disclosure is surfaced as unverified with an advisory, "
+        "conferring nothing and accusing no one.",
+        sign({**base_disclosure(), "issuer_key_id": f"{ISSUER}#ed25519-2027q1"}, KEY),
+        unverified("disclosure_key_unknown"),
+        # The chain names the same key, so issuer binding is satisfied and only trust
+        # fails. Otherwise this fixture would fire two rules and stop isolating one.
+        base_context(predecessor_issuer_key_id=f"{ISSUER}#ed25519-2027q1"))))
+
+    tampered = sign(base_disclosure(), KEY)
+    tampered["cause"] = "shutdown"  # altered after signing
+    out.append(("08-gap-disclosure-tampered.json", fixture(
+        "gap-disclosure-tampered",
+        "Altered after signing, so the signature no longer covers its contents.",
+        tampered, bad("disclosure_signature_invalid"), base_context())))
+
+    # -----------------------------------------------------------------------
+    # 09-16: the second vector for every disclosure rule (#124), each placed
+    # against an implementation shortcut its partner in 01-08 cannot detect.
+    # -----------------------------------------------------------------------
+
+    def tail_flip(value: str) -> str:
+        """The same digest through every prefix, wrong in the final character."""
+        return value[:-1] + ("0" if value[-1] != "0" else "1")
+
+    # disclosure_key_unknown, second vector: the verifier pins this very key under a
+    # case-variant of its id. An exact lookup fails; a case-normalising lookup
+    # resolves it and verifies. 07 names a key absent under any normalisation.
+    out.append(("09-gap-disclosure-key-case-variant.json", fixture(
+        "gap-disclosure-key-case-variant",
+        "The trusted set pins the right public key under a case-variant of the "
+        "disclosure's issuer_key_id. Key identifiers are opaque strings: holding the "
+        "key under a different spelling is not holding the key the disclosure names.",
+        sign(base_disclosure(), KEY),
+        unverified("disclosure_key_unknown"),
+        base_context(),
+        trusted={
+            KEY_ID.upper(): jwk(KEY),
+            PARENT_KEY_ID: jwk(PARENT),
+            FOREIGN_KEY_ID: jwk(FOREIGN),
+        })))
+
+    # disclosure_signature_invalid, second vector: a signature that decodes cleanly
+    # to 32 bytes — half an Ed25519 signature. 08 is a well-formed 64-byte signature
+    # over altered content, which only cryptographic verification rejects; this one
+    # falls to structure alone, so the pair separates the two kinds of check.
+    malformed = sign(base_disclosure(), KEY)
+    malformed["signature"] = b64u(bytes(32))
+    out.append(("10-gap-disclosure-signature-malformed.json", fixture(
+        "gap-disclosure-signature-malformed",
+        "The signature is valid base64url of the wrong length. Together with the "
+        "tampered vector this separates structural validation from verification.",
+        malformed, bad("disclosure_signature_invalid"), base_context())))
+
+    # disclosure_issuer_not_chain_key, second vector: a distinct key registered
+    # under a case-variant of the permitted ancestor's id. The verifier trusts it and
+    # the signature verifies — entitlement is what fails. A membership test that
+    # normalises case admits it. 05's foreign key fails under any normalisation.
+    out.append(("11-gap-disclosure-confusable-ancestor-key.json", fixture(
+        "gap-disclosure-confusable-ancestor-key",
+        "Signed by a trusted key whose id is the permitted ancestor's id in a "
+        "different case — a confusable registration, not the ancestor. Entitlement "
+        "to disclose is bound to the chain's exact key ids.",
+        sign({**base_disclosure(), "issuer_key_id": CONFUSABLE_KEY_ID}, CONFUSABLE),
+        bad("disclosure_issuer_not_chain_key"),
+        base_context(),
+        trusted={**TRUSTED, CONFUSABLE_KEY_ID: jwk(CONFUSABLE)})))
+
+    # disclosure_stream_mismatch, both vectors: the rule the #117 review added.
+    out.append(("12-gap-disclosure-replayed-stream.json", fixture(
+        "gap-disclosure-replayed-stream",
+        "A disclosure honestly signed for a different session, presented against "
+        "this one. Every structural check passes — the splice is sound, the key is "
+        "entitled — because the disclosure was genuine where it was minted. Stream "
+        "binding is the only thing that refuses the transplant.",
+        sign({**base_disclosure(),
+              "session_id": "trace-session-2026-07-01T08:00:00Z"}, KEY),
+        bad("disclosure_stream_mismatch"), base_context())))
+
+    out.append(("13-gap-disclosure-stream-case-variant.json", fixture(
+        "gap-disclosure-stream-case-variant",
+        "The disclosure's session_id is this session's id upper-cased. Session "
+        "identifiers are opaque: a case-normalising comparison reads this as bound "
+        "to the stream, and it is not.",
+        sign({**base_disclosure(), "session_id": SESSION.upper()}, KEY),
+        bad("disclosure_stream_mismatch"), base_context())))
+
+    # disclosure_predecessor_absent, second vector: the predecessor is present and
+    # the link agrees with its hash through every prefix, wrong in the last
+    # character. 02's predecessor is absent outright, which a truncated comparison
+    # still catches via the presence bit — this one it forgives.
+    out.append(("14-gap-disclosure-predecessor-link-tail.json", fixture(
+        "gap-disclosure-predecessor-link-tail",
+        "The disclosure's previous_receipt_hash matches the present predecessor's "
+        "hash in all but the final character. A link to almost the right element is "
+        "a link to nothing.",
+        sign({**base_disclosure(),
+              "previous_receipt_hash": tail_flip(PREDECESSOR_HASH)}, KEY),
+        bad("disclosure_predecessor_absent"), base_context())))
+
+    # disclosure_not_sealed_by_successor, second vector: the successor's link agrees
+    # with the disclosure's digest through every prefix. 03's successor links
+    # somewhere else entirely.
+    sealed_almost = sign(base_disclosure(), KEY)
+    out.append(("15-gap-disclosure-seal-tail-mismatch.json", fixture(
+        "gap-disclosure-seal-tail-mismatch",
+        "The next element's previous_receipt_hash matches the disclosure's digest "
+        "in all but the final character: sealed to a truncated comparison, unsealed "
+        "in fact.",
+        sealed_almost,
+        bad("disclosure_not_sealed_by_successor"),
+        base_context(successor_previous_receipt_hash=tail_flip(digest(sealed_almost))),
+        link_successor=False)))
+
+    # disclosure_contradicted, second vector: the contradiction stands at the tail
+    # of the chain, where no successor exists yet. A contradiction check gated on
+    # the sealed path — natural, since sealing is where cross-examination happens —
+    # never runs here. 04's contradiction sits on the sealed path. The tail position
+    # additionally carries the disclosure_not_yet_sealed advisory: a failure decides
+    # the outcome, and the advisory still reports what could not be checked.
+    out.append(("16-gap-disclosure-contradicted-at-tail.json", fixture(
+        "gap-disclosure-contradicted-at-tail",
+        "Elements the disclosure implies are absent are present, and the disclosure "
+        "sits at the live tail with no successor yet. Self-contradiction impeaches "
+        "the emitter wherever it stands.",
+        sign(base_disclosure(), KEY),
+        {**bad("disclosure_contradicted"), "warnings": ["disclosure_not_yet_sealed"]},
+        base_context(
+            claimed_absent_but_present=["sha256:" + "c9" * 32],
+            successor_present=False,
+            successor_previous_receipt_hash=None,
+        ),
+        link_successor=False)))
+
+    # disclosure_not_yet_sealed, both vectors. At the live tail — after the crash,
+    # before resumption — no successor exists and the seal cannot be checked. Spec
+    # section 3.3.2 logic a third time: inability to check is not evidence of a
+    # defect, so the outcome is gap_disclosure_unverified with an advisory, not
+    # receipt_gap_disclosed and not receipt_invalid. Without this rule the verifier
+    # granted full disclosed status to a splice attached at one end — the state the
+    # draft text says covers nothing, and one an adversary reaches at will by
+    # truncating the chain immediately after a disclosure.
+    out.append(("17-gap-disclosure-at-unsealed-tail.json", fixture(
+        "gap-disclosure-at-unsealed-tail",
+        "A well-formed disclosure at the live tail of the chain: signed by the "
+        "chain key, linked to a present predecessor, and with no successor yet to "
+        "seal it. Not invalid — nothing is defective — and not disclosed either: "
+        "half a splice covers nothing until the chain resumes and the seal can be "
+        "checked. Re-verification after resumption upgrades it.",
+        sign(base_disclosure(), KEY),
+        unverified("disclosure_not_yet_sealed"),
+        base_context(successor_present=False, successor_previous_receipt_hash=None),
+        link_successor=False)))
+
+    # Second vector: the successor is absent but the context's successor-link field
+    # carries a stale value. An implementation that derives sealed-ness from "is
+    # there a link value" rather than "is there a successor" reads this as sealed —
+    # the same presence-versus-state confusion as an explicit-null receipt.
+    out.append(("18-gap-disclosure-tail-with-stale-link.json", fixture(
+        "gap-disclosure-tail-with-stale-link",
+        "The same unsealed tail, but the successor-link field in the verification "
+        "context holds a leftover value from a previous verification. There is "
+        "still no successor: sealed-ness is a fact about the chain, not about a "
+        "field being non-null.",
+        sign(base_disclosure(), KEY),
+        unverified("disclosure_not_yet_sealed"),
+        base_context(
+            successor_present=False,
+            successor_previous_receipt_hash="sha256:" + "d7" * 32,
+        ),
+        link_successor=False)))
+
+    # disclosure_type_unsupported, both vectors. The type member is the contract the
+    # rest of the element is read under, and it is covered by the signature, so a
+    # wrong value is well-signed and fails nothing else: only an explicit equality
+    # check refuses it. 19 carries a plausible future version; 20 omits the member,
+    # which separates an equality check from a presence check.
+    out.append(("19-gap-disclosure-type-version-unknown.json", fixture(
+        "gap-disclosure-type-version-unknown",
+        "A well-signed disclosure whose type names a version this verifier does not "
+        "implement. An unknown version is rejected rather than parsed best-effort.",
+        sign({**base_disclosure(), "type": "GapDisclosure/2.0"}, KEY),
+        bad("disclosure_type_unsupported"), base_context())))
+
+    no_type = {k: v for k, v in base_disclosure().items() if k != "type"}
+    out.append(("20-gap-disclosure-type-absent.json", fixture(
+        "gap-disclosure-type-absent",
+        "A well-signed disclosure with no type member at all. A presence check and "
+        "an equality check differ exactly here.",
+        sign(no_type, KEY),
+        bad("disclosure_type_unsupported"), base_context())))
+
+    for name, doc in out:
+        (OUT / name).write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+        print("wrote", name)
+
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -401,7 +401,7 @@ requirement, such as `required`, `optional`, or `none`, without folding action
 evidence into the supply-chain provenance axis.
 
 An action receipt profile can build on the external execution evidence rules in
-section 3.3.1 by requiring the verifier to:
+section 3.3.2 by requiring the verifier to:
 
 1. recompute the receipt's action or evidence digest from the canonical action
    preimage;
@@ -420,6 +420,114 @@ untrusted, stale, out of order, or not bound to the expected call. Conversely, a
 signed acceptance receipt is not proof of physical completion or
 functional-safety certification unless the external issuer and profile
 explicitly make, and the verifier is configured to trust, that stronger claim.
+
+#### 3.3.4 Disclosed gaps in a receipt chain
+
+<!-- CHANGED: #117 - GapDisclosure chain element and the receipt_gap_disclosed outcome -->
+
+Under a profile requiring action receipts, completeness of the receipt chain is the
+load-bearing property. No emitter can be made gap-proof: any writer operating
+asynchronously has a window in which a crash loses a tail of receipts. A specification
+that offers only "complete" and "broken" therefore rewards concealment, because an
+operator who backfills a lost receipt scores better than one who reports the loss.
+
+A `GapDisclosure` is a signed statement, occupying a position in the receipt chain, that
+receipts which would have occupied that position were never emitted. It is negative
+evidence contributed by the emitter about itself. It does not establish that the missing
+receipts ever existed, how many were lost, or that the emitter did not omit them
+selectively; what the splice proves is where the gap sits in the chain, and nothing else.
+
+**Structure.** A `GapDisclosure` is a chain element. It MUST carry:
+
+- `type`, the value `GapDisclosure/1.0`;
+- `previous_receipt_hash`, the digest of the chain element immediately preceding the gap,
+  in the same form and computed the same way as on a receipt;
+- `session_id`, naming the receipt stream the disclosure belongs to;
+- `issuer_key_id`, identifying the key that signed it;
+- `signature`, over the canonical form of the disclosure with the signature field removed.
+
+It MAY carry `cause` and `receipts_lost_estimate`. Both are descriptive self-reports and
+nothing more: the receipts an estimate counts are absent by definition, so nothing in the
+chain corroborates either field. A verifier MUST NOT treat them as established, MUST NOT
+condition any outcome on their values, and MUST NOT reject a disclosure because either
+disagrees with other evidence. They exist to be reported, not relied on.
+
+**Stream binding.** The `session_id` is covered by the signature, and a verifier MUST
+reject a disclosure whose `session_id` does not match the receipt stream under
+verification. Without that comparison, a disclosure honestly signed for one stream is a
+transplantable excuse for a gap in any other: replay, in the position where replay is
+hardest to distinguish from recovery.
+
+**Chain binding.** A `GapDisclosure` MUST be spliced into the receipt chain at the point
+of resumption. Concretely, its `previous_receipt_hash` MUST name a chain element that is
+present, and the next chain element emitted after resumption MUST carry a
+`previous_receipt_hash` naming the disclosure. A disclosure that is not linked from both
+directions has not been sealed into the chain and MUST NOT be treated as covering
+anything.
+
+That requirement has a window in which it cannot be met honestly: at the live tail of
+the chain, after the failure and before resumption, the sealing successor does not exist
+yet. A verifier meeting a tail disclosure whose other checks pass MUST NOT report
+`receipt_gap_disclosed`, and MUST NOT report `receipt_invalid` either: the absence of a
+successor is an inability to check, not evidence of a defect, the same principle as
+section 3.3.2's treatment of unknown issuer keys. It MUST surface the disclosure as
+unverified with a distinct advisory, and re-verification after the chain resumes upgrades
+or impeaches it on the seal that then exists. This matters adversarially: a chain
+truncated immediately after a disclosure is indistinguishable from an honest tail, so
+whatever a verifier grants the honest tail, it grants the truncation.
+
+Gap boundaries MUST NOT be expressed as timestamps or as emitter-assigned sequence
+numbers. Both are signed by the same key that signs the receipts, so neither constrains
+an emitter that is misrepresenting the gap. The chain links are the boundaries.
+
+**Issuer.** A `GapDisclosure` MUST be signed by the key that signed the chain element its
+`previous_receipt_hash` names, or by an ancestor of that key in the hierarchy of
+section 3.2.1. A disclosure signed by any other key MUST be treated as invalid, whether
+or not that key is otherwise trusted. A gap is the moment at which introducing an
+unrelated key is most useful to an adversary and least distinguishable from recovery.
+
+**Consecutive disclosures.** A `GapDisclosure` MAY name another `GapDisclosure` as its
+predecessor, which represents an emitter that failed again before emitting a receipt. A
+verifier MUST report the number of consecutive disclosures. It MUST NOT reject solely on
+that basis: an emitter failing repeatedly and disclosing each time is behaving better
+than one that is silent.
+
+**Verifier outcomes.** The action-receipt outcome `receipt_missing_required` is narrowed,
+and the outcome `receipt_gap_disclosed` is added beside it:
+
+| Outcome | Meaning |
+|---|---|
+| `receipt_gap_disclosed` | Required receipts are absent, and a valid `GapDisclosure` occupies their position in the chain. Emitter-attested negative evidence. |
+| `receipt_missing_required` | Required receipts are absent and no valid disclosure occupies their position. Silent, and treated as presumptively adversarial. |
+
+A verifier MUST report `receipt_gap_disclosed` distinctly from
+`receipt_missing_required`. Collapsing them discards the distinction the disclosure was
+issued to make.
+
+Whether `receipt_gap_disclosed` is accepted or rejected MUST be a verifier policy input,
+not implementation-defined behaviour. A relying party evaluating a payment authorisation
+and one evaluating a telemetry batch will reasonably differ, and neither should have to
+change verifier to express that. One bound on that policy is not negotiable: a profile
+that requires independently proven completeness of the receipt chain MUST NOT accept
+`receipt_gap_disclosed` as satisfying it. A disclosed gap is an attested absence, not a
+proof of completeness, and no policy setting may promote the former into the latter.
+
+A `GapDisclosure` that fails signature verification, is not bound into the chain from
+both directions, names a session other than the stream under verification, is signed by
+a key outside the permitted set, or whose claimed gap is contradicted by chain elements
+that are in fact present, MUST yield `receipt_invalid` rather than falling back to
+`receipt_missing_required`. A forged, transplanted or self-contradictory disclosure is
+worse evidence than no disclosure: it is an attempt to convert silence into attestation,
+and the attempt itself is a finding.
+
+**Reporting.** A verification result MUST report each disclosed gap individually,
+carrying at minimum the linked predecessor, the number of consecutive disclosures, and
+the `cause` when one was supplied. Reducing disclosed gaps to a count or a boolean
+discards exactly the detail a relying party's policy needs.
+
+The conformance vectors for this section are `examples/action-receipts/gap-disclosure/`:
+twenty fixtures, two independent vectors per rule, with a generator that reproduces them
+byte for byte, and the live-tail contrast pinned by a dedicated test.
 
 ### 3.4 Scope
 

--- a/tests/test_gap_disclosure_fixtures.py
+++ b/tests/test_gap_disclosure_fixtures.py
@@ -1,0 +1,306 @@
+"""Conformance checks for the gap-disclosure fixture set (spec section 3.3.4, #117).
+
+A ``GapDisclosure`` is a chain element: it links back to the element before the gap,
+and the next element emitted after resumption links back to it. Coverage is
+structural, never asserted, so this verifier performs no range arithmetic. It checks
+the splice, and it checks the two things a splice cannot carry by itself: that the
+signing key is entitled to disclose for this chain, and that the disclosure is bound
+to the stream it excuses.
+
+The registry below is the inventory, in the shape #124 settled for the receipt
+verifier next door: every obligation is one ``RULES`` entry, and a check that is not
+registered is a check that never runs. Codes match the fixture set one to one.
+
+Three outcomes, and the boundaries between them are the content of section 3.3.4:
+
+- ``receipt_gap_disclosed`` needs everything to hold, including the seal.
+- ``receipt_invalid`` means a check ran and failed. A forged, transplanted or
+  self-contradictory disclosure is worse evidence than none.
+- ``gap_disclosure_unverified`` means a check could not run: the issuer key is not
+  held, or the chain has not resumed so no successor seals the splice. Inability to
+  check is not evidence of a defect (spec section 3.3.2's treatment of unknown
+  issuer keys), so nothing here is refused; nothing is granted either.
+
+The tail is the adversarial case among these, pinned by its own test below rather
+than left to the fixture sweep: a chain truncated immediately after a disclosure is
+indistinguishable from an honest live tail, so whatever outcome the tail gets, a
+deliberate truncation gets too. Granting the tail ``receipt_gap_disclosed`` would
+hand an adversary that outcome at will.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+FIXTURE_DIR = Path(__file__).parent.parent / "examples" / "action-receipts" / "gap-disclosure"
+
+# The two outcome names this set defines, held once each; their twins live in the
+# generator. #117's carry note expects the disclosed outcome to keep its semantics
+# and possibly not its name, so a rename is these two constants, the generator's,
+# the spec section, the docs row, and one regeneration.
+DISCLOSED = "receipt_gap_disclosed"
+UNVERIFIED = "gap_disclosure_unverified"
+
+STATUSES = frozenset({DISCLOSED, "receipt_invalid", UNVERIFIED})
+
+
+def _element_digest(element: dict[str, Any]) -> str:
+    """The chain digest of an element, over its full canonical form, signature included.
+
+    The successor's ``previous_receipt_hash`` names the disclosure as it stands in the
+    chain, which is the signed object. Hashing the unsigned body instead would let two
+    disclosures with different signatures collide under one seal.
+    """
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(element)).hexdigest()
+
+
+def _signature_valid(disclosure: dict[str, Any], jwk: dict[str, Any]) -> bool:
+    """One code for every way a signature fails to verify.
+
+    Structural malformation and cryptographic mismatch are one obligation here, not
+    two: the signature does not verify. A separate length guard before the library
+    call would be a guard the fixtures cannot see, deletable with every vector still
+    green, which is the deletable-guard defect this suite is built to refuse. The
+    library refuses malformed input on its own; fixture 10 pins that a 32-byte
+    signature yields this code and not an error.
+    """
+    encoded = disclosure.get("signature")
+    if not isinstance(encoded, str):
+        return False
+    try:
+        raw = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+    except (binascii.Error, ValueError):
+        return False
+    body = {k: v for k, v in disclosure.items() if k != "signature"}
+    key = Ed25519PublicKey.from_public_bytes(
+        base64.urlsafe_b64decode(jwk["x"] + "=" * (-len(jwk["x"]) % 4))
+    )
+    try:
+        key.verify(raw, rfc8785.dumps(body))
+    except (InvalidSignature, ValueError):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One registered obligation: a failure code and the predicate that fires it."""
+
+    code: str
+    fires: Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], bool]
+
+
+def _issuer_not_chain_key(d: dict[str, Any], chain: dict[str, Any], _: dict[str, Any]) -> bool:
+    # Entitlement is bound to the chain's exact key ids: the key that signed the
+    # linked element, or a permitted ancestor. Identifiers are opaque strings, so no
+    # case normalisation; fixture 11 is a distinct trusted key under a case-variant
+    # of the ancestor's id, and it must fail here.
+    permitted = {chain["predecessor_issuer_key_id"], *chain["permitted_ancestor_key_ids"]}
+    return d.get("issuer_key_id") not in permitted
+
+
+def _stream_mismatch(d: dict[str, Any], _: dict[str, Any], ctx: dict[str, Any]) -> bool:
+    # Exact comparison. Session ids are opaque; fixture 13 is this session's id
+    # upper-cased, and a normalising comparison reads it as bound.
+    return d.get("session_id") != ctx["session_id"]
+
+
+def _predecessor_absent(d: dict[str, Any], chain: dict[str, Any], _: dict[str, Any]) -> bool:
+    # The disclosure must name a chain element that is present, by its exact digest.
+    # Fixture 14 agrees with the present predecessor through every prefix and is
+    # wrong in the final character: a link to almost the right element is a link to
+    # nothing.
+    if not chain["predecessor_present"]:
+        return True
+    return d.get("previous_receipt_hash") != chain["predecessor_hash"]
+
+
+def _contradicted(_: dict[str, Any], chain: dict[str, Any], __: dict[str, Any]) -> bool:
+    # Runs wherever the disclosure stands, sealed or at the tail (fixture 16): a
+    # self-contradictory disclosure impeaches the emitter wherever it is.
+    return bool(chain["claimed_absent_but_present"])
+
+
+def _not_sealed(d: dict[str, Any], chain: dict[str, Any], _: dict[str, Any]) -> bool:
+    # Only decidable once the chain has resumed. Sealed-ness is a fact about the
+    # chain, not about a link field being non-null: fixture 18 carries a stale link
+    # value with no successor, and must fall to the tail advisory instead.
+    if not chain["successor_present"]:
+        return False
+    return chain["successor_previous_receipt_hash"] != _element_digest(d)
+
+
+def _type_unsupported(d: dict[str, Any], _: dict[str, Any], __: dict[str, Any]) -> bool:
+    # The type member is the contract the rest of the element is read under, and it
+    # is covered by the signature, so a wrong value is well-signed and fails nothing
+    # else: only this equality refuses it. Absence fails the same way (fixture 20):
+    # a presence check alone reads an omitted contract as satisfied.
+    return d.get("type") != "GapDisclosure/1.0"
+
+
+RULES: tuple[Rule, ...] = (
+    Rule("disclosure_type_unsupported", _type_unsupported),
+    Rule("disclosure_issuer_not_chain_key", _issuer_not_chain_key),
+    Rule("disclosure_stream_mismatch", _stream_mismatch),
+    Rule("disclosure_predecessor_absent", _predecessor_absent),
+    Rule("disclosure_contradicted", _contradicted),
+    Rule("disclosure_not_sealed_by_successor", _not_sealed),
+)
+
+
+def verify_gap_disclosure(
+    disclosure: dict[str, Any],
+    context: dict[str, Any],
+    trusted_issuer_keys: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Evaluate one disclosure against its chain context. Returns the outcome shape
+    the fixtures pin: status, failures, warnings, and the consecutive-disclosure
+    count, which is reported rather than judged (an emitter failing repeatedly and
+    disclosing each time is behaving better than one that is silent)."""
+    chain = context["chain"]
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    # Signature first, and only when the named key is held. An exact lookup: holding
+    # the key under a different spelling is not holding the key the disclosure names
+    # (fixture 09). An unknown key is an advisory, not a failure: chain position does
+    # not confer trust, and the verifier's ignorance does not prove forgery.
+    jwk = trusted_issuer_keys.get(disclosure.get("issuer_key_id", ""))
+    if jwk is None:
+        warnings.append("disclosure_key_unknown")
+    elif not _signature_valid(disclosure, jwk):
+        failures.append("disclosure_signature_invalid")
+
+    failures.extend(rule.code for rule in RULES if rule.fires(disclosure, chain, context))
+
+    if not chain["successor_present"]:
+        warnings.append("disclosure_not_yet_sealed")
+
+    if failures:
+        status = "receipt_invalid"
+    elif warnings:
+        status = UNVERIFIED
+    else:
+        status = DISCLOSED
+        warnings = [DISCLOSED]
+
+    assert status in STATUSES
+    return {
+        "status": status,
+        "controller_outcome": "unknown",
+        "failures": failures,
+        "warnings": warnings,
+        "consecutive_disclosures": chain["consecutive_disclosures"],
+        # Reporting (spec section 3.3.4): the linked predecessor and the cause, echoed
+        # as carried. Judged nowhere: a wrong link fails the predecessor rule and a
+        # tampered cause fails the signature rule, so reporting stays reporting.
+        "linked_predecessor": disclosure.get("previous_receipt_hash"),
+        "cause": disclosure.get("cause"),
+    }
+
+
+FIXTURES = sorted(FIXTURE_DIR.glob("*.json"))
+
+
+def test_fixture_set_is_complete() -> None:
+    assert [p.name for p in FIXTURES] == [
+        "01-gap-disclosed-valid.json",
+        "02-gap-disclosure-dangling-predecessor.json",
+        "03-gap-disclosure-successor-does-not-link.json",
+        "04-gap-disclosure-contradicted.json",
+        "05-gap-disclosure-foreign-key.json",
+        "06-gap-disclosed-parent-key-null-estimate.json",
+        "07-gap-disclosure-unknown-key.json",
+        "08-gap-disclosure-tampered.json",
+        "09-gap-disclosure-key-case-variant.json",
+        "10-gap-disclosure-signature-malformed.json",
+        "11-gap-disclosure-confusable-ancestor-key.json",
+        "12-gap-disclosure-replayed-stream.json",
+        "13-gap-disclosure-stream-case-variant.json",
+        "14-gap-disclosure-predecessor-link-tail.json",
+        "15-gap-disclosure-seal-tail-mismatch.json",
+        "16-gap-disclosure-contradicted-at-tail.json",
+        "17-gap-disclosure-at-unsealed-tail.json",
+        "18-gap-disclosure-tail-with-stale-link.json",
+        "19-gap-disclosure-type-version-unknown.json",
+        "20-gap-disclosure-type-absent.json",
+    ]
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_fixture(path: Path) -> None:
+    doc = json.loads(path.read_text())
+    result = verify_gap_disclosure(
+        doc["gap_disclosure"], doc["context"], doc["trusted_issuer_keys"]
+    )
+    assert result == doc["expected"], f"{path.name}: {result} != {doc['expected']}"
+
+
+def test_the_live_tail_is_not_granted_what_the_seal_earns() -> None:
+    """The tail case, as a test rather than a paragraph.
+
+    Fixtures 01 and 17 carry byte-identical disclosures; the only difference is
+    whether a successor exists to seal the splice. The sealed one earns
+    ``receipt_gap_disclosed``. The tail one is ``gap_disclosure_unverified``: not
+    invalid, because nothing is defective and the chain may resume in a moment, and
+    not disclosed, because half a splice covers nothing.
+
+    The adversarial reading is the reason this is pinned separately: a chain
+    truncated immediately after a disclosure is byte-for-byte an honest live tail,
+    so this test is also the assertion that truncation buys an adversary an
+    advisory, never an outcome. Re-verification after resumption upgrades or
+    impeaches the disclosure on the seal that then exists.
+    """
+    sealed = json.loads((FIXTURE_DIR / "01-gap-disclosed-valid.json").read_text())
+    tail = json.loads((FIXTURE_DIR / "17-gap-disclosure-at-unsealed-tail.json").read_text())
+    assert sealed["gap_disclosure"] == tail["gap_disclosure"], (
+        "the contrast only isolates the seal if the disclosures are identical"
+    )
+
+    sealed_result = verify_gap_disclosure(
+        sealed["gap_disclosure"], sealed["context"], sealed["trusted_issuer_keys"]
+    )
+    tail_result = verify_gap_disclosure(
+        tail["gap_disclosure"], tail["context"], tail["trusted_issuer_keys"]
+    )
+    assert sealed_result["status"] == DISCLOSED
+    assert tail_result["status"] == UNVERIFIED
+    assert tail_result["failures"] == []
+    assert tail_result["warnings"] == ["disclosure_not_yet_sealed"]
+
+
+def test_every_registered_rule_is_load_bearing_for_two_fixtures() -> None:
+    """Two independent vectors per rule (#124), enforced rather than remembered.
+
+    Each code must decide at least two fixtures' expected outcomes. The unknown-key
+    advisory and the tail advisory are counted from warnings; failure codes from
+    failures. A rule below two vectors is a rule one fixture regression away from
+    being unenforced."""
+    counts: dict[str, int] = {}
+    for path in FIXTURES:
+        expected = json.loads(path.read_text())["expected"]
+        for code in [*expected["failures"], *expected["warnings"]]:
+            if code != DISCLOSED:
+                counts[code] = counts.get(code, 0) + 1
+    registered = {rule.code for rule in RULES} | {
+        "disclosure_signature_invalid",
+        "disclosure_key_unknown",
+        "disclosure_not_yet_sealed",
+    }
+    assert set(counts) == registered, (
+        f"codes in fixtures and codes registered diverge: {sorted(set(counts) ^ registered)}"
+    )
+    thin = {code: n for code, n in counts.items() if n < 2}
+    assert not thin, f"rules below the two-vector margin: {thin}"


### PR DESCRIPTION
Closes #117. 

Opened per the maintainer-carry note there; all three asks from that comment are in,
each named below. Authorship per CONTRIBUTING step 3: carried by a maintainer, proposer credited
in the CHANGELOG entry.

## What

Section 3.3.4, normative, marked `<!-- CHANGED: #117 -->`: a `GapDisclosure` is a signed chain
element stating that receipts which would have occupied its position were never emitted. Coverage
is structural rather than asserted: the disclosure links back to the element before the gap, the
next element emitted links back to the disclosure, and verification is two link checks a verifier
already performs on every ordinary element. There are no range fields. A hash chain cannot express
a range, and an emitter cannot know its successor's hash at write time; the design discussion in
#117 walks through why the issue's original field list does not survive that.

The action-receipt outcome `receipt_missing_required` is narrowed to silent absence, and
`receipt_gap_disclosed` is added beside it. Acceptance is a verifier policy input, with one
non-negotiable bound: it never satisfies a profile requiring independently proven completeness.

## The tail case, as a test

A disclosure at the live tail, after the failure and before resumption, has no successor to seal
it. The spec text forbids granting it `receipt_gap_disclosed` and forbids `receipt_invalid`
equally: inability to check is not evidence of a defect, section 3.3.2's principle for unknown
issuer keys. It is surfaced unverified with a distinct advisory and upgraded on re-verification
once the chain resumes.

`test_the_live_tail_is_not_granted_what_the_seal_earns` pins it: fixtures 01 and 17 carry
byte-identical disclosures whose only difference is whether a successor exists, and the test
asserts the sealed one earns the outcome and the tail one does not. The adversarial reading is in
the test's docstring: a chain truncated immediately after a disclosure is byte-for-byte an honest
live tail, so this is also the assertion that truncation buys an advisory, never an outcome.
Fixtures 16 and 18 carry the two near misses: a contradiction standing at the tail still fails,
and a stale successor-link field with no successor is still a tail.

## What a disclosed gap does not establish

That the missing receipts ever existed, how many were lost, or that the emitter did not omit them
selectively. What the splice proves is where the gap sits in the chain, and nothing else. The
section states this in its own text, and `cause` and `receipts_lost_estimate` are constrained to
descriptive self-reports a verifier MUST NOT condition any outcome on. The failure mode this
guards is a reader treating disclosure as though it restored what was lost; the text is written so
that no requirement can be read as making a disclosed gap benign.

## The interaction with the undecidable state

`receipt_gap_disclosed` and the tail's unverified state are two more instances of the pattern
being unified across #246, #190, trace-tests#82 and agent-manifest#348: "this was not established"
as a first-class outcome rather than a silent pass. Both names this PR introduces,
`receipt_gap_disclosed` and the tail's `gap_disclosure_unverified`, are candidates for that
vocabulary. Each is held in one constant in the generator and one in the test; outside those, the
disclosed name appears in one spec section and one docs table row. A rename is those sites and one
regeneration. Not blocked on it, per the carry note.

## Evidence

- Twenty conformance vectors under `examples/action-receipts/gap-disclosure/`, two independent
  vectors per rule, enforced by a margin test rather than remembered. The second vector of each
  pair sits against an implementation shortcut the first cannot detect: case-normalised key and
  session lookups, digest comparisons truncated to a prefix, sealed-ness derived from a link field
  rather than from the chain, a contradiction check gated on the sealed path, and a type check
  that only tests presence.
- The verifier consumes a named-rule registry (`RULES`) in the shape #124 settled next door, so an
  unregistered check is a check that never runs.
- The generator reproduces every fixture byte for byte, enforced by the existing
  `tests/test_generators_reproduce_fixtures.py` discovery.
- Fourteen hand-run mutants against the verifier: thirteen killed, each by the fixture built for
  it; the one survivor widens an exception catch that no JSON-expressible fixture can distinguish,
  recorded here rather than left to be found.
- Two known gaps from the issue thread are closed rather than carried: the `type` equality check
  the draft recorded as unimplemented now has a rule and two vectors (19, 20), and the Reporting
  obligations are echoed in every fixture's expected result rather than left unpinned.

## Housekeeping

Two cross-references that predate the renumbering which introduced section 3.3.1 are updated to
name section 3.3.2, where the text they cite now lives: one in section 3.3.3's profile paragraph,
one in the `receipt_unverified` row of `docs/verification.md`.

## Backward compatibility

Non-breaking. The section binds under a profile requiring action receipts; no current profile
does, and section 3.3.3 already contemplates such profiles as future work. Existing verifiers and
records are untouched; the outcome addition follows #114's decision shape, widening under opt-in
rather than in place. No schema change in this PR: per CONTRIBUTING, the schema PR tracks the
merged spec change.

## Checklist

- [x] Issue opened with the Spec change proposal template (#117, 2 August), comment window
  satisfied
- [x] Carried per CONTRIBUTING step 3; proposer credited in the CHANGELOG entry
- [x] Changed normative text marked `<!-- CHANGED: #117 -->`
- [x] `CHANGELOG.md` updated
- [x] DCO sign-off on all commits

Production origin, for the record: the mechanism is operated in a per-action receipt emitter whose
crash recovery writes a functionally equivalent disclosure; relying parties treat a disclosed gap
differently from a silent one, which is the distinction this section makes portable.

Tool-assisted: drafting, the mutant battery and the fixture regeneration. The derivation is in
the section text, the commit message and the test docstrings, where the next reader can find it.
