### PR TITLE
fix(docs): unbreak the docs deploy, broken since 27 August

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ on:
       - "CHANGELOG.md"
       - "CONTRIBUTING.md"
       - "GOVERNANCE.md"
+      - "CHARTER.md"
       - "ROADMAP.md"
       - "LIMITATIONS.md"
       - "CNAME"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: TRACE
-site_description: Trust Runtime Attestation and Compliance Evidence: open attestation standard for agentic AI governance
+site_description: "Trust Runtime Attestation and Compliance Evidence: open attestation standard for agentic AI governance"
 site_url: https://trace.agentrust-io.com
 repo_url: https://github.com/agentrust-io/trace-spec
 repo_name: agentrust-io/trace-spec
@@ -173,7 +173,7 @@ extra:
         - icon: material/emoticon-sad-outline
           name: This page could be improved
           data: 0
-          note: Thanks for your feedback: open an issue to let us know.
+          note: "Thanks for your feedback: open an issue to let us know."
 
 extra_css:
   # Shared AgenTrust editorial design system. Deliberately the only stylesheet:


### PR DESCRIPTION
Every `docs.yml` run since 27 August has failed with `MkDocs encountered an error parsing the configuration file: mapping values are not allowed here`. Eight consecutive failures. `trace.agentrust-io.com` has been serving stale content for four days, and no documentation change merged in that window has reached the site.

## Cause

60610c5 ("style: remove every em dash outside the frozen artifacts") replaced em dashes in `mkdocs.yml` with a colon followed by a space, which is YAML mapping syntax:

```yaml
site_description: Trust Runtime Attestation and Compliance Evidence: open attestation standard for agentic AI governance
note: Thanks for your feedback: open an issue to let us know.
```

Both are now quoted. A third line the same commit touched, `copyright`, was already quoted and was unaffected.

## Verification

Reproduced the workflow's own config generation locally and parsed the result:

```
sed 's|^docs_dir: \.$|docs_dir: .docs_build|' mkdocs.yml > .mkdocs_build.yml
```

That is how the second break was found. The CI error only ever pointed at line 2, and fixing that line alone would have moved the failure to line 176 rather than clearing it.

## Also

Adds `CHARTER.md` to the deploy `paths:` filter. It is copied into the build by the allowlist step but was absent from the filter, so a change to the charter alone would merge, pass CI, and never deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc16CsknaQ9PTLxGj8TXXj