### PR TITLE
docs(verification): add Article 12 and correct the Article 111(2) attribution

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -184,11 +184,12 @@ verification. Articles 11, 12, 15 and 25 sit in Sections 2 and 3 of Chapter III,
 application Regulation (EU) 2026/1744 moved to 2 December 2027 for systems high-risk under
 Article 6(2) and Annex III, and to 2 August 2028 for systems high-risk under Article 6(1)
 and Annex I. Article 111(2), as replaced by the same Regulation, applies the AI Act to
-operators of high-risk systems placed on the market before that date of application only
-where those systems are subject to significant changes in their designs, and requires
-providers and deployers of high-risk systems intended to be used by public authorities to
-comply by 2 August 2030. The reading that one lawfully placed unit carries the other units of
-the same type and model is recital 39 rather than operative text.
+operators of high-risk systems, other than the systems referred to in Article 111(1), that
+have been placed on the market or put into service before that date of application, only
+where, as from that date, those systems are subject to significant changes in their designs,
+and in any case requires providers and deployers of high-risk systems intended to be used by
+public authorities to comply by 2 August 2030. The reading that one lawfully placed unit
+carries the other units of the same type and model is recital 39 rather than operative text.
 
 **Regulation (EU) 2024/2847.** Annex I Part II point 1 requires manufacturers to identify
 and document vulnerabilities and components, including by drawing up a software bill of

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -188,8 +188,9 @@ operators of high-risk systems, other than the systems referred to in Article 11
 have been placed on the market or put into service before that date of application, only
 where, as from that date, those systems are subject to significant changes in their designs,
 and in any case requires providers and deployers of high-risk systems intended to be used by
-public authorities to comply by 2 August 2030. The reading that one lawfully placed unit
-carries the other units of the same type and model is recital 39 rather than operative text.
+public authorities to comply by 2 August 2030. The reading that one unit lawfully placed on
+the market or put into service carries the other units of the same type and model is recital
+39 of Regulation (EU) 2026/1744 rather than operative text.
 
 **Regulation (EU) 2024/2847.** Annex I Part II point 1 requires manufacturers to identify
 and document vulnerabilities and components, including by drawing up a software bill of

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -167,8 +167,11 @@ them, and neither is a floor that is met.
 elements Article 11(1) requires the technical documentation to contain at a minimum. It is
 not a classification annex, since high-risk classification runs through Article 6 with
 Annexes I and III, and neither Article 11 nor Annex IV imposes a verification obligation of
-the kind `provenance_depth_verified` records. Two adjacent provisions are sometimes read as
-supplying one, and neither does. Article 25(4), as amended by Regulation (EU) 2026/1744,
+the kind `provenance_depth_verified` records. Article 12 does not impose one either, since it
+requires that a high-risk system technically allow the automatic recording of events over its
+lifetime, which is a capability requirement about logging rather than a statement about
+provenance or build inputs. Two adjacent provisions are sometimes read as supplying one, and
+neither does. Article 25(4), as amended by Regulation (EU) 2026/1744,
 requires the provider of a high-risk AI system and a third party supplying an AI system, AI
 model, tools, services, components or processes used or integrated in it to specify by
 written agreement the information, capabilities, technical access and other assistance the
@@ -177,11 +180,15 @@ components other than general-purpose AI models publicly available under a free 
 open-source licence. Article 15(5) requires technical solutions addressing, where
 appropriate, data poisoning, model poisoning, adversarial examples, confidentiality attacks
 and model flaws, which is stated as an outcome rather than as a depth of supply-chain
-verification. Articles 11, 15 and 25 sit in Sections 2 and 3 of Chapter III, whose
+verification. Articles 11, 12, 15 and 25 sit in Sections 2 and 3 of Chapter III, whose
 application Regulation (EU) 2026/1744 moved to 2 December 2027 for systems high-risk under
 Article 6(2) and Annex III, and to 2 August 2028 for systems high-risk under Article 6(1)
