### PR TITLE
fix(content-marking): reject boolean assertion version

### DIFF
--- a/src/agentrust_trace/content_marking.py
+++ b/src/agentrust_trace/content_marking.py
@@ -136,9 +136,10 @@ def verify_assertion(assertion: dict[str, Any], record_bytes: bytes) -> dict[str
     data = assertion.get("data")
     if not isinstance(data, dict):
         raise ContentMarkingError("assertion has no data object")
-    if data.get("version") != ASSERTION_VERSION:
+    version = data.get("version")
+    if isinstance(version, bool) or version != ASSERTION_VERSION:
         raise ContentMarkingError(
-            f"unknown assertion version {data.get('version')!r}; expected {ASSERTION_VERSION}. "
+            f"unknown assertion version {version!r}; expected {ASSERTION_VERSION}. "
             "An unknown version is rejected rather than parsed best-effort."
         )
 

--- a/tests/test_content_marking_version_boundary.py
+++ b/tests/test_content_marking_version_boundary.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentrust_trace.content_marking import ContentMarkingError, build_assertion, verify_assertion
+
+URL = "https://registry.example/records/abc123.json"
+
+
+def _record_bytes() -> bytes:
+    return json.dumps(
+        {
+            "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+            "iat": 1760000000,
+            "subject": "spiffe://example.org/agent/image-bot",
+            "data_class": "public",
+        }
+    ).encode()
+
+
+def _assertion_with_version(version):
+    raw = _record_bytes()
+    assertion = build_assertion(raw, url=URL)
+    assertion["data"]["version"] = version
+    return assertion, raw
+
+
+def test_integer_version_one_is_accepted() -> None:
+    assertion, raw = _assertion_with_version(1)
+    assert verify_assertion(assertion, raw)["subject"] == "spiffe://example.org/agent/image-bot"
+
+
+@pytest.mark.parametrize("version", [True, False, "1", None, 2])
+def test_non_v1_version_values_are_refused(version) -> None:
+    assertion, raw = _assertion_with_version(version)
+    with pytest.raises(ContentMarkingError, match="unknown assertion version"):
+        verify_assertion(assertion, raw)
+
+
+def test_boolean_true_cannot_alias_integer_version_one() -> None:
+    assertion, raw = _assertion_with_version(True)
+    with pytest.raises(ContentMarkingError) as excinfo:
+        verify_assertion(assertion, raw)
+    assert "expected 1" in str(excinfo.value)


### PR DESCRIPTION
Closes #281.

## What

`content_marking.verify_assertion()` compared the peer-supplied assertion version directly with integer `1`:

```python
if data.get("version") != ASSERTION_VERSION:
```

Because Python treats `True == 1`, a JSON assertion carrying `"version": true` was accepted as version 1.

This change establishes the boolean boundary explicitly before the existing version comparison:

```python
version = data.get("version")
if isinstance(version, bool) or version != ASSERTION_VERSION:
```

The change is deliberately narrower than a general JSON-number rule. It does not make a claim about floating-point representations; it closes the unambiguous Python `bool`/`int` alias.

## Regression coverage

Focused coverage holds:

- integer `1` -> unchanged success;
- boolean `true` -> refusal;
- boolean `false` -> refusal;
- string `"1"` -> refusal;
- `null` -> refusal;
- integer `2` -> refusal.

A dedicated regression names the mutation property: restoring the old plain `!= 1` comparison makes boolean `true` alias the supported version again.

## Verification

The exact branch source and regression file were re-read after the writes. The predicate matrix was independently exercised for `1`, `true`, `false`, `"1"`, `null`, and `2`; only integer `1` is accepted by the new condition, while the previous condition accepts both `1` and `true`.

A repository-wide pytest/ruff/mypy run is not claimed here because the available execution environment for this contribution does not currently have the TRACE checkout/toolchain. No GitHub Actions run is claimed.

## Scope

Consumer-side primitive validation only. No wire-format, schema, cryptographic, downgrade, or C2PA behavior change.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, and diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.