### PR TITLE
test: add non-JCS signature rejection controls

### DIFF
--- a/examples/canonicalization-boundary/05-ascii-escaped-signature.json
+++ b/examples/canonicalization-boundary/05-ascii-escaped-signature.json
@@ -1,0 +1,58 @@
+{
+  "name": "ascii-escaped-signature",
+  "description": "The payload of vector 01 signed over compact ASCII-escaped JSON rather than RFC 8785 bytes. Its signature verifies over that published alternate preimage but is not a valid TRACE signature. Canonical re-signing of the same payload passes.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6",
+      "version": "modèle-géant-4.6"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "机密",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+      }
+    },
+    "signature": "x3ScchNmGFqQViQ6TNCBIpeRO9nkp9GwIQVC3fOLFnjPjXM1ucJwezSmx2SvW8DG58dxD762k6tqRZ0L4xZzCA"
+  },
+  "expected": {
+    "outcome": "rejected",
+    "failure": "signature_invalid"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact"
+  ],
+  "signing_form": "sort_keys_compact",
+  "signed_input_utf8": "{\"appraisal\":{\"status\":\"affirming\",\"verifier\":\"https://verifier.example/v1\"},\"build_provenance\":{\"digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"slsa_level\":0},\"cnf\":{\"jwk\":{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA\"}},\"data_class\":\"\\u673a\\u5bc6\",\"eat_profile\":\"tag:agentrust-io.com,2026:trace-v0.2\",\"iat\":1785000000,\"model\":{\"model_id\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"version\":\"mod\\u00e8le-g\\u00e9ant-4.6\"},\"policy\":{\"bundle_hash\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"enforcement_mode\":\"enforce\"},\"runtime\":{\"measurement\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"platform\":\"software-only\"},\"subject\":\"spiffe://factory.example/agent/payments/prod\",\"transparency\":\"https://rekor.example/api/v1/log/entries/0\"}",
+  "canonical_input_utf8": "{\"appraisal\":{\"status\":\"affirming\",\"verifier\":\"https://verifier.example/v1\"},\"build_provenance\":{\"digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"slsa_level\":0},\"cnf\":{\"jwk\":{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA\"}},\"data_class\":\"机密\",\"eat_profile\":\"tag:agentrust-io.com,2026:trace-v0.2\",\"iat\":1785000000,\"model\":{\"model_id\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"version\":\"modèle-géant-4.6\"},\"policy\":{\"bundle_hash\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"enforcement_mode\":\"enforce\"},\"runtime\":{\"measurement\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"platform\":\"software-only\"},\"subject\":\"spiffe://factory.example/agent/payments/prod\",\"transparency\":\"https://rekor.example/api/v1/log/entries/0\"}"
+}

--- a/examples/canonicalization-boundary/06-codepoint-order-signature.json
+++ b/examples/canonicalization-boundary/06-codepoint-order-signature.json
@@ -1,0 +1,60 @@
+{
+  "name": "codepoint-order-signature",
+  "description": "The payload of vector 03 signed over compact literal-UTF8 JSON with code-point key ordering. Only key order differs from RFC 8785; ASCII escaping is not the defect. The published alternate signature is cryptographically valid, but TRACE verification rejects it.",
+  "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an RFC 8785-conformant library",
+  "profile": "trace.canonicalization.boundary.v0",
+  "trusted_key": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA"
+  },
+  "record": {
+    "eat_profile": "tag:agentrust-io.com,2026:trace-v0.2",
+    "iat": 1785000000,
+    "subject": "spiffe://factory.example/agent/payments/prod",
+    "model": {
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-4-6"
+    },
+    "runtime": {
+      "platform": "software-only",
+      "measurement": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "policy": {
+      "bundle_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "enforcement_mode": "enforce"
+    },
+    "data_class": "confidential",
+    "build_provenance": {
+      "slsa_level": 0,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "appraisal": {
+      "status": "affirming",
+      "verifier": "https://verifier.example/v1"
+    },
+    "transparency": "https://rekor.example/api/v1/log/entries/0",
+    "cnf": {
+      "jwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA",
+        "zk😀": "sorts-first-under-rfc-8785",
+        "zk�": "sorts-second-under-rfc-8785"
+      }
+    },
+    "signature": "XYFPaOjIpfD1IQ3G1y3T4MYmLjVz4-SFCv46WqH-jV-TtaNyEvmHf_Z2Cn80NM4J-Bn5H5WjquPFGpIKXCDUBA"
+  },
+  "expected": {
+    "outcome": "rejected",
+    "failure": "signature_invalid"
+  },
+  "diverges_under": [
+    "sort_keys_default",
+    "sort_keys_compact",
+    "sort_keys_compact_utf8"
+  ],
+  "signing_form": "sort_keys_compact_utf8",
+  "signed_input_utf8": "{\"appraisal\":{\"status\":\"affirming\",\"verifier\":\"https://verifier.example/v1\"},\"build_provenance\":{\"digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"slsa_level\":0},\"cnf\":{\"jwk\":{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA\",\"zk�\":\"sorts-second-under-rfc-8785\",\"zk😀\":\"sorts-first-under-rfc-8785\"}},\"data_class\":\"confidential\",\"eat_profile\":\"tag:agentrust-io.com,2026:trace-v0.2\",\"iat\":1785000000,\"model\":{\"model_id\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\"},\"policy\":{\"bundle_hash\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"enforcement_mode\":\"enforce\"},\"runtime\":{\"measurement\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"platform\":\"software-only\"},\"subject\":\"spiffe://factory.example/agent/payments/prod\",\"transparency\":\"https://rekor.example/api/v1/log/entries/0\"}",
+  "canonical_input_utf8": "{\"appraisal\":{\"status\":\"affirming\",\"verifier\":\"https://verifier.example/v1\"},\"build_provenance\":{\"digest\":\"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"slsa_level\":0},\"cnf\":{\"jwk\":{\"crv\":\"Ed25519\",\"kty\":\"OKP\",\"x\":\"Be97jkxfFpVXzj9B-gwpMzv5t8PH30Edd-J7AIlrdoA\",\"zk😀\":\"sorts-first-under-rfc-8785\",\"zk�\":\"sorts-second-under-rfc-8785\"}},\"data_class\":\"confidential\",\"eat_profile\":\"tag:agentrust-io.com,2026:trace-v0.2\",\"iat\":1785000000,\"model\":{\"model_id\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\"},\"policy\":{\"bundle_hash\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"enforcement_mode\":\"enforce\"},\"runtime\":{\"measurement\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"platform\":\"software-only\"},\"subject\":\"spiffe://factory.example/agent/payments/prod\",\"transparency\":\"https://rekor.example/api/v1/log/entries/0\"}"
+}

