### PR TITLE
test(vectors): pin which vector carries which discrimination

### DIFF
--- a/examples/action-receipts/README.md
+++ b/examples/action-receipts/README.md
@@ -135,12 +135,14 @@ the key used by `01`–`09` is not published; `gen_rule_coverage_vectors.py` reg
 the range byte-for-byte and only public JWKs appear in the files.
 
 Reissuing `01`–`09` from published keys takes two of them, not one (#178). `04` is the
-only vector whose signature is structurally sound and still does not verify, which is
-the shape that separates it from `24`, and that shape exists only when the signer is a
-key the verifier does not hold: under a single key the obvious way to keep `04` failing
-is to corrupt its signature, which makes it a second `24`. `tests/vector_roles.json`
-records which vector carries which discrimination, and
-`test_no_vector_has_lost_its_role` fails by name if a reissue drops one.
+only vector whose issuer key the verifier holds and whose 64-byte signature still fails
+to verify, which is the shape that separates it from `24`. A single key can keep that
+shape, by corrupting the signature at fixed length; what it cannot keep is the fixture's
+meaning, a signature made by a key the verifier does not hold. The guard below sees the
+shape and not the signer, so the second key is a decision the reissue makes on purpose
+rather than one a test enforces. `tests/vector_roles.json` records which vector carries
+which discrimination, and `test_no_vector_has_lost_its_role` fails by name if a reissue
+drops one.
 
 `tests/test_action_receipt_fixtures.py` recomputes each digest, verifies each
 signature against the pinned key, checks session and call binding, enforces

--- a/examples/action-receipts/README.md
+++ b/examples/action-receipts/README.md
@@ -134,6 +134,14 @@ Everything from `10` up pins its own deterministic test key, since the private h
 the key used by `01`–`09` is not published; `gen_rule_coverage_vectors.py` regenerates
 the range byte-for-byte and only public JWKs appear in the files.
 
+Reissuing `01`–`09` from published keys takes two of them, not one (#178). `04` is the
+only vector whose signature is structurally sound and still does not verify, which is
+the shape that separates it from `24`, and that shape exists only when the signer is a
+key the verifier does not hold: under a single key the obvious way to keep `04` failing
+is to corrupt its signature, which makes it a second `24`. `tests/vector_roles.json`
+records which vector carries which discrimination, and
+`test_no_vector_has_lost_its_role` fails by name if a reissue drops one.
+
 `tests/test_action_receipt_fixtures.py` recomputes each digest, verifies each
 signature against the pinned key, checks session and call binding, enforces
 freshness and receipt-chain ordering, and compares the result with each

--- a/tests/test_vector_completeness.py
+++ b/tests/test_vector_completeness.py
@@ -31,6 +31,7 @@ The questions, in increasing strength:
    implementation defect that one catches and the other misses? Two copies of the
    same vector satisfy question 3 and fail this one.
 5. Has any rule's margin dropped below what it was? (silent thinning)
+6. Is each vector still the one doing the discriminating? (silent substitution)
 
 Independence is #124's definition made executable. For every rule, ``DEFECTS``
 declares at least one *weakened* variant of its check, each modelling a real
@@ -41,6 +42,12 @@ least one of them from its expected outcome while leaving another undisturbed. T
 declaration is fail-closed: a registered rule with no defect entry fails the suite,
 so the question "what bug would your second vector catch that your first would not?"
 has to be answered when the rule is added, not after a regression demonstrates it.
+
+Question 5 counts and question 6 names. A margin is a set of fixture names reduced to
+its size, so a change that keeps the size and moves the work is invisible to it:
+rewriting a vector into a copy of its partner still leaves the count at two.
+``vector_roles.json`` records which fixture carries which discrimination, so that
+substitution fails by name instead of passing.
 """
 
 from __future__ import annotations
@@ -71,6 +78,7 @@ TESTS_DIR = Path(__file__).parent
 VERIFIER_MODULE = TESTS_DIR / "test_action_receipt_fixtures.py"
 FIXTURE_DIR = TESTS_DIR.parent / "examples" / "action-receipts" / "conformance"
 MARGINS_FILE = TESTS_DIR / "vector_margins.json"
+ROLES_FILE = TESTS_DIR / "vector_roles.json"
 FIXTURES = discover_fixtures(FIXTURE_DIR)
 
 RULE_CODES = tuple(rule.code for rule in RULES)
@@ -157,7 +165,10 @@ DEFECTS: dict[str, dict[str, Check]] = {
         ].lower()
         != "none",
     },
-    # A signature check that stops at well-formedness.
+    # A signature check that stops at well-formedness. `04` is the only vector in the
+    # corpus whose signature is structurally sound and still does not verify, a shape
+    # that exists only when the signer is a key the verifier does not hold. Reissuing
+    # that fixture therefore takes a second published key, per #178.
     "signature_or_key_mismatch": {
         "checks_structure_only": lambda f: _trusted_jwk(f, f["receipt"]) is not None
         and _sig_malformed(f["receipt"]),
@@ -467,4 +478,103 @@ def test_margins_have_not_thinned() -> None:
     assert not vanished, (
         f"rules that had recorded margins no longer exist: {vanished}. If they were "
         f"removed on purpose, drop them from {MARGINS_FILE.name} in the same commit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. The role ratchet
+# ---------------------------------------------------------------------------
+
+
+def _roles() -> dict[str, dict[str, list[str]]]:
+    """Per fixture: the rules it is load-bearing for, and the defects it separates.
+
+    The same measurement questions 3 and 4 make, keyed by fixture rather than by rule.
+    `_margin` returns a set and the ratchet stores only its size, so neither can see
+    which fixture is doing the work. This asks whether a given vector still does the
+    job it was written for.
+    """
+    roles: dict[str, dict[str, list[str]]] = {}
+    for code in RULE_CODES:
+        bearing = _margin(code)
+        for name in bearing:
+            roles.setdefault(name, {}).setdefault(code, [])
+        for defect, weakened_check in DEFECTS[code].items():
+            for name in sorted(_deviating(_weakened(code, weakened_check)) & bearing):
+                roles[name][code].append(defect)
+    return roles
+
+
+def test_no_vector_has_lost_its_role() -> None:
+    """A ratchet on identity: a vector may not quietly stop discriminating.
+
+    Margins count, and a count cannot see work moving between vectors. Rewriting a
+    vector into a copy of its partner leaves the rule's margin at two, and
+    `test_vectors_for_each_rule_are_independent` still passes whenever some other
+    declared defect happens to separate the pair. What is lost is the specific
+    property the vector was written to exercise, and nothing recorded which vector
+    carried it.
+
+    The case this is built for is #178, reissuing fixtures 01-09 from a key whose
+    private half is published. Exactly one of the nine carries a discrimination: `04`
+    is the corpus's only structurally sound signature that does not verify, so it
+    catches `checks_structure_only` while `24`, whose signature is the wrong length,
+    does not. That shape exists only when the signer is a key the verifier does not
+    hold, so reissuing `04` under the issuer key and corrupting its signature to keep
+    it failing turns it into a second `24`. The reissue therefore takes two published
+    deterministic keys, the issuer key and one that plays the wrong signer, and this
+    test is what says so at the moment the mistake is made rather than after.
+
+    Six of the remaining eight record as load-bearing with no defect of their own,
+    which is what they are: their partners in 17-30 carry the discrimination. `01` and
+    `02` are the other two, and they are absent from the file altogether, because they
+    are the valid vectors and deleting a rule does not change the outcome of a fixture
+    that passes.
+
+    Gaining a role is an ordinary PR. Losing one is a decision someone makes on
+    purpose, in the same commit, with a reason.
+    """
+    current = _roles()
+
+    if not ROLES_FILE.exists():
+        ROLES_FILE.write_text(
+            json.dumps(current, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        pytest.skip(f"recorded initial roles to {ROLES_FILE.name}; re-run to enforce")
+
+    recorded: dict[str, dict[str, list[str]]] = json.loads(
+        ROLES_FILE.read_text(encoding="utf-8")
+    )
+
+    # Each way of losing a role gets its own reason. They are three different
+    # mistakes, and a single closing sentence fits only one of them.
+    lost: list[str] = []
+    for name in sorted(recorded):
+        if name not in current:
+            lost.append(
+                f"{name}: gone, and it was load-bearing for {sorted(recorded[name])}. "
+                "Retiring a vector retires whatever it was the only one to catch."
+            )
+            continue
+        for code in sorted(recorded[name]):
+            if code not in current[name]:
+                lost.append(
+                    f"{name}: no longer load-bearing for {code!r}. Deleting that rule "
+                    "stopped changing this fixture's outcome, so it no longer "
+                    "exercises it at all."
+                )
+                continue
+            missing = sorted(set(recorded[name][code]) - set(current[name][code]))
+            if missing:
+                lost.append(
+                    f"{name}: no longer separates {missing} for {code!r}. It still "
+                    "fails for the rule, so what it lost is the margin rather than "
+                    "the coverage: it has become a copy of its partner."
+                )
+
+    assert not lost, (
+        "vectors lost the discrimination they were written for:\n  "
+        + "\n  ".join(lost)
+        + f"\nIf the change is intended, update {ROLES_FILE.name} in the same commit "
+        + "and say why."
     )

--- a/tests/test_vector_completeness.py
+++ b/tests/test_vector_completeness.py
@@ -165,10 +165,13 @@ DEFECTS: dict[str, dict[str, Check]] = {
         ].lower()
         != "none",
     },
-    # A signature check that stops at well-formedness. `04` is the only vector in the
-    # corpus whose signature is structurally sound and still does not verify, a shape
-    # that exists only when the signer is a key the verifier does not hold. Reissuing
-    # that fixture therefore takes a second published key, per #178.
+    # A signature check that stops at well-formedness. `04` is the only vector whose
+    # issuer key the verifier holds and whose 64-byte signature still fails to verify;
+    # `14` and `23` fail for want of a key, `24` for length. A single key can produce
+    # that shape by corrupting a signature at fixed length; what it cannot produce is a
+    # signature by a key the verifier does not hold, which is what `04` models. This
+    # check sees the shape, not the signer, so the second key #178 asks for is a
+    # decision the reissue makes on purpose.
     "signature_or_key_mismatch": {
         "checks_structure_only": lambda f: _trusted_jwk(f, f["receipt"]) is not None
         and _sig_malformed(f["receipt"]),
@@ -520,13 +523,14 @@ def test_no_vector_has_lost_its_role() -> None:
 
     The case this is built for is #178, reissuing fixtures 01-09 from a key whose
     private half is published. Exactly one of the nine carries a discrimination: `04`
-    is the corpus's only structurally sound signature that does not verify, so it
-    catches `checks_structure_only` while `24`, whose signature is the wrong length,
-    does not. That shape exists only when the signer is a key the verifier does not
-    hold, so reissuing `04` under the issuer key and corrupting its signature to keep
-    it failing turns it into a second `24`. The reissue therefore takes two published
-    deterministic keys, the issuer key and one that plays the wrong signer, and this
-    test is what says so at the moment the mistake is made rather than after.
+    is the only vector whose issuer key the verifier holds and whose 64-byte signature
+    still fails to verify, so it catches `checks_structure_only` while `24`, whose
+    signature is the wrong length, does not. What this test holds is that shape. A
+    single-key reissue that collapses `04` to the wrong length, or renames it, fails
+    here by name; one that corrupts the signature at fixed length passes, because the
+    shape survives even though the fixture no longer models a wrong signer. The second
+    published key #178 asks for is therefore a decision the reissue makes on purpose,
+    and this test says so about the shape, not about the signer.
 
     Six of the remaining eight record as load-bearing with no defect of their own,
     which is what they are: their partners in 17-30 carry the discrimination. `01` and

--- a/tests/test_vector_completeness.py
+++ b/tests/test_vector_completeness.py
@@ -457,9 +457,12 @@ def test_margins_have_not_thinned() -> None:
     """
     current = {code: len(_margin(code)) for code in RULE_CODES}
 
-    if not MARGINS_FILE.exists():
-        MARGINS_FILE.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
-        pytest.skip(f"recorded initial margins to {MARGINS_FILE.name}; re-run to enforce")
+    assert MARGINS_FILE.exists(), (
+        f"{MARGINS_FILE.name} is missing, so there is nothing to ratchet against. A guard "
+        "that rebuilds its own baseline from the current tree records whatever the tree "
+        "has just lost. Restore the file from history; to rebaseline on purpose, write "
+        "the current margins to it in the same commit that changes the fixtures, and say why."
+    )
 
     recorded: dict[str, int] = json.loads(MARGINS_FILE.read_text(encoding="utf-8"))
     thinned = {
@@ -536,11 +539,12 @@ def test_no_vector_has_lost_its_role() -> None:
     """
     current = _roles()
 
-    if not ROLES_FILE.exists():
-        ROLES_FILE.write_text(
-            json.dumps(current, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
-        pytest.skip(f"recorded initial roles to {ROLES_FILE.name}; re-run to enforce")
+    assert ROLES_FILE.exists(), (
+        f"{ROLES_FILE.name} is missing, so there is nothing to ratchet against. A guard "
+        "that rebuilds its own baseline from the current tree records whatever the tree "
+        "has just lost. Restore the file from history; to rebaseline on purpose, write "
+        "_roles() to it in the same commit that changes the fixtures, and say why."
+    )
 
     recorded: dict[str, dict[str, list[str]]] = json.loads(
         ROLES_FILE.read_text(encoding="utf-8")

--- a/tests/vector_roles.json
+++ b/tests/vector_roles.json
@@ -1,0 +1,114 @@
+{
+  "03-missing-required-receipt.json": {
+    "receipt_missing": []
+  },
+  "04-signature-key-mismatch.json": {
+    "signature_or_key_mismatch": [
+      "checks_structure_only"
+    ]
+  },
+  "05-action-ref-mismatch.json": {
+    "action_ref_mismatch": []
+  },
+  "06-stale-receipt.json": {
+    "receipt_stale": []
+  },
+  "07-receipt-chain-gap.json": {
+    "receipt_chain_gap": []
+  },
+  "08-same-party-self-report.json": {
+    "issuer_not_independent": []
+  },
+  "09-unsupported-physical-completion.json": {
+    "unsupported_physical_completion_claim": []
+  },
+  "10-action-ref-not-recomputable.json": {
+    "action_ref_invalid": []
+  },
+  "11-call-id-mismatch.json": {
+    "call_id_mismatch": []
+  },
+  "12-session-id-mismatch.json": {
+    "session_id_mismatch": []
+  },
+  "13-evidence-hash-mismatch.json": {
+    "evidence_hash_mismatch": []
+  },
+  "14-receipt-issuer-key-unknown.json": {
+    "issuer_key_unknown": []
+  },
+  "15-receipt-from-future.json": {
+    "receipt_from_future": []
+  },
+  "16-decision-not-in-enum.json": {
+    "decision_invalid": []
+  },
+  "17-missing-receipt-explicit-null.json": {
+    "receipt_missing": [
+      "treats_explicit_null_as_present"
+    ]
+  },
+  "18-action-ref-tail-forged.json": {
+    "action_ref_invalid": [
+      "compares_truncated_digest"
+    ]
+  },
+  "19-action-ref-mismatch-in-tail.json": {
+    "action_ref_mismatch": [
+      "compares_truncated_digest"
+    ]
+  },
+  "20-call-id-case-mismatch.json": {
+    "call_id_mismatch": [
+      "compares_case_insensitively"
+    ]
+  },
+  "21-session-id-case-mismatch.json": {
+    "session_id_mismatch": [
+      "compares_case_insensitively"
+    ]
+  },
+  "22-evidence-hash-mismatch-in-tail.json": {
+    "evidence_hash_mismatch": [
+      "compares_truncated_digest"
+    ]
+  },
+  "23-receipt-issuer-key-case-variant.json": {
+    "issuer_key_unknown": [
+      "looks_up_keys_case_insensitively"
+    ]
+  },
+  "24-receipt-signature-malformed.json": {
+    "signature_or_key_mismatch": []
+  },
+  "25-stale-receipt-boundary.json": {
+    "receipt_stale": [
+      "grants_sixty_seconds_grace"
+    ]
+  },
+  "26-receipt-from-future-boundary.json": {
+    "receipt_from_future": [
+      "tolerates_sixty_seconds_skew"
+    ]
+  },
+  "27-receipt-chain-gap-in-tail.json": {
+    "receipt_chain_gap": [
+      "compares_truncated_digest"
+    ]
+  },
+  "28-physical-completion-claim-case.json": {
+    "unsupported_physical_completion_claim": [
+      "compares_case_insensitively"
+    ]
+  },
+  "29-same-party-self-report-rejected.json": {
+    "issuer_not_independent": [
+      "warns_only_on_accepted"
+    ]
+  },
+  "30-decision-case-variant.json": {
+    "decision_invalid": [
+      "matches_enum_case_insensitively"
+    ]
+  }
+}


### PR DESCRIPTION
## What this changes

Takes the `DEFECTS` guard from #178 on its own, ahead of the `01-09` reissue, on @imran-siddique's ruling of 10 September: a guard that lands after the thing it guards protects nothing. The reissue keeps its original timing.

`test_margins_have_not_thinned` stores a count and `_margin` returns a set, so both are blind to identity. A vector rewritten into a copy of its partner leaves the rule's margin at two, and `test_vectors_for_each_rule_are_independent` still passes whenever some other declared defect happens to separate the pair. What is lost in that case is the specific property the vector was written to exercise, and nothing recorded which vector carried it.

`tests/vector_roles.json` records, per fixture, the rules it is load-bearing for and the declared defects it separates. `test_no_vector_has_lost_its_role` fails by name when a fixture drops one, on the same ratchet terms as the margins file: gaining a role is an ordinary PR, losing one is updated in the same commit with a reason.

## Why it is this shape

Of the nine fixtures the reissue moves, exactly one carries a discrimination, which the corpus itself says rather than the argument: measured over all thirty, `04` is the only vector whose issuer key the verifier holds and whose 64-byte signature still fails to verify, so it separates `checks_structure_only` while `24`, at 32 bytes, does not. `14` and `23` carry 64-byte signatures the verifier has no key for, `03` and `17` carry no receipt, and the other twenty-four verify.

What the guard holds is that shape, not the signer. A single-key reissue that collapses `04` to the wrong length, or renames it, fails by name. One that corrupts the signature at fixed length passes every guard, measured by flipping one bit of `04`'s 64 bytes: the shape survives even though the fixture no longer models a wrong signer. So the second published key that #178 asks for stays right, on the fixture's meaning, and it is a decision the reissue makes on purpose rather than one this test enforces. An earlier version of this paragraph, of the README paragraph, of the defect comment and of the docstring said the shape exists only under a second key; `f9841a4` corrects the three files, and this paragraph is the fourth surface.

The remaining six of the nine record as load-bearing with no defect of their own, which is what they are: their partners in `17-30` carry the discrimination. `01` and `02` are absent from the file altogether, because they are the valid vectors and deleting a rule does not change the outcome of a fixture that passes.

The two-key requirement is written down in two places, the `signature_or_key_mismatch` defect comment and the `examples/action-receipts/README.md` paragraph that already explains why `01-09` pin an unpublished key.

## Measured, not argued

Three mutations, each run against all three guards, and two more added after review:

| Mutation | independence | margin ratchet | this guard |
|---|---|---|---|
| `04` collapsed to a wrong-length signature | fails | passes | fails, names `04` |
| `06` and `25` swap which sits inside the grace window | passes | passes | fails, names `25` |
| `04` renamed | passes | passes | fails, names `04` |
| `04` with one bit of its 64-byte signature flipped | passes | passes | passes |
| `tests/vector_roles.json` deleted, on `62fea76` | passes | passes | skipped and rewrote the file; fails by name since `154e7e6` |

The second touches only unsigned context, so both vectors stay stale and the fixture-correctness suite still passes 35 tests: the swap is a real role exchange rather than a broken fixture. The third is the likeliest thing a reissue actually does to a file. In both of those the existing instruments see nothing, because the count is unchanged and some declared defect still separates the pair. The fourth is the limit of the guard, stated above. The fifth is the reviewer's finding, below.

Each of the three ways to lose a role reports its own reason rather than sharing one closing sentence that fits only one of them.

`vector_roles.json` is byte-identical across `PYTHONHASHSEED` values 0, 1, 7, 42, 12345, 31337 and 99999, which matters because `_margin` returns a set and `_roles` iterates it.

Suite is 1403 passed and 1 skipped at `f9841a4` on 3.11 and 3.12, with `ruff check src tests scripts`, `mypy src/agentrust_trace` and `tools/check_dashes.py` clean. The one skip is `test_version`'s environment check.

## Since opened

- `154e7e6`: both ratchets in the module fail by name when their baseline file is missing, instead of writing one and skipping. Found by @rajnisht7: with the file deleted in the same change as a degrading reissue, the first run skipped and recorded the degraded state as the baseline, and the second run passed.
- `f9841a4`: the two-key sentence corrected in the README, the defect comment and the docstring, as above. No code path changes.

## Type of change

- [ ] Editorial (typo, link fix, clarification: no normative effect)
- [ ] Non-breaking spec change (new optional field, new platform profile, informative addition)
- [ ] Breaking spec change (requires 14-day comment period and Project Lead sign-off)
- [ ] Schema change
- [ ] Example addition

None of the five. Tests and one README paragraph. No schema, wire format, signature semantics or verifier behaviour changes, and no fixture is modified.

## Spec section

None.

## Checklist

- [x] DCO sign-off on all commits (`git commit -s`)
- [ ] `CHANGELOG.md` updated (for any normative change): not applicable, nothing normative changes
- [ ] Breaking changes marked with `<!-- CHANGED: #NNN: description -->` in spec text: not a breaking change
- [ ] Backward compatibility statement included (for breaking changes): not a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