-and Annex I, subject to the Article 111(2) grace period for units of a type and model
-already placed on the market.
+and Annex I. Article 111(2), as replaced by the same Regulation, applies the AI Act to
+operators of high-risk systems placed on the market before that date of application only
+where those systems are subject to significant changes in their designs, and requires
+providers and deployers of high-risk systems intended to be used by public authorities to
+comply by 2 August 2030. The reading that one lawfully placed unit carries the other units of
+the same type and model is recital 39 rather than operative text.
 
 **Regulation (EU) 2024/2847.** Annex I Part II point 1 requires manufacturers to identify
 and document vulnerabilities and components, including by drawing up a software bill of

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -185,12 +185,12 @@ application Regulation (EU) 2026/1744 moved to 2 December 2027 for systems high-
 Article 6(2) and Annex III, and to 2 August 2028 for systems high-risk under Article 6(1)
 and Annex I. Article 111(2), as replaced by the same Regulation, applies the AI Act to
 operators of high-risk systems, other than the systems referred to in Article 111(1), that
-have been placed on the market or put into service before that date of application, only
-where, as from that date, those systems are subject to significant changes in their designs,
-and in any case requires providers and deployers of high-risk systems intended to be used by
-public authorities to comply by 2 August 2030. The reading that one unit lawfully placed on
-the market or put into service carries the other units of the same type and model is recital
-39 of Regulation (EU) 2026/1744 rather than operative text.
+have been placed on the market or put into service before that date of application, only if,
+as from that date, those systems are subject to significant changes in their designs, and in
+any case requires providers and deployers of high-risk systems intended to be used by public
+authorities to take the necessary steps to comply by 2 August 2030. The reading that one unit
+lawfully placed on the market or put into service carries the other units of the same type
+and model is recital 39 of Regulation (EU) 2026/1744 rather than operative text.
 
 **Regulation (EU) 2024/2847.** Annex I Part II point 1 requires manufacturers to identify
 and document vulnerabilities and components, including by drawing up a software bill of


### PR DESCRIPTION
## What this changes

Two corrections to the informative section added in #310, in one diff at @lywinged's suggestion in review there.

Article 12 joins Article 11 and Annex IV as a provision a reader might expect to supply a verification depth, and does not. The Article 111(2) sentence is corrected, because it presented a recital as operative text.

## Type of change

- [x] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

## Spec section

None. `docs/verification.md` only. Section 3.3.1 of `spec/trace-v0.2.md` is unchanged and no schema file is touched.

## Why

**Article 12.** Suggested on the ground that a reader who knows this repository will look for it. Article 12(1) requires that a high-risk system technically allow the automatic recording of events over its lifetime, which addresses neither provenance nor build inputs, so it makes the section's argument rather than complicating it. Article 12 sits in Chapter III Section 2, so the closing sentence's list of provisions is extended to `Articles 11, 12, 15 and 25` rather than left inconsistent. The count in "Two adjacent provisions are sometimes read as supplying one" is deliberately untouched, since that sentence refers to Article 25(4) and Article 15(5).

**Article 111(2).** The merged sentence made the dates "subject to the Article 111(2) grace period for units of a type and model already placed on the market". Article 1 point (39)(a) of Regulation (EU) 2026/1744 replaces Article 111(2), and the replacement carries the significant-changes test and a 2 August 2030 compliance date for providers and deployers of high-risk systems intended to be used by public authorities. It does not carry the type-and-model language. That reading is recital 39, and "type and model" occurs three times in the whole Regulation, all three inside that recital and none in the operative articles. The reading was right and the attribution was not.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not applicable, no normative change
- [ ] Breaking changes marked in spec text: not applicable
- [ ] Backward compatibility statement included: not applicable

## AI assistance

Drafting and source verification were AI-assisted. Article 12 of Regulation (EU) 2024/1689, and Article 111(2) as replaced by Article 1 point (39)(a), recital 39, and Article 113 third paragraph point (c) as replaced by point (40)(b) of Regulation (EU) 2026/1744, were read against the Official Journal text before being cited.