### PR TITLE
Remove FAQ structured data from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,63 +120,6 @@ TRACE is the evidence format. AGT and cMCP produce and consume Trust Records, so
 
 The current specification is TRACE v0.2, published with a conformance test suite. See the Limitations page for scope boundaries before relying on it in production.
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What is TRACE?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What does a TRACE Trust Record prove?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "A single signed Trust Record answers, in a form any third party can verify without trusting the operator: what model ran, where it ran, under which policy, what data class it touched, which tools were called, and whether the record is independently anchored to a SCITT transparency ledger."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What standards is TRACE built on?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "TRACE builds on open IETF and IRTF standards: RFC 9711 (CBOR Web Token / EAT) for the claim envelope, RFC 9334 (RATS) for the attester, verifier, and relying-party roles, and the SCITT draft for transparency-ledger anchoring. It is designed for CoSAI WS4 interoperability."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How do I create and verify a Trust Record?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Install the Python library with pip install agentrust-trace, sign a record with TrustRecord.sign(claims, signing_key), anchor it to a SCITT ledger with record.anchor(), and check it with record.verify(verifying_key)."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does TRACE relate to AGT and cMCP?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "TRACE is the evidence format. AGT and cMCP produce and consume Trust Records, so you can connect them into an end-to-end agent governance pipeline. See the integration guides for details."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the current status of TRACE?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The current specification is TRACE v0.2, published with a conformance test suite. See the Limitations page for scope boundaries before relying on it in production."
-      }
-    }
-  ]
-}
-</script>
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [GOVERNANCE.md](GOVERNANCE.md). All contributors must agree to the [ANTITRUST.md](ANTITRUST.md) policy.


### PR DESCRIPTION
Removed JSON-LD structured data for TRACE FAQ from README.

## What this changes

Removes a `<script type="application/ld+json">` FAQPage structured-data block from the bottom of README.md. This JSON-LD was intended for SEO on the docs site (trace.agentrust-io.com) and doesn't belong in a GitHub-rendered README — GitHub's markdown sanitizer doesn't render `<script>` tags cleanly, so the raw tag was showing up as visible text on the README page. No content, links, or spec text is changed — only the removal of this non-rendering script block. The FAQ markdown content itself and the Contributing section are untouched.

```Standards alignment
Hosted at the Linux Foundation as its own series, "TRACE Specification, a Series of LF Projects, LLC", under [LF Projects policies](https://lfprojects.org/policies/). The Linux Foundation [announced the contribution](https://www.linuxfoundation.org/press/linux-foundation-welcomes-trace-to-advance-verifiable-runtime-evidence-for-ai-workloads) on 25 August 2026, developed with AMD, Intel, Microsoft, OPAQUE and TII. Builds on [RFC 9711 (EAT)](https://www.rfc-editor.org/rfc/rfc9711), [RFC 9334 (RATS)](https://www.rfc-editor.org/rfc/rfc9334), and SCITT draft-22.

Frequently asked questions
What is TRACE?
TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools.

What does a TRACE Trust Record prove?
A single signed Trust Record answers, in a form any third party can verify without trusting the operator: what model ran, where it ran, under which policy, what data class it touched, which tools were called, and whether the record is independently anchored to a SCITT transparency ledger.

What standards is TRACE built on?
TRACE builds on open IETF and IRTF standards: RFC 9711 (CBOR Web Token / EAT) for the claim envelope, RFC 9334 (RATS) for the attester, verifier, and relying-party roles, and the SCITT draft for transparency-ledger anchoring. It is designed for CoSAI WS4 interoperability.

How do I create and verify a Trust Record?
Install the Python library with pip install agentrust-trace, sign a record with TrustRecord.sign(claims, signing_key), anchor it to a SCITT ledger with record.anchor(), and check it with record.verify(verifying_key).

How does TRACE relate to AGT and cMCP?
TRACE is the evidence format. AGT and cMCP produce and consume Trust Records, so you can connect them into an end-to-end agent governance pipeline. See the integration guides for details.

What is the current status of TRACE?
The current specification is TRACE v0.2, published with a conformance test suite. See the Limitations page for scope boundaries before relying on it in production.

<script type="application/ld+json"> { "@context": "https://schema.org/", "@type": "FAQPage", "mainEntity": [ { "@type": "Question", "name": "What is TRACE?", "acceptedAnswer": { "@type": "Answer", "text": "TRACE (Trust, Runtime Attestation, and Compliance Evidence) is an open specification for hardware-attested AI agent governance records. It defines the record format, the anchoring protocol, and the verification rules for cryptographic evidence that an AI agent ran under a specific policy, in a verified hardware environment, on a given data class, invoking identified tools." } }, { "@type": "Question", "name": "What does a TRACE Trust Record prove?", "acceptedAnswer": { "@type": "Answer", "text": "A single signed Trust Record answers, in a form any third party can verify without trusting the operator: what model ran, where it ran, under which policy, what data class it touched, which tools were called, and whether the record is independently anchored to a SCITT transparency ledger." } }, { "@type": "Question", "name": "What standards is TRACE built on?", "acceptedAnswer": { "@type": "Answer", "text": "TRACE builds on open IETF and IRTF standards: RFC 9711 (CBOR Web Token / EAT) for the claim envelope, RFC 9334 (RATS) for the attester, verifier, and relying-party roles, and the SCITT draft for transparency-ledger anchoring. It is designed for CoSAI WS4 interoperability." } }, { "@type": "Question", "name": "How do I create and verify a Trust Record?", "acceptedAnswer": { "@type": "Answer", "text": "Install the Python library with pip install agentrust-trace, sign a record with TrustRecord.sign(claims, signing_key), anchor it to a SCITT ledger with record.anchor(), and check it with record.verify(verifying_key)." } }, { "@type": "Question", "name": "How does TRACE relate to AGT and cMCP?", "acceptedAnswer": { "@type": "Answer", "text": "TRACE is the evidence format. AGT and cMCP produce and consume Trust Records, so you can connect them into an end-to-end agent governance pipeline. See the integration guides for details." } }, { "@type": "Question", "name": "What is the current status of TRACE?", "acceptedAnswer": { "@type": "Answer", "text": "The current specification is TRACE v0.2, published with a conformance test suite. See the Limitations page for scope boundaries before relying on it in production." } } ] } </script>```

how it looked earlier

## Type of change
- [x] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

N/A — this change is to README.md only, not spec/trace-v0.2.md.

## Checklist
- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change)
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN: description -->` in spec text
- [ ] Backward compatibility statement included (for breaking changes)