### PR TITLE
docs: say the rule about understanding what you submit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,14 @@ wheel installed elsewhere in the environment must not shadow the code under
 test; a regression test fails with the resolved import path if that guarantee is
 lost.
 
+## Using AI to contribute
+
+Use agents. A lot of this was built with them and saying otherwise would be dishonest.
+
+The rule is that you have to understand what you submit. If you cannot explain what your change does and how it interacts with the rest of the system, with the agent closed, do not open the pull request. Reviewing a change nobody can explain costs more than writing it did, and it becomes someone else's problem the moment it merges.
+
+That is a rule about understanding, not about tooling.
+
 ## DCO sign-off
 
 All commits must include a Developer Certificate of Origin sign-off:


### PR DESCRIPTION
Agents wrote a lot of this and pretending otherwise would be dishonest, so the rule worth stating is not about tooling. It is that you have to be able to explain what your change does, with the agent closed, before opening the pull request. Reviewing a change nobody can explain costs more than writing it did.

This is a direct answer to feedback already on the public record from the AAIF Technical Committee, that much of the code across these projects "feels vibe coded."

**No gate here.** The vouch check going into cmcp, ca2a and agent-manifest is deliberately not proposed for this repository. A vendor-run gate on work heading for neutral governance is the wrong shape. The rule applies everywhere; the enforcement does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc16CsknaQ9PTLxGj8TXXj