--- a/examples/canonicalization-boundary/README.md
+++ b/examples/canonicalization-boundary/README.md
@@ -3,59 +3,99 @@
 Spec section 3.2.2 requires an RFC 8785-conformant canonicalizer and names
 `json.dumps(sort_keys=True)` as insufficient.
 
-**What already existed.** `tests/test_sign.py` carries four literal-byte known-answer
-tests over `_canonical_bytes` — non-ASCII escaping, number formatting, whitespace and
-key sorting, and a comparison against the reference library. They are good tests and
-they do catch a regression in this library.
+**What already existed.** `tests/test_sign.py` carries literal-byte known-answer
+tests over `_canonical_bytes`: non-ASCII escaping, number formatting, whitespace and
+key sorting, and a comparison against the reference library. Those tests catch a
+regression in this library.
 
-**What these vectors add.** Two things those tests cannot do:
+**What these vectors add.** Portable positive and negative controls over complete,
+schema-valid records, with deterministic signatures:
 
 1. **They are portable.** A known-answer test over a private function is runnable only
    from Python, by this package. The roadmap targets Go, Rust and TypeScript verifiers
    for v1.0, and none of them can run `test_sign.py`. These are signed records: any
-   implementation runs them against its own verifier. Every *other* record in the
-   repository is ASCII-only with schema-fixed keys, where all serializers agree
-   byte-for-byte — so no existing record's acceptance depends on canonicalizing
-   correctly.
-2. **One of them separates key ordering, which nothing else does.**
+   implementation can run them against its own verifier. ASCII-only values and
+   schema-fixed keys can conceal the differences between JCS and ad-hoc serializers;
+   these records deliberately exercise those differences.
+2. **They separate key ordering from escaping.**
    `test_jcs_distinguishes_unicode_key_order_from_json_dumps` compares `{"z": 1,
    "\U0001f600": 2}`. Under RFC 8785's UTF-16 code-unit sort and under Python's
-   code-point sort that object serializes in the *same* order — its own docstring says
-   so — and the test detects divergence through `ensure_ascii` escaping instead. A
-   canonicalizer that sorts by code point but emits raw UTF-8 passes it. Vector `03`
-   is the first object in the repository whose two orderings actually disagree.
+   code-point sort that object serializes in the *same* order; its own docstring says
+   so. The test detects divergence through `ensure_ascii` escaping instead. A
+   canonicalizer that sorts by code point but emits raw UTF-8 passes it. Vectors `03`
+   and `04` instead contain keys whose two orderings disagree, at different nesting
+   depths.
+3. **They require both accepting and rejecting answers.** The original four
+   fixtures expect acceptance. Fixtures `05` and `06` retain valid record shapes and
+   genuine Ed25519 signatures, but those signatures cover different bytes from the
+   RFC 8785 signing preimage. A conformant verifier rejects them. This supplies the
+   missing direction recorded by
+   [the corpus adequacy checks](../../tests/test_adequacy_all_sets.py), without
+   changing the signature contract.
 
