### PR TITLE
test(provenance): reject digest under wrong algorithm label

### DIFF
--- a/tests/test_build_provenance_depth_vectors.py
+++ b/tests/test_build_provenance_depth_vectors.py
@@ -297,6 +297,25 @@ def test_sha384_subject_binding_rejects_the_wrong_digest() -> None:
     }
 
 
+def _mislabelled_control() -> dict[str, Any]:
+    """Record declares sha384:X; the subject carries the same hex under `sha256`."""
+    vector = copy.deepcopy(CONTROL)
+    hexadecimal = "a" * 96
+    digest = "sha384:" + hexadecimal
+    vector["build_provenance"]["digest"] = digest
+    vector["context"]["artifact_digest"] = digest
+    statement = _attestation(vector)
+    assert statement is not None
+    statement["subject"][0]["digest"] = {"sha256": hexadecimal}
+    return vector
+
+
+def test_a_hex_declared_under_another_algorithm_does_not_bind() -> None:
+    assert verify(_mislabelled_control(), "builder")["failures"] == [
+        "attestation_subject_mismatch"
+    ]
+
+
 @pytest.mark.parametrize("name,vector", FIXTURES, ids=[name for name, _ in FIXTURES])
 def test_verdicts_are_monotone_over_depth(name: str, vector: dict[str, Any]) -> None:
     """A deeper verifier never accepts what a shallower one rejected."""


### PR DESCRIPTION
Follow-up to #243. In the approving review, @lywinged wrote the missing wrong-label regression control directly. This PR commits that control as an executable test and verifies with a permissive mutant that it is load-bearing.

This commits the exact wrong-label control from @lywinged's review: a record declaring `sha384:X` must not bind when the same hexadecimal value appears only under the subject's `sha256` label. It distinguishes the specific permissive `digest.values()`-style implementation that the previous tests did not catch.

That specific mutant passes the previous 48 tests and fails this new control. This is a bounded reviewer-loop closure, not a claim of complete algorithm/value/subject binding coverage.

This changes tests only. It does not change verifier behavior, schemas, normative text, or wire formats.

Testing:

- Python 3.11: 49 focused passed; 1168 full-suite passed, 1 skipped
- Python 3.12: 49 focused passed; 1168 full-suite passed, 1 skipped
- Ruff, mypy, dash policy, and `git diff --check`: pass
