### PR TITLE
fix(readme): name the API the package actually has, and pin it

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ TRACE builds on open IETF and IRTF standards: RFC 9711 (CBOR Web Token / EAT) fo
 
 ### How do I create and verify a Trust Record?
 
-Install the Python library with `pip install agentrust-trace`, sign a record with `TrustRecord.sign(claims, signing_key)`, anchor it to a SCITT ledger with `record.anchor()`, and check it with `record.verify(verifying_key)`.
+Install the library with `pip install agentrust-trace`, sign a record with `sign_record(record, key)`, and check one with `verify_record(record, public_key_or_jwk=trusted_key)`, both imported from `agentrust_trace`. `verify_record` checks the profile URI, the schema, the signature over the RFC 8785 canonical form, and freshness; it checks revocation only when you pass it a revocation source, and it performs no attestation verification. The library does not anchor a record to a transparency ledger: `transparency` is a string member holding the SCITT receipt URI, which a producer fills in once its ledger returns one. The Quickstart page carries a runnable version of both steps.
 
 ### How does TRACE relate to AGT and cMCP?
 

--- a/tests/test_readme_api_claims.py
+++ b/tests/test_readme_api_claims.py
@@ -1,0 +1,157 @@
+"""Every API call the README names has to exist in the package.
+
+`pyproject.toml` sets `readme = "README.md"`, so this file is the PyPI long
+description: a call written here is the first instruction a new user reads, and
+it is the text an answer engine quotes back when asked how to use TRACE. Through
+0.10.0 the README told them to call `TrustRecord.sign(claims, signing_key)`,
+`record.anchor()` and `record.verify(verifying_key)`. None of the three has ever
+existed. The package signs with `sign_record`, checks with `verify_record`, and
+does not anchor anything.
+
+Nothing caught it. `tests/test_docs_quickstart.py` executes the fenced blocks in
+`docs/`, and the README states its API in inline spans inside prose, which no
+instrument read. That is the gap this file closes, and it closes it for the file
+that travels furthest.
+
+Two instruments, for the two ways the README states an API. The fenced block is
+executed. The inline spans are resolved, by a rule kept deliberately narrow so it
+stays a fact check rather than a style check. A call-shaped inline span is
+resolved one of two ways:
+
+* a qualified name (`agentrust_trace.sign_record(...)`, `TrustRecord.sign(...)`)
+  is walked attribute by attribute from the exported symbol it starts at;
+* an unqualified receiver (`record.anchor()`) cannot be resolved, so the method
+  name has to exist on some exported class instead, and not be one of the names
+  every object inherits, which would resolve for any receiver at all.
+
+A call that is deliberately not package API (`json.dumps(...)`, say) fails here
+by design. Qualify it, or write it without the parentheses, rather than loosening
+the rule: the point is that a reader cannot tell prose from instructions, so
+neither does this test.
+"""
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+import subprocess
+import sys
+
+import agentrust_trace
+
+README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+
+#: A call inside an inline code span: the dotted name in front of the paren.
+CALL = re.compile(r"`([A-Za-z_][A-Za-z0-9_.]*)\s*\(")
+
+
+#: Attributes every object or class carries. A README that told a reader to call
+#: `record.mro()` would otherwise resolve, since the name exists on every class,
+#: and the check would be agreeing with itself rather than with the package.
+UNIVERSAL_ATTRIBUTES = set(dir(object)) | set(dir(type))
+
+
+def _exported_classes() -> list[type]:
+    return [
+        value
+        for name in agentrust_trace.__all__
+        if inspect.isclass(value := getattr(agentrust_trace, name, None))
+    ]
+
+
+def unresolvable(text: str) -> list[str]:
+    """Return the call-shaped names in `text` that do not exist in the package."""
+    missing = []
+    for name in dict.fromkeys(CALL.findall(text)):
+        head, *rest = name.split(".")
+        if head == agentrust_trace.__name__:
+            # Fully qualified, which is the clearest form to write and would
+            # otherwise look like an unresolvable receiver.
+            head, *rest = rest or [head]
+        target = getattr(agentrust_trace, head, None)
+        if target is None:
+            # An unqualified receiver. The method has to exist on some exported
+            # class, or the sentence is telling a reader to call nothing.
+            method = rest[-1] if rest else head
+            on_a_class = any(hasattr(cls, method) for cls in _exported_classes())
+            if method in UNIVERSAL_ATTRIBUTES or not on_a_class:
+                missing.append(name)
+            continue
+        for attribute in rest:
+            target = getattr(target, attribute, None)
+            if target is None:
+                missing.append(name)
+                break
+    return missing
+
+
+def test_every_api_call_in_the_readme_exists() -> None:
+    missing = unresolvable(README.read_text(encoding="utf-8"))
+    assert missing == [], (
+        f"README.md tells a reader to call {missing}, which this package does not have. "
+        "That file is the PyPI long description, so a call written there is what someone "
+        "runs after `pip install agentrust-trace`. Name the function the package exports, "
+        "or, if the call is deliberately not package API, qualify it or write it without "
+        "the parentheses."
+    )
+
+
+def test_a_qualified_call_resolves() -> None:
+    """The other direction: the clearest way to write a call must not be refused."""
+    assert unresolvable("`agentrust_trace.verify_record(record)` and `sign_record(r, k)`") == []
+
+
+def test_the_readme_example_runs(tmp_path: pathlib.Path) -> None:
+    """The README's one fenced block, executed rather than read.
+
+    `tests/test_docs_quickstart.py` runs the fenced blocks in `docs/` this way.
+    The README had no instrument at all, and it is the file that travels to PyPI,
+    so its example is executed here too. The count is pinned: a second block is a
+    deliberate act, not something that arrives unmeasured.
+    """
+    blocks = re.findall(r"^```python\n(.*?)^```", README.read_text(encoding="utf-8"), re.S | re.M)
+    assert len(blocks) == 1, (
+        f"README.md has {len(blocks)} fenced python blocks and this test runs one. Extend "
+        "it to run the others, or the new block is an example nothing executes."
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", blocks[0]],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_the_check_catches_the_calls_that_shipped_through_0_10_0() -> None:
+    """The negative control is the defect itself, kept so the check cannot rot.
+
+    If this ever passes, `unresolvable` has stopped resolving anything and the
+    test above is measuring nothing.
+    """
+    shipped = (
+        "sign a record with `TrustRecord.sign(claims, signing_key)`, anchor it to a "
+        "SCITT ledger with `record.anchor()`, and check it with "
+        "`record.verify(verifying_key)`."
+    )
+    assert unresolvable(shipped) == [
+        "TrustRecord.sign",
+        "record.anchor",
+        "record.verify",
+    ]
+
+
+def test_a_name_every_object_carries_does_not_count_as_an_api() -> None:
+    """`record.mro()` names nothing a reader can act on, and must not resolve.
+
+    The unqualified branch asks whether some exported class has the method. Every
+    class has `mro`, `__init__` and the rest of the object surface, so without
+    this the check would pass on a receiver that does not exist either.
+    """
+    assert unresolvable("`record.mro()` and `record.__init__()`") == [
+        "record.mro",
+        "record.__init__",
+    ]
+    # Real methods of exported classes still resolve, which is the other half.
+    assert unresolvable("`record.model_dump()`") == []


### PR DESCRIPTION
## What this changes

The FAQ answer for "How do I create and verify a Trust Record?" told readers to call `TrustRecord.sign(claims, signing_key)`, `record.anchor()` and `record.verify(verifying_key)`. None of the three exists, and none ever did: `TrustRecord` carries no `sign` or `verify`, nothing exported anchors anything, and `git log -S "def anchor(self"` over the package returns nothing. The same README already carried a working example thirty six lines earlier, a fenced block ending in `signed = sign_record(record, key)`, so the file contradicted itself.

`pyproject.toml` sets `readme = "README.md"`, so that sentence is also the PyPI long description. It has shipped in every release since 0.4.0 on 2026-07-21 and is on the project page for 0.10.0, which makes it the first instruction a reader gets after `pip install agentrust-trace`.

The replacement names `sign_record` and `verify_record`, both of which `tests/test_docs_quickstart.py` already executes out of `docs/quickstart.md`, and states the boundaries a reader would otherwise infer: `verify_record` checks revocation only when it is handed a revocation source, it performs no attestation verification, and the package does not anchor a record to a transparency ledger, `transparency` being a string member that carries the SCITT receipt URI once a ledger returns one.

`tests/test_readme_api_claims.py` keeps it from drifting back. Nothing checked what the README says before this: the quickstart test executes the fenced blocks under `docs/`, and the README had no instrument at all. The new file carries two, one per way the README states an API. The fenced block is executed, the way `tests/test_docs_quickstart.py` runs the pages under `docs/`. The inline spans are resolved by a deliberately narrow rule: a call written in an inline span has to name something that exists, and not one of the names every object carries, which would resolve for any receiver at all. Its negative control is this defect itself, so the check cannot quietly stop resolving anything, and when it fails it names the call and says what to write instead.

Three notes for review. The same sentence also sits inside the `application/ld+json` block that #308 removes; this PR leaves that copy alone rather than conflict with #308, which deletes it outright, and the two merge cleanly in either order. The guard reads inline code spans only, which is why it does not see that copy. And it is scoped to the README on purpose: pointed at the whole tree it would flag ten files that legitimately name `json.dumps(...)` and friends in prose, which would make it a style check rather than a fact check.

Checked on this branch: `pytest` 1310 passed and 1 skipped on 3.11 and on 3.12, `ruff check src tests scripts`, `python tools/check_dashes.py` and `mypy src/agentrust_trace` all clean, on a fresh clone with only `pip install -e ".[dev]"`. Rendering the new README with `readme_renderer`, which is what PyPI uses, introduces no escaped markup of its own.

## Type of change

- [x] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None. `spec/trace-v0.2.md` is not touched.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not a normative change
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN: description -->` in spec text: not a breaking change
- [ ] Backward compatibility statement included (for breaking changes): not a breaking change