-Each record is schema-valid and correctly signed over its RFC 8785 bytes, so a
-conformant verifier accepts it, and a verifier built on any ad-hoc form computes
-different signing bytes and rejects a valid record.
+The positive records are correctly signed over their RFC 8785 bytes. The negative
+records have signatures that are mathematically valid over their declared alternate
+preimages, but are not valid TRACE signatures over those records. This is not a
+test of rejecting random signature bytes, a different trust key, or malformed JSON.
 
 ## The ladder
 
-Each form fixes the previous one's divergence and still fails somewhere:
+Each ad-hoc form fixes the previous one's divergence and still rejects at least one
+positive record. The two negative records also distinguish a verifier that tries
+alternate serializations after JCS signature verification fails:
 
-| Form | Diverges because | Caught by |
+| Form | Diverges because | Positive vectors that it rejects |
 |---|---|---|
-| `json.dumps(o, sort_keys=True)` | Default separators insert spaces | every vector (and any signed record) |
-| `… separators=(",", ":")` | `ensure_ascii` escapes non-ASCII as `\uXXXX`; RFC 8785 emits literal UTF-8 | `01`, `02`, `03` |
-| `… separators=(",", ":"), ensure_ascii=False` | Python sorts keys by code point; RFC 8785 sorts by UTF-16 code units. The orders differ exactly when a key contains a supplementary-plane character | `03` only |
+| `json.dumps(o, sort_keys=True)` | Default separators insert spaces | `01`, `02`, `03`, `04` |
+| `json.dumps(o, sort_keys=True, separators=(",", ":"))` | `ensure_ascii` escapes non-ASCII as `\uXXXX`; RFC 8785 emits literal UTF-8 | `01`, `02`, `03`, `04` |
+| `json.dumps(o, sort_keys=True, separators=(",", ":"), ensure_ascii=False)` | Code-point key order can differ from RFC 8785's UTF-16 code-unit order | `03`, `04` |
 
-`03-utf16-key-order.json` is the load-bearing vector: it is the only record in this
-repository that distinguishes a true RFC 8785 serializer from `json.dumps` with every
-option chosen carefully. Its two extra `cnf.jwk` members (RFC 7517 permits additional
-JWK members, and `cnf.jwk` is the one schema object open to them) are `zk` followed by
-U+1F600 and `zk` followed by U+FFFD — U+1F600 is `D83D DE00` in UTF-16, so it sorts
+`03-utf16-key-order.json` carries two extra `cnf.jwk` members (RFC 7517 permits
+additional JWK members): `zk` followed by U+1F600 and `zk` followed by U+FFFD.
+U+1F600 is `D83D DE00` in UTF-16, so it sorts
 *before* U+FFFD by code units and *after* it by code points.
+`04-utf16-key-order-nested.json` moves that divergence inside another object, so the
+set does not depend on one key-order vector at one nesting depth.
+
+## Negative signing-preimage controls
+
+| Vector | Bytes actually signed | Expected result |
+|---|---|---|
+| `05-ascii-escaped-signature.json` | Compact JSON with non-ASCII string values escaped | `rejected`, `signature_invalid` |
+| `06-codepoint-order-signature.json` | Compact literal-UTF-8 JSON with keys sorted by code point | `rejected`, `signature_invalid` |
+
+For each negative, the tests check the schema and configured key, verify the
+signature over the declared alternate bytes, and confirm that those bytes differ
+from the RFC 8785 form. Verification over the RFC 8785 form fails. Re-signing the
+same payload over its RFC 8785 form succeeds, isolating the signing preimage as the
+reason for rejection. The two forms test different serialization shortcuts rather
+than two arbitrary corruptions of a signature.
+
+The whitespace, escaping and key order of the outer fixture file are not the
+signature preimage. A consumer parses the `record` object and canonicalizes it with
+only `signature` absent. Pretty-printing that same object does not invalidate a
+correct TRACE signature. These fixtures are generated here; they are not evidence
+of an independent producer or a test of delegation parent-record hash semantics.
 
 ## What each fixture carries
 
-- `record` — a complete, schema-valid, signed v0.2 Trust Record.
-- `trusted_key` — the Ed25519 JWK to verify against.
-- `expected.outcome` — `verified`, always. These are positive vectors; the negative
-  behaviour (rejection) is what a non-conformant verifier does to them.
-- `diverges_under` — which ad-hoc forms compute different bytes for this record.
+- `record`: a complete, schema-valid v0.2 record with an embedded signature.
+- `trusted_key`: the Ed25519 JWK selected externally for verification.
+- `expected.outcome`: `verified` for `01` through `04`, or `rejected` for `05` and
+  `06`; the negatives also carry `expected.failure: signature_invalid`.
+- `diverges_under`: which ad-hoc forms compute different bytes for this record.
   `tests/test_canonicalization_boundary.py` recomputes this list on every run rather
   than trusting it, and separately asserts that the set as a whole still catches every
   form on the ladder.
