### PR TITLE
fix(intent-bridge): preserve canonicalization error classification

### DIFF
--- a/src/agentrust_trace/intent_bridge.py
+++ b/src/agentrust_trace/intent_bridge.py
@@ -240,20 +240,17 @@ def verify_bridge(
         if not isinstance(transcript, dict) or set(transcript) != {"before", "after"}:
             raise AuthorizationMismatch("a full before/after transcript is required")
         before = transcript.get("before")
-        if not isinstance(before, dict) or not isinstance(before.get("tool_call"), dict):
+        before_call = before.get("tool_call") if isinstance(before, dict) else None
+        if not isinstance(before_call, dict):
             raise AuthorizationMismatch("transcript.before.tool_call does not match execution")
         # Host-language equality is not this bridge's identity relation. Python holds
-        # True == 1 and False == 0, nested objects included, so comparing the two call
-        # objects with != accepts a transcript whose call has different JCS bytes from
-        # the one the authorization digested (#317). Every other comparison in this
-        # function is over canonical bytes; so is this one.
-        try:
-            before_digest = digest_jcs(before["tool_call"])
-        except IntentBridgeError:
-            raise AuthorizationMismatch(
-                "transcript.before.tool_call does not match execution"
-            ) from None
-        if not compare_digest(before_digest, tool_call_digest):
+        # True == 1 and False == 0, nested objects included, so compare the exact RFC
+        # 8785 bytes instead. If either object has no canonical form, _jcs raises
+        # IntentBridgeError: that input cannot be evaluated, which is not a mismatch.
+        if not compare_digest(
+            _jcs(before_call, "transcript.before.tool_call"),
+            _jcs(tool_call, "tool_call"),
+        ):
             raise AuthorizationMismatch("transcript.before.tool_call does not match execution")
         if not isinstance(transcript.get("after"), dict):
             raise AuthorizationMismatch("transcript.after must contain the execution result")

--- a/tests/test_intent_bridge.py
+++ b/tests/test_intent_bridge.py
@@ -355,3 +355,19 @@ def test_transcript_call_that_is_not_an_object_stays_an_authorization_mismatch(
             transcript={"before": {"tool_call": bad}, "after": {"status": "accepted"}},
             now=150,
         )
+
+@pytest.mark.parametrize("bad", [{"approved": 2**60}, {"approved": float("nan")}])
+def test_uncanonicalizable_transcript_call_is_intentbridgeerror_not_mismatch(
+    bad: dict,
+) -> None:
+    """An unrepresentable transcript call cannot be evaluated; it is not a mismatch."""
+    bridge, key, declaration, intent, args, tool_call, _ = _fixture()
+    transcript_call = {"name": "send_invoice", "arguments": bad}
+    with pytest.raises(IntentBridgeError, match="transcript.before.tool_call") as excinfo:
+        verify_bridge(
+            bridge, {**key_to_jwk(key), "kid": "key-7"}, declaration=declaration,
+            pic_intent_digest=intent, pic_args_digest=args, tool_call=tool_call,
+            transcript={"before": {"tool_call": transcript_call}, "after": {"status": "accepted"}},
+            now=150,
+        )
+    assert not isinstance(excinfo.value, AuthorizationMismatch)


### PR DESCRIPTION
Follow-up to #317 / #333.

## What

#333 correctly moved the required transcript-call comparison off Python container equality, but it wraps an RFC 8785 canonicalization failure from `transcript.before.tool_call` back into `AuthorizationMismatch`.

That classification is inconsistent with this module's own contracts:

- `IntentBridgeError`: malformed, untrusted, stale, or cannot be evaluated.
- `AuthorizationMismatch`: execution evidence does not match the signed authorization.

A transcript call with no RFC 8785 canonical form cannot be evaluated; it has not been shown to mismatch.

This PR removes that wrap and lets the existing `_jcs()` boundary raise `IntentBridgeError`, while preserving the explicit object-type guard so a non-object transcript call remains `AuthorizationMismatch`.

The comparison is performed directly over canonical bytes with `compare_digest(_jcs(a), _jcs(b))`. The signed `tool_call_digest` semantics are unchanged.

## Regression coverage

Existing coverage from #333 continues to pin:

- integer/boolean substitutions as `AuthorizationMismatch`;
- identical canonical calls as accepted;
- non-object transcript calls as `AuthorizationMismatch`.

This PR adds explicit cases for transcript calls containing values the pinned canonicalizer cannot represent (`2**60` and `NaN`) and requires:

- `IntentBridgeError`;
- specifically, not `AuthorizationMismatch`;
- the diagnostic to identify `transcript.before.tool_call`.

## Scope

No schema, wire-format, authorization, scope, digest, or signature semantics change.

This is only an exception-classification correction at the canonicalization boundary, plus the direct canonical-byte comparison already discussed on this PR.

The branch is rebuilt directly on current `main` after #325 and #333. No `CHANGELOG.md` hunk, per maintainer request.

AI-assistance disclosure: ChatGPT assisted with repository triage, diff reconstruction, test drafting, and branch cleanup. `altrudev` reviewed the bounded claim and remains responsible for the contribution.