### PR TITLE
spec: state what delegation.parent_record_hash is a digest of

### DIFF
--- a/spec/trace-v0.2.md
+++ b/spec/trace-v0.2.md
@@ -195,6 +195,30 @@ Rule 3 is what makes the block safe to add. A reference that could invalidate a 
 
 **Unsettled, and deliberately named rather than hidden.** `retention` states an undertaking and nothing in this specification enforces it. A reference is worth only the ability to resolve it later, and transparency-log practice shows that gap is real rather than theoretical: a record can remain valid and become unreachable when the index that addressed it is removed. §7 open question 3 covers the same ground for `transparency` and the two should be resolved together.
 
+#### 3.1.3 `delegation.parent_record_hash`: what the digest covers
+
+<!-- CHANGED: #245 - preimage stated normatively -->
+
+`delegation.parent_record_hash` is the field a verifier walks to reconstruct a delegation chain. The schema gives it a pattern and calls it a "digest of the parent hop's Trust Record", which does not say which bytes are digested, and at least three readings of that phrase produce different digests.
+
+The preimage is the **complete parent record as published, with its `signature` member present**, canonicalised with RFC 8785 (JCS):
+
+```
+delegation.parent_record_hash = "sha256:" + hex(SHA-256(JCS(parent_record)))
+```
+
+with `sha384:` and SHA-384 as the permitted alternative, per the schema pattern.
+
+1. A producer MUST compute `parent_record_hash` over the complete parent record, including its `signature` member where the profile embeds one, canonicalised with RFC 8785. No member is removed, blanked or reordered before digesting.
+2. A verifier MUST recompute the digest the same way, over the parent record as it received it, and MUST NOT reconstruct or re-serialise the parent by any other route.
+3. The digest algorithm named in the prefix MUST match the algorithm used, and a verifier MUST reject a record whose prefix names an algorithm it does not support rather than fall back to another.
+
+**This is not the canonical form defined in §3.2.2, and the difference is deliberate.** §3.2.2 constructs the signature pre-image with the `signature` field *absent*, because a signature cannot cover itself. A chain digest has no such constraint and gains from not having one: digesting the record as published means a verifier digests exactly what it fetched, with no member-removal step to get wrong, and the parent's signature is then covered by the chain digest as well as checked on its own. For an enveloping-signature profile, where the record carries no `signature` member, the two pre-images coincide.
+
+The other two readings fail for concrete reasons. Digesting the file's raw bytes makes the value sensitive to whitespace and key order, so it breaks the first time a record passes through a system that re-serialises it. Digesting with `signature` removed adds a second canonicalisation rule for implementers to get wrong and buys nothing.
+
+**A near-miss here passes every existing vector.** The RFC 8785 key ordering that §3.2.2 describes, and the code-point ordering that `sort_keys=True` produces in several JSON libraries, agree across the Basic Multilingual Plane and diverge only once a key contains a supplementary-plane character. An implementation that takes the shortcut therefore computes correct chain digests for ASCII records indefinitely and produces an unverifiable chain the first time such a key appears. Every vector in `examples/delegation-link/` is currently ASCII, so the corpus does not discriminate the two; a vector whose parent record carries a supplementary-plane key is what closes that.
+
 ### 3.2 Wire format
 
 **Envelope: ** EAT (RFC 9711): JWT (JSON, human-readable contexts) or CWT/CBOR-COSE (constrained and high-throughput contexts).


### PR DESCRIPTION
Closes the normative half of #245.

## The gap

`delegation.parent_record_hash` is the field a verifier walks to reconstruct a delegation chain, and at `5c69dc1` its preimage was stated in no binding document:

- `spec/trace-v0.2.md`: **zero occurrences** of the field.
- `schema/trace-claim.json`: `"SHA-256 or SHA-384 digest of the parent hop's Trust Record."` plus a pattern. That phrase has at least three readings that produce different digests.
- `docs/rfcs/a2a-delegation-profile.md` §4.1 states a rule, and is headed **"Status: Draft proposal. Binds nothing."**

Reported by @chernistry, who then posted the rule from a shipped implementation with a verified three-hop chain.

## The ruling, and why it is not a new rule

New §3.1.3 fixes the preimage as the **complete parent record as published, `signature` member present**, canonicalised with RFC 8785:

```
delegation.parent_record_hash = "sha256:" + hex(SHA-256(JCS(parent_record)))
```

This is what the repository already ships. Recomputing every link in the five-record chain in `examples/delegation-link/02-valid-full-depth-out-of-order.json`:

| link | recomputed | value in the child |
|---|---|---|
| records[1] → records[0] | `sha256:575f7a64...` | same |
| records[2] → records[1] | `sha256:d05ba16a...` | same |
| records[3] → records[2] | `sha256:94e67431...` | same |
| records[4] → records[3] | `sha256:b1d65c65...` | same |

All four resolve, every record carries its `signature` member, nothing is removed or blanked.

## The part worth reviewing carefully

The section states that this is **deliberately not** the canonical form in §3.2.2. §3.2.2 builds the signature pre-image with `signature` absent, because a signature cannot cover itself. A chain digest has no such constraint, and digesting the record as published removes a member-removal step for implementers to get wrong. My first draft of this section said "canonicalised under §3.2.2" and would have mandated the opposite rule, which is a good illustration of why the distinction needs writing down.

For enveloping-signature profiles, where the record carries no `signature` member, the two pre-images coincide.

## Known gap, not closed here

**The 23 delegation-link vectors cannot discriminate the correct rule from the wrong one.** Recomputing the same four links with `json.dumps(record, sort_keys=True, separators=(",", ":"))` gives identical digests, because every vector is ASCII and JCS agrees with code-point key ordering across the BMP. An implementation taking that shortcut passes the whole corpus and produces an unverifiable chain on the first supplementary-plane key.

§3.1.3 says so explicitly rather than leaving it implicit. The discriminating vector is tracked on #245 and is @chernistry's if they want it, since they hold the generator and the published key.

Same class as #247.

## Scope note

`spec/trace-v0.2.md` still does not define the `delegation` block at all; it exists only in the schema. This PR states the preimage because that is what #245 reported and what a verifier gets wrong silently. Specifying the rest of the block is a larger piece of work and is not attempted here.

Docs-only change, 24 lines added, nothing removed.
