### PR TITLE
fix(sandbox): validate required textual fields

### DIFF
--- a/src/agentrust_trace/adapters/sandbox.py
+++ b/src/agentrust_trace/adapters/sandbox.py
@@ -324,7 +324,7 @@ class TraceSandboxAdapter:
     def software_measurement(image_digest: str, bundle_hash: str) -> str:
         """The measurement for an unattested sandbox.
 
-        ``sha256(image_digest + "\n" + bundle_hash)`` over UTF-8, both operands in their
+        ``sha256(image_digest + "\\n" + bundle_hash)`` over UTF-8, both operands in their
         ``sha256:``-prefixed form. Deliberately simple so another implementation can
         reproduce it without a JSON library.
 

--- a/src/agentrust_trace/adapters/sandbox.py
+++ b/src/agentrust_trace/adapters/sandbox.py
@@ -96,6 +96,10 @@ class SandboxAttestation:
     nonce: str | None = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.platform, str):
+            raise ValueError(
+                f"SandboxAttestation.platform must be a string, got {type(self.platform).__name__}"
+            )
         if self.platform == "software-only":
             raise ValueError(
                 "SandboxAttestation.platform must not be 'software-only'. Omit the "
@@ -107,6 +111,11 @@ class SandboxAttestation:
             raise ValueError(
                 f"SandboxAttestation.platform {self.platform!r} is not an accepted "
                 f"platform. Accepted: {', '.join(sorted(_PLATFORMS))}."
+            )
+        if not isinstance(self.measurement, str):
+            raise ValueError(
+                "SandboxAttestation.measurement must be a string, got "
+                f"{type(self.measurement).__name__}"
             )
         if not _DIGEST_RE.match(self.measurement):
             raise ValueError(
@@ -151,11 +160,17 @@ class SandboxSessionResult:
     """Issuance timestamp. Defaults to now."""
 
     def __post_init__(self) -> None:
+        if not isinstance(self.sandbox_id, str):
+            raise ValueError(f"sandbox_id must be a string, got {type(self.sandbox_id).__name__}")
         if not _SUBJECT_RE.match(self.sandbox_id):
             raise ValueError(
                 f"sandbox_id {self.sandbox_id!r} must be a SPIFFE URI "
                 "('spiffe://<trust-domain>/<path>') or a DID ('did:<method>:<id>'). "
                 "It becomes the record subject, which is what a verifier keys on."
+            )
+        if not isinstance(self.image_digest, str):
+            raise ValueError(
+                f"image_digest must be a string, got {type(self.image_digest).__name__}"
             )
         if not _DIGEST_RE.match(self.image_digest):
             raise ValueError(
@@ -309,7 +324,7 @@ class TraceSandboxAdapter:
     def software_measurement(image_digest: str, bundle_hash: str) -> str:
         """The measurement for an unattested sandbox.
 
-        ``sha256(image_digest + "\\n" + bundle_hash)`` over UTF-8, both operands in their
+        ``sha256(image_digest + "\n" + bundle_hash)`` over UTF-8, both operands in their
         ``sha256:``-prefixed form. Deliberately simple so another implementation can
         reproduce it without a JSON library.
 

--- a/tests/test_sandbox_required_string_fields.py
+++ b/tests/test_sandbox_required_string_fields.py
@@ -1,0 +1,59 @@
+"""Regression tests for sandbox adapter required-string primitive boundaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentrust_trace.adapters.sandbox import SandboxAttestation, SandboxSessionResult
+
+DIGEST = "sha256:" + "a" * 64
+BAD_VALUES: tuple[Any, ...] = (True, 1, [1], {"x": 1})
+
+
+@pytest.mark.parametrize("platform", BAD_VALUES, ids=repr)
+def test_attestation_platform_refuses_non_string_values(platform: Any) -> None:
+    with pytest.raises(ValueError, match="SandboxAttestation.platform"):
+        SandboxAttestation(platform=platform, measurement=DIGEST)
+
+
+@pytest.mark.parametrize("measurement", BAD_VALUES, ids=repr)
+def test_attestation_measurement_refuses_non_string_values(measurement: Any) -> None:
+    with pytest.raises(ValueError, match="SandboxAttestation.measurement"):
+        SandboxAttestation(platform="tpm2", measurement=measurement)
+
+
+@pytest.mark.parametrize("sandbox_id", BAD_VALUES, ids=repr)
+def test_session_sandbox_id_refuses_non_string_values(sandbox_id: Any) -> None:
+    with pytest.raises(ValueError, match="sandbox_id"):
+        SandboxSessionResult(
+            sandbox_id=sandbox_id,
+            image_digest=DIGEST,
+            policy_bundle_bytes=b"policy",
+            decisions=[],
+        )
+
+
+@pytest.mark.parametrize("image_digest", BAD_VALUES, ids=repr)
+def test_session_image_digest_refuses_non_string_values(image_digest: Any) -> None:
+    with pytest.raises(ValueError, match="image_digest"):
+        SandboxSessionResult(
+            sandbox_id="spiffe://runtime.example.org/sandbox/test",
+            image_digest=image_digest,
+            policy_bundle_bytes=b"policy",
+            decisions=[],
+        )
+
+
+def test_textual_controls_still_construct() -> None:
+    attestation = SandboxAttestation(platform="tpm2", measurement=DIGEST)
+    session = SandboxSessionResult(
+        sandbox_id="spiffe://runtime.example.org/sandbox/test",
+        image_digest=DIGEST,
+        policy_bundle_bytes=b"policy",
+        decisions=[],
+        attestation=attestation,
+    )
+    assert attestation.platform == "tpm2"
+    assert session.sandbox_id.startswith("spiffe://")


### PR DESCRIPTION
Closes #289.

## What

The sandbox adapter's public dataclasses accepted several runtime-supplied values directly into regex or membership checks before establishing that they were strings. Malformed non-string inputs could therefore escape as bare `TypeError` instead of the adapter's field-specific `ValueError` refusal.

This change establishes the primitive boundary for:

- `SandboxAttestation.platform`;
- `SandboxAttestation.measurement`;
- `SandboxSessionResult.sandbox_id`;
- `SandboxSessionResult.image_digest`.

The existing accepted syntax and semantics are unchanged.

## Regression coverage

Focused tests exercise representative non-string values (`True`, integer `1`, array `[1]`, object {"x": 1}) across all four required textual fields, plus valid textual controls.

## Scope

No schema change, no wire-format change, no URL/digest syntax widening, and no change to optional sandbox fields.

AI-assistance disclosure: ChatGPT assisted with source triage, adversarial-case design, implementation drafting, duplicate/ownership review, and diff review. `altrudev` reviewed the bounded claim and remains responsible for the contribution.