+- `signing_form` (negative fixtures): identifies the alternate serialization that
+  produced the signed bytes.
+- `signed_input_utf8` (negative fixtures): the actual signing preimage as a JSON
+  string; encode its decoded value as UTF-8 to recover the bytes.
+- `canonical_input_utf8` (negative fixtures): the RFC 8785 preimage in the same
+  representation, recomputed by the tests rather than trusted as an assertion.
+
+These fixture metadata fields are outside `record`. They describe the test; they
+are not new TRACE fields or instructions to a verifier to accept another form.
 
 `iat` is fixed so the set regenerates byte-for-byte; run with freshness disabled or
 with `iat`'s instant supplied as "now". `gen_boundary_vectors.py` regenerates the set.
@@ -90,7 +130,7 @@ range produce one digest under `canonicalize` 4.0.0. Section 3.2.2 states the ru
 object canonicalized under it, and here `rfc8785` refuses the value, which is pinned as
 behaviour rather than assumed.
 
-So neither half is reachable now, and neither can be carried by a vector here: a positive
+So neither half is reachable now, and neither can be carried by a vector here: every
 vector is a schema-valid record, and these cases are exactly the records the schema
 rejects. The tests in this directory carry them instead, structurally and behaviourally.
 If a `number` field is ever wanted, `test_no_schema_field_is_typed_number` is the place to

--- a/examples/canonicalization-boundary/gen_boundary_vectors.py
+++ b/examples/canonicalization-boundary/gen_boundary_vectors.py
@@ -2,15 +2,17 @@
 
 The spec: "Implementations MUST use an RFC 8785-conformant library. Using
 `json.dumps(sort_keys=True)` (Python) or equivalent ad-hoc sorting is insufficient."
-No published test material exercised that sentence: every existing record is
-ASCII-only with schema-fixed keys, and on such records every ad-hoc serializer agrees
-with RFC 8785 byte-for-byte, so an implementation using one passes everything.
+ASCII-only values and schema-fixed keys can conceal escaping and key-order
+differences. These portable records make the signature-byte contract observable.
 
-These are the records on which they disagree. Each is schema-valid and correctly
-signed over its RFC 8785 bytes, and each carries ``diverges_under`` — the ad-hoc
-canonicalizations whose output differs, so that a verifier built on them computes
-different bytes and rejects a valid record. ``tests/test_canonicalization_boundary.py``
-recomputes that list rather than trusting it.
+These are the records on which they disagree. The four positive records are
+schema-valid and correctly signed over RFC 8785 bytes. Two negative controls use
+the same payloads but sign different, non-JCS byte forms: their Ed25519 signatures
+are valid over those declared preimages, not valid TRACE signatures. Each carries
+``diverges_under`` — the ad-hoc canonicalizations whose output differs from JCS.
+For positive vectors these forms reject valid records; the negatives instead
+expose acceptance of signatures over an alternate form. The tests recompute
+this list rather than trusting it.
 
 The ad-hoc forms make a ladder, each rung needing a sharper vector to expose:
 
@@ -95,10 +97,23 @@ BASE_RECORD: dict[str, Any] = {
 }
 
 
