### PR TITLE
docs(verification): profile floors are specification choices, not regulatory derivations

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -141,17 +141,56 @@ before this field existed valid and correctly interpreted.
 
 ### Profile floors
 
-Deployment profiles select the minimum acceptable verified depth:
+Deployment profiles select the minimum acceptable verified depth. Every floor below is a
+choice this specification makes for deployments that describe themselves as operating under
+the named regime, rather than a requirement derived from that regime. Neither regulation
+discussed in the next section requires a verification depth at all.
 
 | Profile | Floor |
 |---|---|
 | Default, SLSA L0 to L1 | `surface` |
 | SLSA L2 and above | `builder` |
-| FIPS-aligned, EU AI Act Annex IV high-risk, HIPAA | `transitive` |
+| FIPS-aligned, EU AI Act Article 6 high-risk, HIPAA | `transitive` |
 | cMCP reference profile | `builder`, with `transitive` recommended where ecosystem coverage permits |
 
 A verifier whose configured floor is not met by `provenance_depth_verified` sets
 `appraisal.status` to `contraindicated`.
+
+### Regulatory context for the profile floors (informative)
+
+The floors above name the EU AI Act. This section records what that Regulation actually
+requires, together with the Cyber Resilience Act, which is the instrument most often reached
+for in its place. Verification at any depth is not evidence of compliance with either of
+them, and neither is a floor that is met.
+
+**Regulation (EU) 2024/1689.** Annex IV is the technical documentation schedule whose
+elements Article 11(1) requires the technical documentation to contain at a minimum. It is
+not a classification annex, since high-risk classification runs through Article 6 with
+Annexes I and III, and neither Article 11 nor Annex IV imposes a verification obligation of
+the kind `provenance_depth_verified` records. Two adjacent provisions are sometimes read as
+supplying one, and neither does. Article 25(4), as amended by Regulation (EU) 2026/1744,
+requires the provider of a high-risk AI system and a third party supplying an AI system, AI
+model, tools, services, components or processes used or integrated in it to specify by
+written agreement the information, capabilities, technical access and other assistance the
+provider needs, and it does not apply to third parties making tools, services, processes or
+components other than general-purpose AI models publicly available under a free and
+open-source licence. Article 15(5) requires technical solutions addressing, where
+appropriate, data poisoning, model poisoning, adversarial examples, confidentiality attacks
+and model flaws, which is stated as an outcome rather than as a depth of supply-chain
+verification. Articles 11, 15 and 25 sit in Sections 2 and 3 of Chapter III, whose
+application Regulation (EU) 2026/1744 moved to 2 December 2027 for systems high-risk under
+Article 6(2) and Annex III, and to 2 August 2028 for systems high-risk under Article 6(1)
+and Annex I, subject to the Article 111(2) grace period for units of a type and model
+already placed on the market.
+
+**Regulation (EU) 2024/2847.** Annex I Part II point 1 requires manufacturers to identify
+and document vulnerabilities and components, including by drawing up a software bill of
+materials in a commonly used and machine-readable format covering at the very least the
+top-level dependencies of the product. That is a component inventory obligation, so it does
+not by itself establish `builder` or `transitive` verification, both of which are claims
+about provenance rather than about composition. Its Annex I obligations apply from
+11 December 2027, with the reporting obligations in Article 14 applying from
+11 September 2026.
 
 ### Why depth is recorded rather than assumed
 


### PR DESCRIPTION
## What this changes

`docs/verification.md` presents the `transitive` profile floor as following from "EU AI Act Annex IV high-risk". This corrects that attribution, keeps every profile and every floor exactly as it stands, and adds an informative section recording what the cited instruments actually require.

The line being corrected:

> | FIPS-aligned, EU AI Act Annex IV high-risk, HIPAA | `transitive` |

## Type of change

- [x] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

The added subsection is informative and sits in `docs/` rather than in the specification, so it carries no normative effect and no conformance test IDs.

## Spec section

None. The change is confined to `docs/verification.md`. Section 3.3.1 of `spec/trace-v0.2.md`, which this document is the implementation guide to, is unchanged, and no schema file is touched.

## Why

Two separate problems sit in the same phrase.

Annex IV is the technical documentation schedule whose elements Article 11(1) requires the technical documentation to contain at a minimum. It is not a classification annex, so "Annex IV high-risk" names no category a reader can look up, since high-risk classification runs through Article 6 with Annexes I and III. The row now reads "EU AI Act Article 6 high-risk".

Separately, no provision of the Regulation requires a verification depth, so a floor cannot be derived from it. The floor is still the right requirement for that profile, and it is a requirement this specification makes rather than one the Regulation imposes. The lead-in now says so for every row.

No other instrument is put in Annex IV's place. A floor that rests on a citation is only as stable as the reading of that citation, and the security argument already in this document carries the floor without one. The regulatory material therefore moves into an informative section that records what each instrument requires and stops there, which also keeps the table clear of anything a reader could take as a compliance claim. @safal207's refinement is carried in that section: the software bill of materials obligation in the CRA is a component inventory, and an inventory of top-level dependencies does not by itself establish `builder` or `transitive` verification, which are claims about provenance rather than about composition.

FIPS and HIPAA are unchanged and are not spoken to here, as in my comment on #66.

## Not changed, deliberately

The depth vocabulary is untouched. #66 gives the same supply-chain ladder two names, `surface | builder_chain | dependency_chain` for `verification.depth` and `surface | builder | transitive` for `build_provenance.provenance_depth`, and reconciling the two was asked for on that thread. `docs/verification.md` uses the short names throughout, so this PR uses them too. Which vocabulary survives is a maintainer decision worth settling before v1.0, and this PR does not make it.

No new conformance claim and no legal-compliance claim are introduced, and the informative section states explicitly that verification at any depth is not evidence of compliance with either instrument.

## Context

The profile-floor correction was directed on #66 to be a separate docs-only contribution with source verification and no new conformance or legal-compliance claim: https://github.com/agentrust-io/trace-spec/issues/66#issuecomment-5565108464. #66 has since been closed via #306, whose description states that it does not close #66, so this is filed as the separate contribution that was asked for rather than as a change to that issue's scope.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not applicable, no normative change
- [ ] Breaking changes marked in spec text: not applicable
- [ ] Backward compatibility statement included: not applicable

## AI assistance

Drafting and source verification were AI-assisted. Article 6, Article 11(1), Article 15(5), Article 25(4), Article 111(2), Article 113 and Annex IV were read against Regulation (EU) 2024/1689 as amended; Article 1 points (10) and (12) and the Article 113 replacement against Regulation (EU) 2026/1744; and Annex I Part II point 1 and Article 71 against Regulation (EU) 2024/2847, before being cited.