### PR TITLE
fix: recognize lywinged as a trace-spec code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for all files
-* @agentrust-io/maintainers
+* @agentrust-io/maintainers @lywinged
 
 # CI/CD workflow changes
-.github/workflows/ @agentrust-io/maintainers
+.github/workflows/ @agentrust-io/maintainers @lywinged

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,14 @@ The Project Lead has final decision authority on specification changes, AAIF/CoS
 | Rishabh Poddar | OPAQUE Systems | Specification, TEE profiles |
 | Aaron Fulkerson | OPAQUE Systems | Specification, governance |
 
+## Repository Maintainers
+
+| Name | GitHub | Scope |
+|---|---|---|
+| Louie Lu | [@lywinged](https://github.com/lywinged) | TRACE specification and conformance requirements |
+
+Louie's appointment was [announced by the Project Lead](https://github.com/orgs/agentrust-io/discussions/33).
+
 ## How to become a maintainer
 
 **Reviewer**: 3+ merged PRs with substantive contributions. Nominated by a Maintainer, confirmed by Project Lead.


### PR DESCRIPTION
## What this changes

Louie Lu already has direct Maintain access and is recognized by the maintainer-approval workflow, but required CODEOWNER reviews still recognize only the older organization team. Add @lywinged alongside that team for both default and workflow ownership in trace-spec, and record his [announced appointment](https://github.com/orgs/agentrust-io/discussions/33) in MAINTAINERS.md.

This change is confined to trace-spec. It preserves existing owners and branch rules. The workflow-specific rule also needs his name because CODEOWNERS uses the last matching rule.

## Type of change

Repository ownership and maintainer documentation; no normative specification change.

## Spec section

None.

## Validation

- Verified active direct Maintain access through GitHub's collaborators API.
- Confirmed the approval workflow already includes lywinged.
- Reviewed both CODEOWNERS rules and ran `git diff --check` successfully.
- No runtime code changed; runtime tests were not run locally.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- CHANGELOG and breaking-change requirements: not applicable.