-def signed(record: dict[str, Any]) -> dict[str, Any]:
+def signing_bytes(body: dict[str, Any], form: str) -> bytes:
+    """Fixture generation only; no alternate serialization is accepted by TRACE."""
+    if form == "rfc8785":
+        return rfc8785.dumps(body)
+    if form == "sort_keys_compact":
+        return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if form == "sort_keys_compact_utf8":
+        return json.dumps(
+            body, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode("utf-8")
+    raise ValueError(f"unknown fixture signing form: {form}")
+
+
+def signed(record: dict[str, Any], *, signing_form: str = "rfc8785") -> dict[str, Any]:
     body = dict(record)
     body["cnf"] = {"jwk": {**public_jwk(), **body.get("cnf", {}).get("jwk", {})}}
-    body["signature"] = b64u(KEY.sign(rfc8785.dumps(body)))
+    body["signature"] = b64u(KEY.sign(signing_bytes(body, signing_form)))
     return body
 
 
@@ -107,18 +122,29 @@ def vector(
     description: str,
     record: dict[str, Any],
     diverges_under: list[str],
+    *,
+    signing_form: str = "rfc8785",
 ) -> dict[str, Any]:
-    return {
+    result: dict[str, Any] = {
         "name": name,
         "description": description,
         "spec": "trace-v0.2 section 3.2.2 — implementations MUST use an "
         "RFC 8785-conformant library",
         "profile": "trace.canonicalization.boundary.v0",
         "trusted_key": public_jwk(),
-        "record": signed(record),
+        "record": signed(record, signing_form=signing_form),
         "expected": {"outcome": "verified"},
         "diverges_under": diverges_under,
     }
+    if signing_form != "rfc8785":
+        body = {key: value for key, value in result["record"].items() if key != "signature"}
+        result["expected"] = {"outcome": "rejected", "failure": "signature_invalid"}
+        result["signing_form"] = signing_form
+        # Exact UTF-8 preimages, encoded as JSON strings for portable inspection.
+        # These are fixture metadata, not fields added to the Trust Record.
+        result["signed_input_utf8"] = signing_bytes(body, signing_form).decode("utf-8")
+        result["canonical_input_utf8"] = rfc8785.dumps(body).decode("utf-8")
+    return result
 
 
 def main() -> None:
@@ -196,6 +222,36 @@ def main() -> None:
         "with that vector.",
         r,
         ["sort_keys_default", "sort_keys_compact", "sort_keys_compact_utf8"],
+    )))
+
+    # Negative controls keep the unsigned payloads of 01 and 03 unchanged. Only
+    # the signature preimage changes; schema, trust key and timestamp cannot be
+    # the reason a conformant verifier refuses them. Neither expected result is
+    # inferred from running the verifier under test.
+    r = {key: copy.deepcopy(value) for key, value in out[0][1]["record"].items()
+         if key != "signature"}
+    out.append(("05-ascii-escaped-signature.json", vector(
+        "ascii-escaped-signature",
+        "The payload of vector 01 signed over compact ASCII-escaped JSON rather "
+        "than RFC 8785 bytes. Its signature verifies over that published alternate "
+        "preimage but is not a valid TRACE signature. Canonical re-signing of the "
+        "same payload passes.",
+        r,
+        ["sort_keys_default", "sort_keys_compact"],
+        signing_form="sort_keys_compact",
+    )))
+
+    r = {key: copy.deepcopy(value) for key, value in out[2][1]["record"].items()
+         if key != "signature"}
+    out.append(("06-codepoint-order-signature.json", vector(
+        "codepoint-order-signature",
+        "The payload of vector 03 signed over compact literal-UTF8 JSON with "
+        "code-point key ordering. Only key order differs from RFC 8785; ASCII "
+        "escaping is not the defect. The published alternate signature is "
+        "cryptographically valid, but TRACE verification rejects it.",
+        r,
+        ["sort_keys_default", "sort_keys_compact", "sort_keys_compact_utf8"],
+        signing_form="sort_keys_compact_utf8",
     )))
 
     for name, doc in out:

--- a/tests/test_adequacy_all_sets.py
+++ b/tests/test_adequacy_all_sets.py
@@ -4,12 +4,11 @@ The criteria come from defects found on real sets. A standard that only ever mea
 other people's work is advocacy, so this module measures every set by the same loader
 and records the shortfalls where they fall rather than where it would be comfortable.
 
-Where they fall today: `canonicalization-boundary`, which is ours, expects acceptance
-in every vector, so it cannot tell a conformant verifier from one that accepts
-unconditionally. That is recorded in `KNOWN_ONE_DIRECTIONAL` with the record asserted
-exactly, so it cannot widen unnoticed and the entry is deleted when the missing
-direction is added. `build-provenance-depth` carries a margin at every boundary and
-nothing is recorded against it.
+`canonicalization-boundary` previously expected acceptance in every vector, so it
+could not tell a conformant verifier from one that accepts unconditionally. Its
+non-JCS signing-preimage negatives supply the missing direction. No set currently
+needs an exemption in `KNOWN_ONE_DIRECTIONAL`; any future shortfall is recorded
+exactly rather than allowed to widen unnoticed.
 
 A set is measured here or named in `MEASURED_ELSEWHERE` with the test that covers it.
 Neither is possible to skip: `test_every_vector_set_on_disk_is_measured_somewhere`
