### PR TITLE
docs: run the checks CI runs, and what a green one does not prove

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Install the development dependencies and run the suite from the repository root:
 ```bash
 pip install -e ".[dev]"
 pytest
-ruff check src tests
+ruff check src tests scripts
+python tools/check_dashes.py
 mypy src/agentrust_trace
 ```
 
@@ -17,6 +18,16 @@ Pytest is configured to import `src/agentrust_trace` from the checkout. A stale
 wheel installed elsewhere in the environment must not shadow the code under
 test; a regression test fails with the resolved import path if that guarantee is
 lost.
+
+A check turning green is not a review of the edit that turned it green. Each of
+these was built to see one thing, and none of them sees what your repair
+introduced. `tools/check_dashes.py` bans four characters and prints the form to
+use instead, and it cannot tell whether you used that form. Take an en dash out
+of a range, put a bare `to` in its place, and you have `1to3` where `1 to 3` was
+meant, with the check passing: a ban on a character cannot see the shape of the
+replacement. Read the changed line in the shape a reader meets it, rendered
+rather than as source, and run something that could have caught the new mistake.
+The check you just fixed is not that something.
 
 ## Using AI to contribute
 


### PR DESCRIPTION
## What this changes

`CONTRIBUTING.md` only. The command block under "Running the reference-library checks" now lists the checks CI runs, and a paragraph after it says what a passing check does not establish.

Two of CI's steps were not reachable from this file. `ci.yml` runs `ruff check src tests scripts`; the file said `ruff check src tests`. `ci.yml` runs `python tools/check_dashes.py` as a step of its own; the file did not mention it. A contributor following this file meets both for the first time as a red build. The five commands now match CI one for one, except that CI adds coverage flags to `pytest`; the block keeps the bare form it already carried.

The paragraph is there because of what a red build invites. A ban on a character cannot see the shape of its replacement: take an en dash out of a range, put a bare `to` in its place, and the checker passes on `1to3` where `1 to 3` was meant. The general form is that the check you just fixed is the one instrument guaranteed not to see what your fix introduced, so it cannot be the evidence that your fix is right. `tools/check_dashes.py` already prints the intended form for each character it bans, which is advice rather than an instrument, and nothing verifies that the repair used it.

## Type of change

- [x] Editorial (typo, link fix, clarification: no normative effect)

## Spec section

None. No normative text, no schema change.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not applicable, and recent docs-only changes to this file carry no entry
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN: description -->` in spec text: not applicable
- [ ] Backward compatibility statement included (for breaking changes): not applicable

Tool-assisted: the comparison against `ci.yml` and this write-up.
