### PR TITLE
fix(schema): refuse private key material in cnf.jwk

### DIFF
--- a/schema/trace-claim.json
+++ b/schema/trace-claim.json
@@ -472,6 +472,46 @@
               }
             }
           ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "d"
+                ]
+              },
+              {
+                "required": [
+                  "p"
+                ]
+              },
+              {
+                "required": [
+                  "q"
+                ]
+              },
+              {
+                "required": [
+                  "dp"
+                ]
+              },
+              {
+                "required": [
+                  "dq"
+                ]
+              },
+              {
+                "required": [
+                  "qi"
+                ]
+              },
+              {
+                "required": [
+                  "k"
+                ]
+              }
+            ]
+          },
+          "$comment": "RFC 8747 defines cnf as a confirmation key: the public half, present so a verifier can bind the record to the key that signed it. A private member here publishes the signing key inside the signed, self-authenticating, typically anchored record, and the only remedy afterwards is to revoke the identity. Mirrors _JWK_PRIVATE_PARAMS in the reference model, which already refuses these.",
           "additionalProperties": {
             "$ref": "#/$defs/canonicalizableValue"
           }

--- a/src/agentrust_trace/schema/trace-v0.2.json
+++ b/src/agentrust_trace/schema/trace-v0.2.json
@@ -472,6 +472,46 @@
               }
             }
           ],
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "d"
+                ]
+              },
+              {
+                "required": [
+                  "p"
+                ]
+              },
+              {
+                "required": [
+                  "q"
+                ]
+              },
+              {
+                "required": [
+                  "dp"
+                ]
+              },
+              {
+                "required": [
+                  "dq"
+                ]
+              },
+              {
+                "required": [
+                  "qi"
+                ]
+              },
+              {
+                "required": [
+                  "k"
+                ]
+              }
+            ]
+          },
+          "$comment": "RFC 8747 defines cnf as a confirmation key: the public half, present so a verifier can bind the record to the key that signed it. A private member here publishes the signing key inside the signed, self-authenticating, typically anchored record, and the only remedy afterwards is to revoke the identity. Mirrors _JWK_PRIVATE_PARAMS in the reference model, which already refuses these.",
           "additionalProperties": {
             "$ref": "#/$defs/canonicalizableValue"
           }

--- a/tests/test_provenance_cnf_boundary.py
+++ b/tests/test_provenance_cnf_boundary.py
@@ -76,3 +76,59 @@ def test_valid_embedded_cnf_jwk_still_verifies() -> None:
     record["signature"] = base64.urlsafe_b64encode(key.sign(body)).rstrip(b"=").decode()
 
     verify_record(record, trusted)
+
+
+# ---------------------------------------------------------------------------
+# GHSA-vc4p-h84j-7qxj: cnf.jwk accepted private key material, so a record could
+# publish the key that signed it.
+#
+# RFC 8747 defines cnf as a confirmation key: the public half, present so a
+# verifier can bind the record to the key that signed it. models.TrustRecord
+# already refused d/p/q/dp/dq/qi/k, but the verification path validates against
+# the schema rather than the model, and the schema's jwk block carried no
+# constraint on private members. No attacker is involved; this is a producer
+# mistake the format did not defend against, and the consequence is durable:
+# the record is signed, self-authenticating and typically anchored, so the only
+# remedy after the fact is to revoke the identity.
+# ---------------------------------------------------------------------------
+
+_PRIVATE_JWK_MEMBERS = ["d", "p", "q", "dp", "dq", "qi", "k"]
+
+
+def _jwk_schema():
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads((root / "schema" / "trace-claim.json").read_text(encoding="utf-8"))
+    return schema["properties"]["cnf"]["properties"]["jwk"]
+
+
+@pytest.mark.parametrize("member", _PRIVATE_JWK_MEMBERS)
+def test_schema_refuses_private_key_material_in_cnf_jwk(member: str) -> None:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(_jwk_schema())
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": "abc", member: "SECRET"}
+
+    assert not validator.is_valid(jwk)
+
+
+def test_schema_still_accepts_an_ordinary_public_jwk() -> None:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(_jwk_schema())
+
+    assert validator.is_valid({"kty": "OKP", "crv": "Ed25519", "x": "abc"})
+    assert validator.is_valid({"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"})
+
+
+def test_the_two_schema_copies_stay_in_step() -> None:
+    """schema/ is the published artifact, src/ is what the package ships."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    published = (root / "schema" / "trace-claim.json").read_bytes()
+    packaged = (root / "src" / "agentrust_trace" / "schema" / "trace-v0.2.json").read_bytes()
+
+    assert published == packaged


### PR DESCRIPTION
Closes GHSA-vc4p-h84j-7qxj. Reproduced against current `main` before changing anything.

## The gap

RFC 8747 defines `cnf` as a confirmation key: the **public** half, carried so a verifier can bind the record to the key that signed it.

`models.TrustRecord` already knew that. It refuses `d`, `p`, `q`, `dp`, `dq`, `qi` and `k` via `_JWK_PRIVATE_PARAMS`, with the comment *"cnf.jwk is a public proof-of-possession key"*.

But the verification path validates against `schema/trace-claim.json`, not the model. The schema's `jwk` block constrained only the `kty`/`crv`/`x`/`y` shapes through two `if`/`then` entries; everything else fell through `additionalProperties`. So a Trust Record carrying its own **private** key validated cleanly and `verify_record` accepted it.

The rule existed, and only in the half that verification does not call.

## Why it matters even with no attacker

There is no attacker step here. This is a producer mistake the format did not defend against. What makes it worth fixing rather than documenting is that the consequence is durable: the record is signed, self-authenticating, and typically anchored. Once it is out, the key is out, and the only remedy is to revoke the identity.

`sign.sign_record` could never produce this, because it builds `cnf` from `key_to_jwk`, which returns the public half only. The exposure is a record assembled by hand or by another implementation, which is exactly the population a published schema exists to constrain.

## The fix

A `not`/`anyOf` constraint over the seven private JWK members, placed alongside the existing `allOf` shape rules, mirroring `_JWK_PRIVATE_PARAMS` in the reference model. Public JWKs are unaffected.

Applied to both copies, `schema/trace-claim.json` (the published artifact) and `src/agentrust_trace/schema/trace-v0.2.json` (what the package ships). They were byte-identical and still are, with a test that keeps them that way, since drifting copies is how this kind of gap survives a fix.

## Tests

Nine in `test_provenance_cnf_boundary.py`: one per private member, two that ordinary OKP and EC public JWKs still validate, and the copy-equality check. Reverting the schema turns all seven member tests red.

Full suite: 1172 passed, with the same 4 failures that reproduce on a clean `main` (three fixture-regeneration tests and one schema-classification test, all unrelated).

## Not fixed here

`agentrust-io/trace-tests` carries a third copy of this schema with the same gap, and its conformance modules do not inspect `cnf.jwk` members (`TR-ENV-004` checks only that `kty` is present, so a record carrying `d` passes the suite). Tracked separately against that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbDBXDWWvMFa7c2jGgyq9t