@@ -137,15 +136,12 @@ SETS = {
 # only ever expects rejection is passed by one that rejects everything; a set that
 # only ever expects acceptance is passed by one that accepts everything, and that
 # half is the one that gets left out.
-# One set is knowingly one-directional. `canonicalization-boundary` detects a
-# non-conformant canonicalizer by the fact that it *rejects* records a conformant
-# verifier accepts, so every vector in it expects acceptance and the set cannot tell
-# a correct verifier from one that accepts unconditionally. That second implementation
-# is a real failure, not a hypothetical, so this is a gap rather than a design: it
-# closes when the set gains one record signed over a non-JCS form, which a conformant
-# verifier must reject. Recorded rather than skipped, and asserted exactly, so it
-# cannot widen and cannot be forgotten.
-KNOWN_ONE_DIRECTIONAL = {"canonicalization-boundary": "accept"}
+# No set currently needs an exemption. The former `canonicalization-boundary`
+# entry was removed when schema-valid records signed over non-JCS preimages added
+# the rejecting direction alongside the existing RFC 8785 positive controls.
+# Keep any future shortfall explicit and exact; removing an exemption does not
+# relax either unconditional-answer check below.
+KNOWN_ONE_DIRECTIONAL: dict[str, str] = {}
 
 
 @pytest.mark.parametrize("name", sorted(SETS))

--- a/tests/test_canonicalization_boundary.py
+++ b/tests/test_canonicalization_boundary.py
@@ -1,11 +1,14 @@
 """Canonicalization boundary vectors (spec section 3.2.2).
 
 The spec requires an RFC 8785-conformant library and names
-``json.dumps(sort_keys=True)`` as insufficient. On every other record in this
-repository the two agree byte-for-byte, so nothing distinguished an implementation
-that complied from one that did not. These vectors are the records on which they
-disagree: schema-valid, correctly signed, and rejected by any verifier whose
-canonicalizer is one of the ad-hoc forms below.
+``json.dumps(sort_keys=True)`` as insufficient. ASCII-only values and fixed object
+keys can conceal escaping and key-order differences. These vectors deliberately
+exercise those differences. The four positive vectors are signed over JCS and
+must be accepted.
+Two negative vectors carry the same schema-valid payloads but signatures over
+alternate serializations and must be rejected specifically for their signatures.
+Together they distinguish exact JCS verification from accepting everything or
+falling back to a second serialization after JCS verification fails.
 
 Each fixture declares ``diverges_under``. The declaration is recomputed here, not
 trusted: a vector that stopped diverging would otherwise keep documenting a
@@ -20,6 +23,8 @@ ones the schema rejects.
 from __future__ import annotations
 
 import json
+import base64
+import runpy
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -27,6 +32,8 @@ from typing import Any
 
 import pytest
 import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from agentrust_trace import verify_record
 from agentrust_trace.validate import validate_json
@@ -34,6 +41,19 @@ from agentrust_trace.validate import validate_json
 REPO_ROOT = Path(__file__).parent.parent
 FIXTURE_DIR = REPO_ROOT / "examples" / "canonicalization-boundary"
 FIXTURE_PATHS = sorted(FIXTURE_DIR.glob("*.json"))
+POSITIVE_PATHS = [path for path in FIXTURE_PATHS if path.name[:2] in {"01", "02", "03", "04"}]
+NEGATIVE_CASES = [
+    (
+        FIXTURE_DIR / "05-ascii-escaped-signature.json",
+        FIXTURE_DIR / "01-non-ascii-values.json",
+        "sort_keys_compact",
+    ),
+    (
+        FIXTURE_DIR / "06-codepoint-order-signature.json",
+        FIXTURE_DIR / "03-utf16-key-order.json",
+        "sort_keys_compact_utf8",
+    ),
+]
 
 # The ladder of ad-hoc canonicalizations, least careful first. Each rung fixes the
 # previous rung's divergence and still fails on at least one vector; the last is
@@ -57,16 +77,46 @@ def _signing_input(record: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in record.items() if k != "signature"}
 
 
+def _verify(fixture: dict[str, Any]) -> None:
+    """Exercise the public API with real schema, trust, age and revocation inputs."""
+    validate_json(fixture["record"])
+    result = verify_record(
+        fixture["record"],
+        fixture["trusted_key"],
+        allow_embedded_key=False,
+        max_age_seconds=60,
+        max_future_skew_seconds=0,
+        revocation=frozenset(),
+        now=fixture["record"]["iat"],
+    )
+    assert result.revocation.outcome == "verified"
+    assert result.revocation.evidence == {"source": "store"}
+
+
+def _b64u(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _verify_preimage(fixture: dict[str, Any], preimage: bytes) -> None:
+    """Independent cryptography operation, with no TRACE canonicalizer involved."""
+    trusted = fixture["trusted_key"]
+    assert trusted["kty"] == "OKP" and trusted["crv"] == "Ed25519"
+    public_key = Ed25519PublicKey.from_public_bytes(_b64u(trusted["x"]))
+    public_key.verify(_b64u(fixture["record"]["signature"]), preimage)
+
+
 def test_vector_set_is_complete() -> None:
     assert [path.name for path in FIXTURE_PATHS] == [
         "01-non-ascii-values.json",
         "02-non-bmp-values.json",
         "03-utf16-key-order.json",
         "04-utf16-key-order-nested.json",
+        "05-ascii-escaped-signature.json",
+        "06-codepoint-order-signature.json",
     ]
 
 
-@pytest.mark.parametrize("path", FIXTURE_PATHS, ids=lambda p: p.stem)
+@pytest.mark.parametrize("path", POSITIVE_PATHS, ids=lambda p: p.stem)
 def test_vector_is_schema_valid_and_verifies(path: Path) -> None:
     """The record is an ordinary valid Trust Record; only its bytes are unusual.
 
@@ -74,14 +124,10 @@ def test_vector_is_schema_valid_and_verifies(path: Path) -> None:
     the wrong reason and still look conformant.
     """
     fixture = _load(path)
-    validate_json(fixture["record"])
-    verify_record(
-        fixture["record"],
-        fixture["trusted_key"],
-        # iat is fixed for reproducibility; canonicalization, not freshness, is the
-        # property under test.
-        max_age_seconds=None,
-    )  # must not raise
+    assert fixture["expected"] == {"outcome": "verified"}
+    # iat is fixed for reproducibility. Pin evaluation time rather than disabling
+    # freshness: a signature failure must not hide behind an unrelated refusal.
+    _verify(fixture)
 
 
 @pytest.mark.parametrize("path", FIXTURE_PATHS, ids=lambda p: p.stem)
@@ -107,7 +153,7 @@ def test_every_adhoc_form_is_caught_by_some_vector() -> None:
     longer distinguish a conformant canonicalizer from json.dumps, and the spec's
     MUST is back to being unenforced.
     """
-    killed = {name for path in FIXTURE_PATHS for name in _load(path)["diverges_under"]}
+    killed = {name for path in POSITIVE_PATHS for name in _load(path)["diverges_under"]}
     assert killed == set(ADHOC)
 
 
@@ -125,7 +171,7 @@ def test_every_adhoc_form_is_caught_by_at_least_two_vectors() -> None:
     UTF-16 code units at the outer levels and by code points below them passes `03`
     and fails `04`.
     """
-    counts = Counter(name for path in FIXTURE_PATHS
+    counts = Counter(name for path in POSITIVE_PATHS
                      for name in _load(path)["diverges_under"])
     assert set(counts) == set(ADHOC), "a form is separated by no vector at all"
     thin = {name: n for name, n in counts.items() if n < 2}
@@ -133,3 +179,104 @@ def test_every_adhoc_form_is_caught_by_at_least_two_vectors() -> None:
         f"separated by a single vector: {thin}. One vector is coverage until that "
         "vector changes; two are required per boundary."
     )
+
+
+@pytest.mark.parametrize(
+    "path,positive_path,form", NEGATIVE_CASES,
+    ids=["ascii-escaped-signature", "codepoint-order-signature"],
+)
+def test_negative_preimages_are_exact_and_signature_failure_is_isolated(
+    path: Path, positive_path: Path, form: str,
+) -> None:
+    """Only the signed bytes differ; malformed schema/key/time is not the reason."""
+    fixture, positive = _load(path), _load(positive_path)
+    assert fixture["expected"] == {"outcome": "rejected", "failure": "signature_invalid"}
+    assert fixture["signing_form"] == form
+    assert fixture["trusted_key"] == positive["trusted_key"]
+    body = _signing_input(fixture["record"])
+    assert body == _signing_input(positive["record"])
+    alternate = ADHOC[form](body)
+    canonical = rfc8785.dumps(body)
+    assert fixture["signed_input_utf8"].encode("utf-8") == alternate
+    assert fixture["canonical_input_utf8"].encode("utf-8") == canonical
+    assert alternate != canonical
+    # These are genuine Ed25519 signatures over the declared non-JCS preimages,
+    # not random signature corruption that could pass for the wrong reason.
+    _verify_preimage(fixture, alternate)
+    with pytest.raises(InvalidSignature):
+        _verify_preimage(fixture, canonical)
+    validate_json(fixture["record"])
+    with pytest.raises(InvalidSignature):
+        _verify(fixture)
+    _verify(positive)
+
+
+@pytest.mark.parametrize(
+    "path,positive_path,form", NEGATIVE_CASES,
+    ids=["ascii-escaped-signature", "codepoint-order-signature"],
+)
+def test_same_negative_payload_resigned_over_jcs_passes(
+    path: Path, positive_path: Path, form: str,
+) -> None:
+    """Use the published deterministic fixture key, never a production key."""
+    generator = runpy.run_path(str(FIXTURE_DIR / "gen_boundary_vectors.py"))
+    fixture = _load(path)
+    assert fixture["signing_form"] == form
+    repaired = generator["signed"](_signing_input(fixture["record"]))
+    assert _signing_input(repaired) == _signing_input(fixture["record"])
+    # Ed25519 is deterministic; this is exactly the existing positive record.
+    assert repaired == _load(positive_path)["record"]
+    _verify({**fixture, "record": repaired})
+
+
+def _accepted(fixture: dict[str, Any]) -> bool:
+    try:
+        _verify(fixture)
+    except InvalidSignature:
+        return False
+    return True
+
+
+def _mismatches(verifier: Callable[[dict[str, Any]], bool]) -> set[str]:
+    return {
+        path.name for path in FIXTURE_PATHS
+        if verifier(_load(path)) != (_load(path)["expected"]["outcome"] == "verified")
+    }
+
+
+def test_both_unconditional_verifiers_are_killed() -> None:
+    """Adding only positives or only negatives cannot pin this boundary."""
+    assert _mismatches(lambda _: True) == {case[0].name for case in NEGATIVE_CASES}
+    assert _mismatches(lambda _: False) == {path.name for path in POSITIVE_PATHS}
+    assert _mismatches(_accepted) == set()
+
+
+@pytest.mark.parametrize(
+    "form,incorrectly_accepted",
+    [
+        ("sort_keys_compact", "05-ascii-escaped-signature.json"),
+        ("sort_keys_compact_utf8", "06-codepoint-order-signature.json"),
+    ],
+    ids=["fallback-accepts-ascii-escaping", "fallback-accepts-codepoint-key-order"],
+)
+def test_each_alternate_fallback_is_a_distinct_killed_defect(
+    form: str, incorrectly_accepted: str,
+) -> None:
+    """Controlled test mutants, not a claim that the public verifier falls back.
+
+    Each mutant still accepts all four positive records. It admits just one of
+    the two wrong-preimage signatures, so neither negative substitutes for the
+    other. This measures independent failure mechanisms rather than trusting
+    their names or merely counting two instances of signature_invalid.
+    """
+    def fallback(fixture: dict[str, Any]) -> bool:
+        if _accepted(fixture):
+            return True
+        alternate = ADHOC[form](_signing_input(fixture["record"]))
+        try:
+            _verify_preimage(fixture, alternate)
+        except InvalidSignature:
+            return False
+        return True
+
+    assert _mismatches(fallback) == {incorrectly_accepted}


### PR DESCRIPTION
## Summary

Close the explicitly recorded acceptance-only gap in `examples/canonicalization-boundary`, under the already accepted section 3.2.2 signature-byte contract.

The four existing fixtures all expect `verified`. The repository's adequacy loader therefore records `canonicalization-boundary` in `KNOWN_ONE_DIRECTIONAL`: an implementation that accepts everything satisfies the whole set. This is the gap described in #186, not a newly proposed verification requirement.

This PR keeps the four positive fixtures byte-identical and adds two portable, schema-valid negative controls:

| Fixture | Signature actually covers | Expected TRACE result |
| --- | --- | --- |
| `05-ascii-escaped-signature.json` | Compact JSON with non-ASCII values escaped | `rejected`, `signature_invalid` |
| `06-codepoint-order-signature.json` | Compact literal-UTF8 JSON with code-point key ordering | `rejected`, `signature_invalid` |

These are genuine Ed25519 signatures over the **wrong preimages**, not valid TRACE signatures, malformed records, or random signature corruptions. Their unsigned payloads match positive fixtures 01 and 03 exactly.

## Why the new cases are load-bearing

- Each fixture publishes the exact alternate and RFC 8785 UTF-8 preimages. Tests recompute both independently and check that they differ.
- Direct `cryptography` verification succeeds over the declared alternate bytes and raises `InvalidSignature` over the JCS bytes.
- Public `verify_record()` rejects specifically with `InvalidSignature`, with schema validity, configured trust key, and `now=iat` controlled.
- Re-signing the identical payload canonically reproduces the corresponding original positive record exactly and verifies.
- The accept-everything mutant fails both negatives; reject-everything fails all four positives.
- A JCS-then-ASCII-fallback mutant incorrectly accepts only 05; a JCS-then-code-point-fallback mutant incorrectly accepts only 06. Both are actually executed, so the two negatives separate distinct implementation defects.
- Existing ad-hoc-serializer ladder and two-vector margin checks remain restricted to the **positive** controls. The new negatives cannot inflate that margin.
- Deterministic generation reproduces all six fixtures. The exact one-directional exemption is removed without relaxing any adequacy criterion.

## Scope and relation to #66

The exact-byte action/intent-binding discussion in #66 is why I checked this corpus. This supplies missing portable rejection evidence for a settled prerequisite. It does **not** implement the two-axis model, decide receipt coverage/cardinality, define a new schema or public API, or close #66/#279. It also does not claim independent-producer interoperability or overlap #245's delegation parent-record-hash evidence.

The production verifier already rejects these cases. This is conformance-test hardening, **not a newly discovered production vulnerability**. Outer JSON file formatting is not the signature preimage.

## Validation

- Hash-pinned CI requirements on Python **3.11.14** and **3.12.14**: **1,314 passed, 1 existing environment-dependent version-metadata skip** on each. No new skips/xfails.
- Targeted set: **48 passed**: 20 boundary, 11 corpus adequacy, 17 generator-reproduction tests.
- Ruff, repository dash/style check, mypy (11 source files), Bandit on the changed generator, sdist/wheel build, Twine metadata validation, and dependency audit passed.
- Exact-patch Gitleaks: no leaks. Detect-secrets candidates were inspected and are deterministic public fixture keys/signatures, not production credentials.
- Independent source review confirmed the rejection cause, unchanged positive payloads/fixtures, non-circular outcome assertions, and independently caught fallback mutants.
- Exact-commit clean clone with hash-pinned dependencies: **1,314 passed, 1 existing metadata skip** on Python 3.12.14. Two Git-policy tests require a clone rather than a metadata-free archive; no tests were disabled for the rerun.
- Built the sdist and wheel from the clean commit export with the hash-pinned build backend. Twine and package-inventory checks passed; the sdist includes all six fixtures, and neither artifact contains forbidden generated paths or private-key PEM blocks.
- Installed the wheel into a fresh isolated environment and ran outside the checkout: packaged-schema/signing round trip passed, and the public verifier returned **four verified positives and two `InvalidSignature` negatives** against the six fixtures.

DCO-signed commit: `1b935ea88bce44eb4fa213b172975c65d8a9f8f8`.
